### PR TITLE
add ids to curriculum headings

### DIFF
--- a/curriculum/arts-dance/foundation-year.md
+++ b/curriculum/arts-dance/foundation-year.md
@@ -1,6 +1,6 @@
-# The Arts - Dance - Foundation Year
+# Dance - Foundation Year {#dance-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 In Foundation, learning in The Arts builds on the Early Years Learning Framework and each student’s prior learning and experiences. The curriculum allows for play-based approaches that integrate arts learning experiences across the 5 Arts subjects and/or specialist teaching. There are examples in the content elaborations for each subject and examples that span across the subjects.
 
@@ -15,11 +15,11 @@ In Foundation, learning in Dance can involve students:
 *   using fundamental movement skills and combining movements to create dance sequences that use locomotor movements (travelling); for example, walking or rolling, and non-locomotor movements (not travelling); for example, bending, melting, balancing, or being as tall or as small as they can be
 *   experimenting with simple technical skills such as posture or coordination, and expressive skills such as facial expression or gesture, as they select and organise movements in their own dances.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADAFE01
+##### AC9ADAFE01 {#ac9adafe01}
 
 explore how and why the arts are important for people and communities
 
@@ -32,9 +32,9 @@ explore how and why the arts are important for people and communities
 *  exploring how illustrations/images in a text (fiction or non-fiction, print or screen) help to communicate narrative or information about characters, settings and/or mood
 *  listening to First Nations Australians talk about the importance of the arts for connecting to People, Culture and Country/Place; for example, using resources created or co-created by First Nations Australians
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADAFD01
+##### AC9ADAFD01 {#ac9adafd01}
 
 use play, imagination, arts knowledge, processes and/or skills to discover possibilities and develop ideas
 
@@ -48,9 +48,9 @@ use play, imagination, arts knowledge, processes and/or skills to discover poss
 *  exploring their speaking and singing voices and discovering ways to use their voices/vocalisation to communicate ideas and feelings
 *  improvising movements to explain the steps in a process, and then using a camera to capture a series of images or a photographic story that can be displayed in the classroom to remind everybody about the process
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADAFC01
+##### AC9ADAFC01 {#ac9adafc01}
 
 create arts works that communicate ideas
 
@@ -63,9 +63,9 @@ create arts works that communicate ideas
 *  repurposing materials and objects such as clothing or packing boxes as starting points for imagining and developing scenes and scenarios; for example, using packing boxes to create an imagined environment or vehicle
 *  considering as a class the characters and situations associated with a story and then re-imagining them by asking questions of the story, such as “What’s up?”, “What happens next?” or “What else might/could happen?" to support the development of their own socio-dramatic or miniature worlds play
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADAFP01
+##### AC9ADAFP01 {#ac9adafp01}
 
 share their arts works with audiences
 
@@ -79,7 +79,7 @@ share their arts works with audiences
 *  performing movement/dance sequences they have created for other groups in their class and introducing their work by describing their favourite moments in the sequence or explaining why they chose a particular movement
 *  using digital devices to record their arts explorations; for example, curating (selecting, ordering) a sequence of digital images (photos) to show the steps in a process; for example, images that show how they created new colours by mixing primary colours (using playdough or paint) and adding commentary that expresses their feelings, emotions and understandings
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Foundation, learning in The Arts builds on the Early Years Learning Framework and each student’s prior learning and experiences. The curriculum allows for play-based approaches that integrate arts learning experiences across the 5 Arts subjects and/or specialist teaching. There are examples in the content elaborations for each subject and examples that span across the subjects.
 

--- a/curriculum/arts-dance/years-1-and-2.md
+++ b/curriculum/arts-dance/years-1-and-2.md
@@ -1,6 +1,6 @@
-# The Arts - Dance - Years 1 and 2
+# Dance - Years 1 and 2 {#dance-years-1-and-2}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in The Arts builds on each student’s prior learning and experiences. Students continue to learn through purposeful and creative play in structured learning programs designed to foster a strong sense of wellbeing and develop their connection with and contribution to the world. They work individually and in collaboration with peers and teachers, drawing on their imaginations, real-life experiences, stimulus materials and learnings from across the curriculum.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating dance sequences by selecting and combining movements that communicate ideas and intentions using fundamental movement skills, the elements of dance and imagination. Students may focus on choreographing dance sequences, or they may create work that combines dance and other arts forms, such as a dance sequence for use in a dramatic re-telling of a story
 6.  performing/sharing dance they have learnt and/or choreographed in informal settings such as classroom presentations.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADA2E01
+##### AC9ADA2E01 {#ac9ada2e01}
 
 explore where, why and how people across cultures, communities and/or other contexts experience dance
 
@@ -36,7 +36,7 @@ explore where, why and how people across cultures, communities and/or other cont
 *  identifying similarities and differences in dances by sharing, viewing and/or learning dances that they are familiar with or have experienced with their families and communities
 *  identifying how dance can show what feelings people have about places, people or experiences
 
-##### AC9ADA2E02
+##### AC9ADA2E02 {#ac9ada2e02}
 
 explore examples of dance choreographed and/or performed by First Nations Australians
 
@@ -46,9 +46,9 @@ explore examples of dance choreographed and/or performed by First Nations Austra
 *  identifying where they might experience dance in First Nations Australians’ cultural expressions, such as in ceremonies at their school, in their community, or as part of state and national events, and taking notice of ways the performers and audiences observe protocols and respect Elders or knowledge holders
 *  learning about First Nations Australians’ interpretations of the night sky; for example, working with First Nations Australians who have cultural authority to co-create movements to represent shapes and patterns that can be seen at different times of the year
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADA2D01
+##### AC9ADA2D01 {#ac9ada2d01}
 
 experiment with ways to move safely and expressively using fundamental movement skills and the elements of dance
 
@@ -59,9 +59,9 @@ experiment with ways to move safely and expressively using fundamental movement
 *  exploring fundamental movements safely to develop ideas for movement; for example, ideas about familiar situations, objects, animals or environmental features, such as running in a race, jumping like a frog, stomping like a giant, rolling like a log, falling like an autumn leaf, floating like a cloud, gliding like a bird
 *  moving around open and crowded spaces safely and using a variety of travelling steps, such as running, skipping, rolling, jumping, walking backwards and sideways movements; identifying the distance between themselves and others when dancing and using props such as scarves; and responding by reflecting on the space and movements that made them feel safe or unsafe
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADA2C01
+##### AC9ADA2C01 {#ac9ada2c01}
 
 use the elements of dance to choreograph dance sequences
 
@@ -73,9 +73,9 @@ use the elements of dance to choreograph dance sequences
 *  using patterns of movement such as a sequence of locomotor movements (travelling movements) they have improvised, sharing/teaching these movements to a partner (and learning the partner’s movements), and working collaboratively to combine and extend these movement ideas to create a dance sequence
 *  using their own words and learnt dance terminology to share ideas about the dance they are creating and recognising and accepting constructive feedback from peers or teachers; for example, in response to a “work-in-progress” sharing
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADA2P01
+##### AC9ADA2P01 {#ac9ada2p01}
 
 share dance sequences in informal settings
 
@@ -85,7 +85,7 @@ share dance sequences in informal settings
 *  expressing ideas to an audience through movement; for example, showing contrasting dynamics by stamping heavily and tip­toeing lightly or using movement qualities, such as slow controlled sinking to the floor to express melting ice or sharp jerky movement to express a robot
 *  using Viewpoints to develop questions when responding to dances they experience in order to reflect on their choreography and/or performance; for example, “What did this dance make you think about?”, “Did the dance movements remind you of anything?”, “How did you communicate the ideas or intention in this dance?”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 2, students identify where they experience dance. They describe where, why and/or how people across cultures, communities and/or other contexts experience dance.
 

--- a/curriculum/arts-dance/years-3-and-4.md
+++ b/curriculum/arts-dance/years-3-and-4.md
@@ -1,6 +1,6 @@
-# The Arts - Dance - Years 3 and 4
+# Dance - Years 3 and 4 {#dance-years-3-and-4}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in The Arts builds on each student’s prior learning and experiences. Arts learning in this band continues to use purposeful and creative play-based activities that foster development of students’ identity and wellbeing, and their connection with and contribution to the world. Students further develop their capability and confidence in using subject-specific skills, and creative and critical practices. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating dance by selecting and combining movements and structuring dance sequences that communicate ideas and intentions using fundamental movement skills, the elements of dance and imagination. Students use processes such as improvisation to develop and extend ideas for their dance. They may focus on choreographing dance sequences or they may create work that combines dance and other arts forms, such as a dance sequence they will perform to accompany a song
 6.  performing dance they have learnt and/or choreographed in informal settings, such as spaces within the school.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADA4E01
+##### AC9ADA4E01 {#ac9ada4e01}
 
 explore where, why and how dance is choreographed and/or performed across cultures, times, places and/or other contexts
 
@@ -34,7 +34,7 @@ explore where, why and how dance is choreographed and/or performed across cultur
 *  learning dances created for different purposes such as entertainment; for example, dances from a range of cultures, times or places that are/have been a dance craze or are a dance that “everyone” knows
 *  using Viewpoints to ask questions about dance they are experiencing, such as “Are the movements in this dance similar to movements in dances that you know?”, “Where are these dances performed?”
 
-##### AC9ADA4E02
+##### AC9ADA4E02 {#ac9ada4e02}
 
 explore how First Nations Australians use dance to communicate their connection to and responsibility for Country/Place
 
@@ -45,9 +45,9 @@ explore how First Nations Australians use dance to communicate their connectio
 *  observing how the elements of dance are used in dances choreographed and performed by First Nations Australians to communicate connection to and responsibility for Country/Place; for example, in dance about wind, water or fire
 *  exploring the movements in dances with representatives of a First Nations Australian community or through resources created or co-created by First Nations Australians; for example, dances that share cultural accounts of Country/Place
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADA4D01
+##### AC9ADA4D01 {#ac9ada4d01}
 
 experiment with and practise skills for moving safely and expressively using fundamental movement skills and the elements of dance
 
@@ -58,9 +58,9 @@ experiment with and practise skills for moving safely and expressively using f
 *  developing the habit of always using safe dance practice; for example, warming up their bodies before executing more complex movement patterns in dance sequences and cooling/calming down afterwards, removing socks if the floor surface is slippery
 *  developing body awareness and refining technical skills of body control, accuracy, alignment, strength, balance and coordination in fundamental movements; for example, in response to teacher feedback
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADA4C01
+##### AC9ADA4C01 {#ac9ada4c01}
 
 use the elements of dance to choreograph dance that communicates ideas, perspectives and/or meaning
 
@@ -71,9 +71,9 @@ use the elements of dance to choreograph dance that communicates ideas, perspe
 *  using Viewpoints to ask questions when making choices about ideas and intentions for a dance; for example, “How can we connect these 2 parts of our dance?” or “What level should we choose for the start of the dance?”
 *  using learning from explorations of dances that communicate First Nations Australians’ connection to and responsibility for Country/Place to devise dance that communicates their own connection to and responsibility for Country/Place; for example, devising a dance that communicates their feelings about a “favourite” place or shows how they care for a place in their community, taking care to follow protocols for respecting Indigenous Cultural and Intellectual Property rights
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADA4P01
+##### AC9ADA4P01 {#ac9ada4p01}
 
 practise and perform dances in informal settings
 
@@ -83,7 +83,7 @@ practise and perform dances in informal settings
 *  being an attentive audience member during class performances and providing constructive feedback to peers
 *  sharing with others the meaning and intended purposes of their own dance; for example, in a class debrief discussion after a performance; using their own words, images and some learnt dance terminology or responding through movement or by drawing (visual)
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 4, students describe use of the elements of dance in dance they experience, create and/or perform. They describe where, why and/or how dance is choreographed and/or performed across cultures, times, places and/or other contexts.
 

--- a/curriculum/arts-dance/years-5-and-6.md
+++ b/curriculum/arts-dance/years-5-and-6.md
@@ -1,6 +1,6 @@
-# The Arts - Dance - Years 5 and 6
+# Dance - Years 5 and 6 {#dance-years-5-and-6}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, students continue to learn in and through their practices of The Arts subjects, building on their prior learning and experiences. They work creatively and purposefully, and continue to develop their connection with and contribution to the world as artist and as audience. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating dances by developing ideas and structuring movements to communicate their intentions as choreographers. They may focus on creating a dance work or they may create work that combines dance and another arts form, such as a dance for a media arts production
 6.  presenting and performing dance they have learnt and/or choreographed for audiences, in available, informal and/or formal settings including, as appropriate, school-hosted digital spaces such as a school learning management system.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADA6E01
+##### AC9ADA6E01 {#ac9ada6e01}
 
 explore ways that the elements of dance are combined to communicate ideas, perspectives and/or meaning in dance across cultures, times, places and/or other contexts
 
@@ -36,7 +36,7 @@ explore ways that the elements of dance are combined to communicate ideas, persp
 *  asking questions based on Viewpoints to explore similarities and differences in ways that choreographers or performers and audiences experience/respond to aspects of a dance; for example, “How were elements of dance used to communicate the main idea in the dance?”, “How was your mood changed by this dance?” and developing and asking questions that refer to energy, shape, tempo or use of production elements such as props or music
 *  exploring how dance is used to communicate cultural traditions; for example, considering dance from a country or region in Asia and asking, “What stories, narratives or ways of being and doing does this dance reflect?”, “Is this dance communicating something about the culture where it originated that we can’t learn any other way?”, “How is this dance evolving over time? For example, are costumes now made from different materials?”
 
-##### AC9ADA6E02
+##### AC9ADA6E02 {#ac9ada6e02}
 
 explore the ways that First Nations Australians use dance to continue and revitalise cultures
 
@@ -47,9 +47,9 @@ explore the ways that First Nations Australians use dance to continue and rev
 *  using Viewpoints to develop questions to build understanding about First Nations Australians’ dances and exploring what they could investigate further, such as “What do I already know about this dance practice?”, “What do I need to learn to have a better understanding?”, “What knowledge can I share with others?”, “What questions would I ask the dancers about this performance?”
 *  exploring how dances that tell stories maintain culture; for example, narrative dances that communicate knowledge about sustainable approaches to locating and gathering food or stories about how places got their names
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADA6D01
+##### AC9ADA6D01 {#ac9ada6d01}
 
 develop and practise technical and expressive skills using safe dance practice and the elements of dance
 
@@ -59,9 +59,9 @@ develop and practise technical and expressive skills using safe dance practice
 *  developing expressive skills of focus, clarity of the movement, confidence and facial expression/character
 *  exploring an element of dance; for example, experimenting with shapes and considering ideas such as positive and negative space or use of contrasting dynamics
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADA6C01
+##### AC9ADA6C01 {#ac9ada6c01}
 
 manipulate the elements of dance and/or choreographic devices to choreograph dances that communicate ideas, perspectives and/or meaning
 
@@ -72,9 +72,9 @@ manipulate the elements of dance and/or choreographic devices to choreograph dan
 *  creating a dance that focuses on use of technical and expressive skills such as control, coordination and balance
 *  creating a dance that explores a theme or an issue such as a theme from a known text or an issue relating to sustainable ways of living
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADA6P01
+##### AC9ADA6P01 {#ac9ada6p01}
 
 practise and perform dances using technical and expressive skills in informal and/or formal settings
 
@@ -84,7 +84,7 @@ practise and perform dances using technical and expressive skills in informal 
 *  presenting dances, using production elements such as music, costumes and props where appropriate to enhance different contexts; for example, using traditional music when performing dances with representatives of the cultural group from the community
 *  using questions based on Viewpoints such as questions about forms and elements to reflect on their performance; for example, “How did the dancers/you use space and energy to create a feeling of strength/isolation/happiness?”, “What relationship are you aiming to create between the dancers and the audience?”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 6, students explain how the elements of dance are used in dance that they choreograph, perform and/or experience. They describe how dance from across cultures, times, places and/or other contexts communicates ideas, perspectives and/or meaning. They describe how dance is used to continue and revitalise cultures.
 

--- a/curriculum/arts-dance/years-7-and-8.md
+++ b/curriculum/arts-dance/years-7-and-8.md
@@ -1,6 +1,6 @@
-# The Arts - Dance - Years 7 and 8
+# Dance - Years 7 and 8 {#dance-years-7-and-8}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in Dance builds on each student’s prior learning and experiences. Students learn in and through the practices of Dance: choreography, performance and responding. They use dance-specific processes in purposeful and creative ways, and continue to develop their connection with and contribution to the world as artist and as audience. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating/choreographing dance to communicate their intentions as choreographers, using the elements of dance, choreographic devices and form. Students may focus on choreographing in a range of dance styles and forms and/or choreographing for multi-arts, hybrid or trans-disciplinary work such as screen-based or theatrical forms
 6.  presenting and performing dance using technical and expressive skills to communicate their ideas and intentions to audiences; for example, through planned and rehearsed live or streamed performances, as appropriate.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADA8E01
+##### AC9ADA8E01 {#ac9ada8e01}
 
 investigate ways that dance works, performers and/or choreographers across cultures, times, places and/or other contexts use the elements of dance, choreographic devices and/or production elements to communicate ideas, perspectives and/or meaning
 
@@ -36,7 +36,7 @@ investigate ways that dance works, performers and/or choreographers across cultu
 *  comparing use of one or more elements of dance and/or choreographic devices such as repetition in dances from a range of genres/styles, cultures, times and/or places; for example, dances from a range of cultures or countries in Asia
 *  investigating how digital tools and use of immersive technologies such as virtual reality (VR) are influencing choreography, performance or use of production elements
 
-##### AC9ADA8E02
+##### AC9ADA8E02 {#ac9ada8e02}
 
 investigate the diversity of dance choreographed and/or performed by First Nations Australians considering culturally responsive approaches to Indigenous Cultural and Intellectual Property rights
 
@@ -46,9 +46,9 @@ investigate the diversity of dance choreographed and/or performed by First Natio
 *  analysing how linear and non-linear narrative is used in specific examples of dance choreographed and/or performed by First Nations Australians to explore issues such as relationships, identity or empathy
 *  investigating an example of cultural appropriation where it has been found that First Nations Australian Indigenous Cultural and Intellectual Property rights have been denied and identifying how this situation could have been approached respectfully; for example, a situation where a choreographer has used movement vocabulary that carries cultural knowledge without permission from the knowledge holders
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADA8D01
+##### AC9ADA8D01 {#ac9ada8d01}
 
 develop safe dance practice and use of expressive and technical skills and, as appropriate, genre- or style-specific techniques
 
@@ -57,7 +57,7 @@ develop safe dance practice and use of expressive and technical skills and, as a
 *  exploring how expressive skills can be used to communicate ideas; for example, using gesture or facial expression to communicate relationships or emotions
 *  extending technical competence such as control, coordination, accuracy, alignment, balance, flexibility, strength, endurance and articulation when moving, in response to self, peer and/or teacher feedback
 
-##### AC9ADA8D02
+##### AC9ADA8D02 {#ac9ada8d02}
 
 reflect on own and others’ dance works and/or practices to inform choreographic choices and use of technical and expressive skills
 
@@ -66,9 +66,9 @@ reflect on own and others’ dance works and/or practices to inform choreograph
 *  evaluating influences on their own performance or choreography; for example, using a journal to document interesting examples of how others use an element of dance or genre- or style-specific techniques, and considering how to use these ideas in their own choreography or performance
 *  reflecting on feedback from peers who have observed a workshop or a rehearsal and using ideas from the feedback/reflection to refine dance; for example, use of technical and expressive skills or a choreographic device
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADA8C01
+##### AC9ADA8C01 {#ac9ada8c01}
 
 choreograph dance by selecting and manipulating elements of dance and choreographic devices to communicate ideas, perspectives and/or meaning
 
@@ -79,7 +79,7 @@ choreograph dance by selecting and manipulating elements of dance and choreo
 *  selecting, combining, refining and sequencing movement using choreographic devices such as transitions, variation and contrast, and choreographic forms such as binary, ternary and narrative
 *  analysing and evaluating the structural choices made in their dance by documenting their process in records such as journals, blogs, video or audio recordings, securing permission where appropriate
 
-##### AC9ADA8C02
+##### AC9ADA8C02 {#ac9ada8c02}
 
 apply technical and expressive skills and/or genre- or style-specific techniques to communicate ideas, perspectives and/or meaning
 
@@ -88,9 +88,9 @@ apply technical and expressive skills and/or genre- or style-specific techniques
 *  responding to feedback to enhance communication of choreographic intent to the audience; for example, by refining use of technical skills such as accuracy or flexibility
 *  using questions based on Viewpoints to evaluate clarity of movement, projection, focus and musicality when preparing for a performance, and using video to evaluate and refine spatial placement or articulation
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADA8P01
+##### AC9ADA8P01 {#ac9ada8p01}
 
 rehearse and perform dance for audiences, using technical and expressive skills and, as appropriate genre- or style-specific techniques
 
@@ -101,7 +101,7 @@ rehearse and perform dance for audiences, using technical and expressive skills 
 *  using rehearsal strategies or techniques such as spotting to enhance confidence, clarity of movement, projection, focus and musicality in performance
 *  introducing their dance to an audience; for example, in a program note or voice-over that uses descriptive style-specific dance terminology
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8, students analyse how the elements of dance, choreographic devices and/or production elements are manipulated in dance they create and/or experience. They evaluate the ways that dance works and/or performances in a range of styles and/or from across cultures, times, places and/or other contexts communicate ideas, perspectives and/or meaning. They describe respectful approaches to creating, performing and/or responding to dance.
 

--- a/curriculum/arts-dance/years-9-and-10.md
+++ b/curriculum/arts-dance/years-9-and-10.md
@@ -1,6 +1,6 @@
-# The Arts - Dance - Years 9 and 10
+# Dance - Years 9 and 10 {#dance-years-9-and-10}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in Dance continues to build on each student’s prior learning and experiences as students develop their capability and confidence across the practices of Dance: choreography, performance and responding. They continue to use dance-specific processes in purposeful and creative ways that are informed by their engagement with the work of living choreographers and performers from across local, regional, national and global cultures, times, places and/or other contexts, such as countries or regions in Asia. This can include use of dance in multi-arts, trans-disciplinary or hybrid forms. This awareness of diverse dance practices, genres and/or styles informs their own work as choreographers and performers. They work collaboratively with peers and teachers.
 
@@ -19,11 +19,11 @@ In this band, the focus is on students:
 5.  creating work to communicate ideas and intentions using the elements of dance, choreographic devices and form. They use choreographic processes that are appropriate to the genre/style. As they develop and refine their work, students consider how they can employ technical and expressive skills to communicate ideas, perspectives and/or meaning in their work. Students may focus on choreographing in a range of dance styles and forms and/or they may choreograph dance for multi-arts, hybrid or trans-disciplinary works; for example, using immersive technologies
 6.  performing their work using technical and expressive skills and genre- or style-specific techniques to communicate their ideas and intentions to audiences; for example, in planned and rehearsed live or streamed performances.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADA10E01
+##### AC9ADA10E01 {#ac9ada10e01}
 
 investigate performers’ and/or choreographers’ use of elements of dance, choreographic devices, genre- or style-specific techniques, conventions and/or production elements to communicate and/or challenge ideas, perspectives and/or meaning in dance across cultures, times, places and/or other contexts
 
@@ -34,7 +34,7 @@ investigate performers’ and/or choreographers’ use of elements of dance, cho
 *  extending their movement vocabulary as they explore their own stylistic preferences and personal identity; for example, using analysis of dance styles from a range of cultures they identify with or dance styles from different times to inform their choreographic practice
 *  analysing use of elements of dance in different genres/styles, such as styles that feature in popular culture or from a country or region in Asia, as a stimulus for choreography or to inform performance of a learnt work
 
-##### AC9ADA10E02
+##### AC9ADA10E02 {#ac9ada10e02}
 
 investigate the ways First Nations Australian choreographers and/or performers celebrate and challenge multiple perspectives of Australian identity through dance
 
@@ -43,9 +43,9 @@ investigate the ways First Nations Australian choreographers and/or performers 
 *  investigating dance works that challenge our understandings about “first contacts” between the First Nations Peoples of Australia and people from Britain or Europe
 *  exploring the ways that First Nations Australian choreographers and/or performers use their practice to communicate ideas, messages and lived experiences to the broader community
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADA10D01
+##### AC9ADA10D01 {#ac9ada10d01}
 
 develop and refine safe dance practice, expressive and technical skills and genre- or style-specific techniques
 
@@ -54,7 +54,7 @@ develop and refine safe dance practice, expressive and technical skills and genr
 *  using experimentation and improvisation to develop techniques for executing expressive skills in a range of genres and/or styles
 *  practising and refining technical skills to develop proficiency in genre- and style-specific techniques
 
-##### AC9ADA10D02
+##### AC9ADA10D02 {#ac9ada10d02}
 
 reflect on own and others’ use of the elements of dance, choreographic devices, structure, genre- or style-specific techniques and/or technical and expressive skills to inform their choreographic or performance choices
 
@@ -65,9 +65,9 @@ reflect on own and others’ use of the elements of dance, choreographic devices
 *  improvising using the elements of dance and analysing movement choices to reflect their individuality and to clarify their choreographic intent
 *  considering how they can use the elements of dance and choreographic devices to reflect ways that meaning and experiences, political statements, critical theories or emotions influence and shape their approach to dance
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADA10C01
+##### AC9ADA10C01 {#ac9ada10c01}
 
 choreograph dance that communicates ideas, perspectives and/or meaning by selecting and manipulating elements of dance, choreographic devices and/or structure
 
@@ -79,7 +79,7 @@ choreograph dance that communicates ideas, perspectives and/or meaning by select
 *  using motifs from a known dance as the starting point for their own choreography; for example, identifying and improvising on movements from a dance being shared via a social media platform to develop ideas that can be extended and structured into new work
 *  using a style-specific form such as a form associated with a culturally specific dance genre/style, to structure a dance
 
-##### AC9ADA10C02
+##### AC9ADA10C02 {#ac9ada10c02}
 
 apply technical and expressive skills and genre- or style-specific techniques to enhance communication of ideas, perspectives and/or meaning
 
@@ -88,9 +88,9 @@ apply technical and expressive skills and genre- or style-specific techniques to
 *  using observations/analysis of a dance in a selected genre/style to identify characteristic techniques, building ability to execute the technical and expressive skills using safe dance practice over time and applying it to enhance performance of dances
 *  seeking feedback on their choreography and performance; for example, using Viewpoints to frame questions such as “What emotion did you feel most strongly as you viewed the dance?” and using the feedback to refine use of technical and expressive skills
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADA10P01
+##### AC9ADA10P01 {#ac9ada10p01}
 
 rehearse and perform dance for audiences, using technical and expressive skills and genre- or style-specific techniques
 
@@ -99,7 +99,7 @@ rehearse and perform dance for audiences, using technical and expressive skills 
 *  using rehearsal to build confidence that they can accurately and fluently maintain spatial placement during performance of a dance
 *  using available production elements such as music, costume and props to enhance communication of ideas, perspectives or meaning in a performance
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In this band, learning in Dance continues to build on each student’s prior learning and experiences as students develop their capability and confidence across the practices of Dance: choreography, performance and responding. They continue to use dance-specific processes in purposeful and creative ways that are informed by their engagement with the work of living choreographers and performers from across local, regional, national and global cultures, times, places and/or other contexts, such as countries or regions in Asia. This can include use of dance in multi-arts, trans-disciplinary or hybrid forms. This awareness of diverse dance practices, genres and/or styles informs their own work as choreographers and performers. They work collaboratively with peers and teachers.
 

--- a/curriculum/arts-drama/foundation-year.md
+++ b/curriculum/arts-drama/foundation-year.md
@@ -1,6 +1,6 @@
-# The Arts - Drama - Foundation Year
+# Drama - Foundation Year {#drama-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 In Foundation, learning in The Arts builds on the Early Years Learning Framework and each student’s prior learning and experiences. The curriculum allows for play-based approaches that integrate arts learning experiences across the 5 Arts subjects and/or specialist teaching. There are examples in the content elaborations for each subject and examples that span across the subjects.
 
@@ -15,11 +15,11 @@ In Foundation, learning in Drama can involve students:
 *   accepting and participating in fictional situations
 *   reflecting on their drama experiences and contributing to the drama using language and/or in embodied ways.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADRFE01
+##### AC9ADRFE01 {#ac9adrfe01}
 
 explore how and why the arts are important for people and communities
 
@@ -32,9 +32,9 @@ explore how and why the arts are important for people and communities
 *  exploring how illustrations/images in a text (fiction or non-fiction, print or screen) help to communicate narrative or information about characters, settings and/or mood
 *  listening to First Nations Australians talk about the importance of the arts for connecting to people, culture and Country/Place; for example, using resources created or co-created by First Nations Australians
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADRFD01
+##### AC9ADRFD01 {#ac9adrfd01}
 
 use play, imagination, arts knowledge, processes and/or skills to discover possibilities and develop ideas
 
@@ -48,9 +48,9 @@ use play, imagination, arts knowledge, processes and/or skills to discover poss
 *  exploring their speaking and singing voices and discovering ways to use their voices/vocalisation to communicate ideas and feelings
 *  improvising movements to explain the steps in a process, and then using a camera to capture a series of images or a photographic story that can be displayed in the classroom to remind everybody about the process
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADRFC01
+##### AC9ADRFC01 {#ac9adrfc01}
 
 create arts works that communicate ideas
 
@@ -63,9 +63,9 @@ create arts works that communicate ideas
 *  repurposing materials and objects such as clothing or packing boxes as starting points for imagining and developing scenes and scenarios; for example, using packing boxes to create an imagined environment or vehicle
 *  considering as a class the characters and situations associated with a story and then re-imagining them by asking questions of the story, such as “What’s up?”, “What happens next?” or “What else might/could happen?" to support the development of their own socio-dramatic or miniature worlds play
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADRFP01
+##### AC9ADRFP01 {#ac9adrfp01}
 
 share their arts works with audiences
 
@@ -79,7 +79,7 @@ share their arts works with audiences
 *  performing movement/dance sequences they have created for other groups in their class and introducing their work by describing their favourite moments in the sequence or explaining why they chose a particular movement
 *  using digital devices to record their arts explorations; for example, curating (selecting, ordering) a sequence of digital images (photos) to show the steps in a process; for example, images that show how they created new colours by mixing primary colours (using playdough or paint) and adding commentary that expresses their feelings, emotions and understandings
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Foundation, learning in The Arts builds on the Early Years Learning Framework and each student’s prior learning and experiences. The curriculum allows for play-based approaches that integrate arts learning experiences across the 5 Arts subjects and/or specialist teaching. There are examples in the content elaborations for each subject and examples that span across the subjects.
 

--- a/curriculum/arts-drama/years-1-and-2.md
+++ b/curriculum/arts-drama/years-1-and-2.md
@@ -1,6 +1,6 @@
-# The Arts - Drama - Years 1 and 2
+# Drama - Years 1 and 2 {#drama-years-1-and-2}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in The Arts builds on each student’s prior learning and experiences. Students continue to learn through purposeful and creative play in structured learning programs designed to foster a strong sense of wellbeing and develop their connection with and contribution to the world. They work individually and in collaboration with peers and teachers, drawing on their imagination, real-life experiences and learnings from across the curriculum.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating drama using forms such as dramatic play, process drama, puppetry, improvisation, Readers’ Theatre and/or mime and movement
 6.  performing/sharing drama in informal settings such as classroom presentations.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADR2E01
+##### AC9ADR2E01 {#ac9adr2e01}
 
 explore where, why and how people across cultures, communities and/or other contexts experience drama
 
@@ -35,7 +35,7 @@ explore where, why and how people across cultures, communities and/or other cont
 *  asking questions about the drama they experience; for example, “How and why are these people making drama?”, “Where are they making drama?”, “What is the drama about?”
 *  considering how drama communicates cultural knowledge in their own communities; for example, exploring how drama communicates stories, traditions and experiences that are important to people, such as drama that communicates stories from cultures, countries or regions in Asia
 
-##### AC9ADR2E02
+##### AC9ADR2E02 {#ac9adr2e02}
 
 explore examples of drama created and/or performed by First Nations Australians
 
@@ -46,9 +46,9 @@ explore examples of drama created and/or performed by First Nations Australians
 *  exploring ways of communicating knowledge through stories; for example, learning about stories that communicate knowledge of the environment in their region, through direct engagement (co-creating drama to share the knowledge) or using resources created or co-created by First Nations Australians
 *  co-creating a Welcome to Country (as appropriate) or an Acknowledgement of Country to perform before their drama class with a First Nations Australian person who has cultural authority, or using advice from a resource such as protocols from their school sector
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADR2D01
+##### AC9ADR2D01 {#ac9adr2d01}
 
 use the elements of drama and imagination in dramatic play and/or process drama
 
@@ -60,9 +60,9 @@ use the elements of drama and imagination in dramatic play and/or process drama
 *  taking turns in offering and accepting ideas, and staying in a role when participating in improvised drama
 *  brainstorming and discussing situations based on their experiences, such as situations related to games played during break time, and using these ideas to improvise drama
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADR2C01
+##### AC9ADR2C01 {#ac9adr2c01}
 
 create and co-create fictional situations based on imagination and/or experience
 
@@ -77,9 +77,9 @@ create and co-create fictional situations based on imagination and/or experience
 *  accepting the pretence situation established by others or participating in its active development; for example, by creating relevant props and suggesting relevant roles or additional situations to explore
 *  using inquiry questions to propose situations to explore in dramatic play and process drama, such as “What else might happen to these characters?”, “What might happen next?”, “What might have happened before the story?”, “What if I was there?”
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADR2P01
+##### AC9ADR2P01 {#ac9adr2p01}
 
 share their drama in informal settings
 
@@ -88,7 +88,7 @@ share their drama in informal settings
 *  performing sequences of frozen images linked by transitions in order to communicate key scenes from a familiar story
 *  considering their personal responses to drama experiences at school, in their homes or in their communities; for example, reflecting on their drama using questions such as, “What do you want your audience to think about your drama?”, “What did this drama make you think about?”, “How did you feel when making/watching the drama?”, and evaluating: “What did you like best in the drama? Why?”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 2, students identify where they experience drama. They describe where, why and/or how people across cultures, communities and/or other contexts experience drama.
 

--- a/curriculum/arts-drama/years-3-and-4.md
+++ b/curriculum/arts-drama/years-3-and-4.md
@@ -1,6 +1,6 @@
-# The Arts - Drama - Years 3 and 4
+# Drama - Years 3 and 4 {#drama-years-3-and-4}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in The Arts builds on each student’s prior learning and experiences. Arts learning continues to use purposeful and creative play-based activities that foster development of students’ identity and wellbeing, and their connection with and contribution to the world. Students further develop their capability and confidence in using subject-specific skills, and creative and critical practices. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating drama in improvised and devised forms such as dramatic play, process drama, puppetry, improvisation, Readers’ Theatre, mime and movement, and/or basic play-building
 6.  performing drama in informal settings such as spaces within the school.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADR4E01
+##### AC9ADR4E01 {#ac9adr4e01}
 
 explore where, why and how drama is created and/or performed across cultures, times, places and/or other contexts
 
@@ -36,7 +36,7 @@ explore where, why and how drama is created and/or performed across culture
 *  examining drama in their community and comparing it to other drama of different people, times and cultures; for example, exploring examples of puppetry and/or physical (movement-based) theatre in their communities and comparing this with examples of those forms from other cultures, times or places
 *  reflecting on and sharing ideas with others about the meaning and intended purposes of their own drama; for example, sharing embodied responses using movement, gesture or language
 
-##### AC9ADR4E02
+##### AC9ADR4E02 {#ac9adr4e02}
 
 explore how First Nations Australians use drama to communicate their connection to, and responsibility for, Country/Place
 
@@ -47,9 +47,9 @@ explore how First Nations Australians use drama to communicate their connection 
 *  accessing drama created and/or performed by First Nations Australians and exploring how drama communicates knowledge, such as ways to live sustainably, and to respect and care for the land, sea, sky or waterways
 *  looking at performances that represent the importance of Country/Place and Story for First Nations Australians as a starting point for talking about different ways of seeing the same place and telling stories
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADR4D01
+##### AC9ADR4D01 {#ac9adr4d01}
 
 use the elements of drama to explore and develop ideas for dramatic action in improvisations and/or devised drama
 
@@ -59,9 +59,9 @@ use the elements of drama to explore and develop ideas for dramatic action in im
 *  improvising ways to connect short scenes, such as clapping a rhythmic pattern, saying words or phrases and/or through movement
 *  developing spatial awareness when creating dramatic action; for example, considering how close/far apart they should stand to others in the performance space or how they can use movement to manipulate tension
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADR4C01
+##### AC9ADR4C01 {#ac9adr4c01}
 
 improvise and/or devise and shape drama using the elements of drama to communicate ideas, perspectives and/or meaning
 
@@ -74,9 +74,9 @@ improvise and/or devise and shape drama using the elements of drama to communica
 *  working in groups to devise sections of a drama (for example, using process drama strategies) and then, working as a class, using a guided play-building process to combine the sections
 *  communicating with an audience their connection to and responsibility for Country/Place by Acknowledging Country before a performance or presentation, taking care to observe protocols and using resources created or co-created by First Nations Australians, and/or by participating with Elders in a Welcome to Country (as appropriate)
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADR4P01
+##### AC9ADR4P01 {#ac9adr4p01}
 
 perform improvised and/or devised drama in informal settings
 
@@ -85,7 +85,7 @@ perform improvised and/or devised drama in informal settings
 *  demonstrating commitment to the reality/world of the drama; for example, staying “in-role” throughout the performance (even when not actively participating in the dramatic action)
 *  manipulating focus, tension, space and time to shape dramatic action when performing their drama
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 4, students describe use of selected elements of drama in drama they experience, create and/or perform. TThey describe where, why and/or how drama is created and/or performed across cultures, times, places and/or other contexts.
 

--- a/curriculum/arts-drama/years-5-and-6.md
+++ b/curriculum/arts-drama/years-5-and-6.md
@@ -1,6 +1,6 @@
-# The Arts - Drama - Years 5 and 6
+# Drama - Years 5 and 6 {#drama-years-5-and-6}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, students continue to learn in and through the practices of The Arts subjects, building on their prior learning and experiences. They use play and imagination in purposeful and creative ways and continue to develop their connection with and contribution to the world as artist and as audience. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating drama in improvised, devised and scripted forms such as process drama, puppetry, improvisation, Readers’ Theatre, mime and movement, play-building and devising, clowning, scripted drama/script interpretation
 6.  presenting and performing drama for audiences in available, informal and/or formal settings, including as appropriate, school-hosted digital spaces such as a school learning management system.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADR6E01
+##### AC9ADR6E01 {#ac9adr6e01}
 
 explore ways that the elements of drama are combined to communicate ideas, perspectives and/or meaning in drama across, cultures, times, places and/or other contexts
 
@@ -34,7 +34,7 @@ explore ways that the elements of drama are combined to communicate ideas, persp
 *  identifying and discussing use of elements of drama such as space, time, language, movement, character and/or relationships in the drama; for example, using Viewpoints to develop questions such as, “What did you see in the drama?”, “How did the actors make the characters believable?”, “When was the drama set? (For example, time, place or other context)”, “What was the purpose of the drama?”
 *  exploring drama from other places and times, and discussing how it might contribute to their own drama, and how cultural understandings shape meaning in drama; for example, exploring how drama is used to share cultural knowledge in celebrations, ceremonies or rituals that happen in their local community and/or in another place, such as a country or region in Asia
 
-##### AC9ADR6E02
+##### AC9ADR6E02 {#ac9adr6e02}
 
 explore the ways that First Nations Australians use drama to continue and revitalise cultures
 
@@ -44,9 +44,9 @@ explore the ways that First Nations Australians use drama to continue and revita
 *  identifying examples that illustrate how cultural expressions change over time; for example, by using available resources published by First Nations Australian communities and organisations
 *  investigating the ways that a diverse range of First Nations Australian drama makers and performers embed themselves and their communities in drama in a range of representative forms as a visual declaration of identity, storytelling and resilience; for example, exploring how drama is used to share cultural narratives
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADR6D01
+##### AC9ADR6D01 {#ac9adr6d01}
 
 explore ways to combine the elements of drama to communicate ideas, perspectives and/or meaning in improvisations, devised drama and/or scripted drama
 
@@ -57,9 +57,9 @@ explore ways to combine the elements of drama to communicate ideas, perspective
 *  using improvisation or process drama to compare different ways that improvised and scripted drama can create characters and action, or evaluating drama they experience in live performance and considering how they can use specific techniques in their own work
 *  imagining that they are in the time/place of an historical event and considering why people involved in the event made (or will make) certain decisions and/or what they could have done differently
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADR6C01
+##### AC9ADR6C01 {#ac9adr6c01}
 
 develop characters and situations, and shape and sustain dramatic action to communicate ideas, perspectives and/or meaning in improvised, devised and/or scripted forms
 
@@ -71,9 +71,9 @@ develop characters and situations, and shape and sustain dramatic action to comm
 *  devising drama based on research or knowledge about a project happening in their school/local community to encourage cultural awareness or to present different perspectives in a debate, such as a debate about an environmental issue
 *  working collaboratively to devise drama for a school ritual, gathering (such as an assembly) or ceremony; for example, drama that explores a school motto, a health message or a campaign such as “no-packaging lunch”
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADR6P01
+##### AC9ADR6P01 {#ac9adr6p01}
 
 rehearse and perform improvised, devised and/or scripted drama in informal and/or formal settings
 
@@ -83,7 +83,7 @@ rehearse and perform improvised, devised and/or scripted drama in informal and/o
 *  showing understanding of the purpose of rehearsing and the need for collaboration
 *  sharing ideas about their drama with audiences; for example, through choice of performance space, approach to entering or leaving the performance space, pre-show presentations or by creating an introduction such as a podcast that can be distributed when an audience member obtains their ticket
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 6, students explain how the elements of drama are used in drama they create, perform and/or experience. They describe how drama created and/or performed across cultures, times, places and/or other contexts communicates ideas, perspectives and/or meaning. They describe how drama is used to continue and revitalise cultures.
 

--- a/curriculum/arts-drama/years-7-and-8.md
+++ b/curriculum/arts-drama/years-7-and-8.md
@@ -1,6 +1,6 @@
-# The Arts - Drama - Years 7 and 8
+# Drama - Years 7 and 8 {#drama-years-7-and-8}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in Drama builds on each student’s prior learning and experiences. Students learn in and through the practices of Drama: creating, performing and responding. They use drama processes in purposeful and creative ways, and continue to develop their connection with and contribution to the world as artist and as audience. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating drama in improvised, devised and scripted forms such as process drama, puppetry, object theatre, short- or long-form improvisation, play-building and devising, scripted drama/script interpretation; for example, interpretation of realism and/or non-realism, exploration of historic, contemporary or hybrid styles
 6.  presenting and performing drama in informal and/or formal settings; for example, performing for a specific target audience.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADR8E01
+##### AC9ADR8E01 {#ac9adr8e01}
 
 investigate ways the elements of drama and/or conventions are used to communicate ideas, perspectives and/or meaning in drama created and/or performed across cultures, times, places and/or other contexts
 
@@ -35,7 +35,7 @@ investigate ways the elements of drama and/or conventions are used to communica
 *  writing or pod/vodcasting a review of a drama they experience, focusing on use of specific elements of drama and/or conventions; for example, identifying and describing how an element of drama has been manipulated to communicate ideas, perspectives and/or meaning
 *  analysing how linear and non-linear narrative is used in examples of drama from diverse cultures; for example, in contemporary drama from countries or regions in Asia or in drama from historical times
 
-##### AC9ADR8E02
+##### AC9ADR8E02 {#ac9adr8e02}
 
 investigate the diversity of drama created and/or performed by First Nations Australians, considering culturally responsive approaches to Indigenous Cultural and Intellectual Property rights
 
@@ -46,9 +46,9 @@ investigate the diversity of drama created and/or performed by First Nations Aus
 *  investigating specific examples of how drama practitioners select and use First Nations Australians’ historical and cultural material to develop and create contemporary First Nations Australian theatre; for example, using historical and cultural materials that accurately communicate First Nations Australian perspectives, such as resilience to the impacts of colonisation
 *  identifying and analysing what cultural appropriation is and how to avoid it by considering the original purpose, context and intended audience of cultural expressions; for example, using advice from protocols for protecting Indigenous Cultural and Intellectual Property rights
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADR8D01
+##### AC9ADR8D01 {#ac9adr8d01}
 
 develop performance skills relevant to selected drama styles and/or forms
 
@@ -61,7 +61,7 @@ develop performance skills relevant to selected drama styles and/or forms
 *  experimenting with ways to manipulate elements of drama and use performance skills to communicate status/power relationships in drama being devised and/or when interpreting scripts
 *  understanding the importance of and applying respectful relationships and empathy when developing roles and characters, and conveying historical and cultural ideas and meaning
 
-##### AC9ADR8D02
+##### AC9ADR8D02 {#ac9adr8d02}
 
 reflect on their own and others’ drama to inform choices when manipulating elements of drama and/or conventions to shape dramatic action
 
@@ -71,9 +71,9 @@ reflect on their own and others’ drama to inform choices when manipulating ele
 *  developing understanding of human behaviours and emotions using appropriate boundaries, by recalling and re-enacting past experiences and people they have observed in situations relevant to the text or content being used; asking “What did my/their body do?”, “How did my/their voice sound/communicate meaning in the situation?”, “How can I adapt my facial expression, posture, gesture, movement and voice/vocalisation to portray age, power or attitude?”, “How can I express character relationships through vocal dynamics, eye contact, distance and space?”
 *  reflecting on how performance skills are used to communicate perspectives; for example, how performance skills can be used in drama that seeks to communicate ideas such as perpetuating or challenging unequal power relationships and oppression
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADR8C01
+##### AC9ADR8C01 {#ac9adr8c01}
 
 improvise and devise drama and/or interpret scripted drama, manipulating elements of drama and applying conventions relevant to the style/form
 
@@ -85,7 +85,7 @@ improvise and devise drama and/or interpret scripted drama, manipulating element
 *  employing voice/vocalisation and movement appropriate to situation, and manipulating space and time in dramatic action to heighten tension, focus action and shape meaning
 *  using feedback, reflection or evaluation to develop and extend ideas when improvising, devising and/or scripting drama
 
-##### AC9ADR8C02
+##### AC9ADR8C02 {#ac9adr8c02}
 
 evaluate and refine use of elements of drama and/or conventions to shape and sustain dramatic action and/or communicate ideas, perspectives and/or meaning
 
@@ -95,9 +95,9 @@ evaluate and refine use of elements of drama and/or conventions to shape and su
 *  planning, organising and rehearsing dramatic action to stage devised and scripted drama; for example, arranging use of available theatre technologies and collaborating in rehearsal to stage drama for a clear and intended purpose and effect, considering choices within the overall structure
 *  considering how and why empathy should be considered when creating effects and communicating intended meaning; for example, exploring conventions for developing characters and stories in drama from a range of cultures
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADR8P01
+##### AC9ADR8P01 {#ac9adr8p01}
 
 rehearse and perform improvised, devised and/or scripted drama to audiences, using performance skills and conventions relevant to style and/or form
 
@@ -108,7 +108,7 @@ rehearse and perform improvised, devised and/or scripted drama to audiences, usi
 *  respecting Indigenous Cultural and Intellectual Property rights when performing drama that explores First Nations Australians’ perspectives on themes and issues such as identity, resilience, oppression or environmental practices
 *  reflecting on how respectful relationships and empathy were applied in their performance, and interpreted by the audience
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8, students analyse how elements of drama and/or conventions are manipulated in drama they create and/or experience. They evaluate the ways drama created and/or performed across cultures, times, places and/or other contexts communicates ideas, perspectives and/or meaning. They describe respectful approaches to creating, performing and/or responding to drama.
 

--- a/curriculum/arts-drama/years-9-and-10.md
+++ b/curriculum/arts-drama/years-9-and-10.md
@@ -1,6 +1,6 @@
-# The Arts - Drama - Years 9 and 10
+# Drama - Years 9 and 10 {#drama-years-9-and-10}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in Drama continues to build on each student’s prior learning and experiences as students develop their capability and confidence across the practices of Drama: creating, performing and responding. They continue to use drama processes in purposeful and creative ways that are informed by their engagement with the work of living performers and drama-makers from across local, regional, national and global contexts, such as countries or regions in Asia, including use of drama in multi-arts, trans-disciplinary and/or hybrid forms. This awareness of diverse drama practices, genres and/or styles informs their own drama practice. They work collaboratively with peers and teachers.
 
@@ -19,11 +19,11 @@ In this band, the focus is on students:
 5.  creating drama in improvised, devised and scripted forms such as process drama, puppetry, object theatre, short- or long-form improvisation, play building and devising, scripted drama/script interpretation; for example, interpretation of realism and non-realism, exploration of historic, contemporary and/or hybrid styles
 6.  presenting and performing drama in informal and/or formal settings; for example, using acting skills and working in an ensemble to perform drama for familiar and unfamiliar audiences.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9ADR10E01
+##### AC9ADR10E01 {#ac9adr10e01}
 
 investigate use of elements of drama, performance skills and/or conventions to communicate and/or challenge ideas, perspectives and/or meaning in drama across cultures, times, places and/or other contexts
 
@@ -35,7 +35,7 @@ investigate use of elements of drama, performance skills and/or conventions to c
 *  viewing or reading and exploring examples of historical texts and styles from a range of cultural traditions where artists have used the conventions of contemporary performance, such as mediatisation or intertextuality, or styles such as physical theatre, non-realist or emerging/innovative forms, to affect meaning and for various purposes; then unpacking this as a foundation for their own creative process
 *  identifying conventions of a collaborative, improvised style to communicate ideas or intentions to audiences; for example, to satirise or to elicit change; then considering how they, as artists, could use these creative tools for their own purposes
 
-##### AC9ADR10E02
+##### AC9ADR10E02 {#ac9adr10e02}
 
 investigate the ways that drama created and/or performed by First Nations Australians celebrates and challenges multiple perspectives of Australian identity
 
@@ -45,9 +45,9 @@ investigate the ways that drama created and/or performed by First Nations Austra
 *  investigating specific examples of how Contemporary First Nations Australian Theatre explores and challenges concepts and histories of Australia and Australian identity
 *  comparing and critiquing ways in which contemporary drama and cultural expressions celebrate and challenge influences on Australia's identity
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9ADR10D01
+##### AC9ADR10D01 {#ac9adr10d01}
 
 develop performance skills and/or techniques to manipulate elements of drama and/or use conventions to communicate the physical and psychological aspects of roles and characters consistent with intentions
 
@@ -56,7 +56,7 @@ develop performance skills and/or techniques to manipulate elements of drama and
 *  using analysis of examined text and performances to provide information for exploring and refining the implied or underlying aspects of character and dramatic action in a text or devised action
 *  refining their skills of voice/vocalisation through warm-ups or exercises focusing on character and delivery or movement
 
-##### AC9ADR10D02
+##### AC9ADR10D02 {#ac9adr10d02}
 
 reflect on their own and others’ drama or practices to refine and inform their use of elements of drama, conventions and/or approaches to shape and sustain dramatic action
 
@@ -65,9 +65,9 @@ reflect on their own and others’ drama or practices to refine and inform their
 *  analysing and making choices about how to manipulate elements of drama and experimenting with the application of conventions, such as subtext or beats, to affect meaning, focus action or shape a scene
 *  shaping their use of elements of drama, conventions and styles to achieve an intended meaning or effect
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9ADR10C01
+##### AC9ADR10C01 {#ac9adr10c01}
 
 improvise and devise drama, and interpret scripted drama, using elements of drama and conventions to shape and manipulate dramatic action and convey intended ideas, perspectives and/or meaning
 
@@ -79,7 +79,7 @@ improvise and devise drama, and interpret scripted drama, using elements of dram
 *  scripting scenes initially developed through improvisation or process drama and using play-building techniques to develop the scenes; for example, scenes for a music theatre work
 *  considering use of props, set items or digital tools to enhance communication of meaning in their drama
 
-##### AC9ADR10C02
+##### AC9ADR10C02 {#ac9adr10c02}
 
 rehearse and refine drama making deliberate aesthetic choices to unify dramatic meaning
 
@@ -92,9 +92,9 @@ rehearse and refine drama making deliberate aesthetic choices to unify dramatic 
 *  considering the impact of design elements such as costume, prop, set, lighting, sound or technologies on meaning and aesthetic effect
 *  manipulating elements of drama and using conventions to create and manipulate actor–audience relationships
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9ADR10P01
+##### AC9ADR10P01 {#ac9adr10p01}
 
 perform improvised, devised and/or scripted drama to audiences, using performance skills and conventions to shape the drama.
 
@@ -104,7 +104,7 @@ perform improvised, devised and/or scripted drama to audiences, using performanc
 *  performing on stage or in class in a sustained presentation
 *  reflecting on and evaluating how successfully their intentions/purposes, clear action and meaning, and effects were achieved in context, through use of the elements, conventions, performance skills and design, and what can be learnt from this for future dramatic practice
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In this band, learning in Drama continues to build on each student’s prior learning and experiences as students develop their capability and confidence across the practices of Drama: creating, performing and responding. They continue to use drama processes in purposeful and creative ways that are informed by their engagement with the work of living performers and drama-makers from across local, regional, national and global contexts, such as countries or regions in Asia, including use of drama in multi-arts, trans-disciplinary and/or hybrid forms. This awareness of diverse drama practices, genres and/or styles informs their own drama practice. They work collaboratively with peers and teachers.
 

--- a/curriculum/arts-media-arts/foundation-year.md
+++ b/curriculum/arts-media-arts/foundation-year.md
@@ -1,6 +1,6 @@
-# The Arts - Media Arts - Foundation Year
+# Media Arts - Foundation Year {#media-arts-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 In Foundation, learning in The Arts builds on the Early Years Learning Framework and each student’s prior learning and experiences. The curriculum allows for play-based approaches that integrate arts learning experiences across the 5 Arts subjects and/or specialist teaching. There are examples in the content elaborations for each subject and examples that span across the subjects.
 
@@ -15,11 +15,11 @@ In Foundation, learning in Media Arts can involve students:
 *   exploring ways to construct representations that communicate ideas and stories
 *   discovering how they and others can use media to communicate feelings and understandings.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMAFE01
+##### AC9AMAFE01 {#ac9amafe01}
 
 explore how and why the arts are important for people and communities
 
@@ -32,9 +32,9 @@ explore how and why the arts are important for people and communities
 *  exploring how illustrations/images in a text (fiction or non-fiction, print or screen) help to communicate narrative or information about characters or settings and/or mood
 *  listening to First Nations Australians talk about the importance of the arts for connecting to people, culture and Country/Place; for example, using resources created or co-created by First Nations Australians
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMAFD01
+##### AC9AMAFD01 {#ac9amafd01}
 
 use play, imagination, arts knowledge, processes and/or skills to discover possibilities and develop ideas
 
@@ -48,9 +48,9 @@ use play, imagination, arts knowledge, processes and/or skills to discover poss
 *  exploring their speaking and singing voices and discovering ways they can use their voices/vocalisation to communicate ideas and feelings
 *  improvising movements to explain the steps in a process, and then using a camera to capture a series of images/photographic story that can be displayed in the classroom to remind everybody about the process
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMAFC01
+##### AC9AMAFC01 {#ac9amafc01}
 
 create arts works that communicate ideas
 
@@ -63,9 +63,9 @@ create arts works that communicate ideas
 *  repurposing materials and objects such as clothing or packing boxes as starting points for imagining and developing scenes and scenarios; for example, using packing boxes to create an imagined environment or vehicle
 *  considering as a class the characters and situations associated with a story and then re-imagining them by asking questions of the story, such as “What’s up?”, “What happens next?” or “What else might/could happen?" to support the development of their own socio-dramatic or miniature worlds play
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMAFP01
+##### AC9AMAFP01 {#ac9amafp01}
 
 share their arts works with audiences
 
@@ -79,7 +79,7 @@ share their arts works with audiences
 *  performing movement/dance sequences they have created for other groups in their class and introducing their work by describing their favourite moments in the sequence or explaining why they chose a particular movement
 *  using digital devices to record their arts explorations; for example, curating (selecting, ordering) a sequence of digital images (photos) to show the steps in a process; for example, images that show how they created new colours by mixing primary colours (using playdough or paint) and adding commentary that expresses their feelings, emotions and understandings
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Foundation, learning in The Arts builds on the Early Years Learning Framework and each student’s prior learning and experiences. The curriculum allows for play-based approaches that integrate arts learning experiences across the 5 Arts subjects and/or specialist teaching. There are examples in the content elaborations for each subject and examples that span across the subjects.
 

--- a/curriculum/arts-media-arts/years-1-and-2.md
+++ b/curriculum/arts-media-arts/years-1-and-2.md
@@ -1,6 +1,6 @@
-# The Arts - Media Arts - Years 1 and 2
+# Media Arts - Years 1 and 2 {#media-arts-years-1-and-2}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in The Arts builds on each student’s prior learning and experiences. Students continue to learn through purposeful and creative play in structured learning programs designed to foster a strong sense of wellbeing and develop their connection with and contribution to the world. They work individually and in collaboration with peers and teachers drawing on their imaginations, works of fiction, real-life experiences and learnings from across the curriculum to support their engagement in arts learning, as artists and as audiences.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating media arts works by selecting and combining images, sounds, text and/or interactive elements to construct representations
 6.  presenting/sharing media arts works they have created in informal settings such as classroom presentations.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMA2E01
+##### AC9AMA2E01 {#ac9ama2e01}
 
 explore where, why and how people across cultures, communities and/or other contexts experience media arts
 
@@ -35,7 +35,7 @@ explore where, why and how people across cultures, communities and/or other cont
 *  discussing the roles of media artists and what permission means; for example, deciding on a class set of rules for using and creating images, sounds and text in media arts works
 *  considering how media arts works communicate and celebrate cultural knowledge in their own communities; for example, through podcasts or animated children’s shows
 
-##### AC9AMA2E02
+##### AC9AMA2E02 {#ac9ama2e02}
 
 explore examples of media arts produced and/or distributed by First Nations Australians
 
@@ -45,9 +45,9 @@ explore examples of media arts produced and/or distributed by First Nations Aust
 *  observing how visual, audio and/or interactive elements are used in media arts works created by First Nations Australians; for example, exploring colours, symbols and patterns used in media arts works with representatives of the First Nations Australian community or through resources that are created or co-created by First Nations Australians
 *  exploring media arts works created and/or co-created by First Nations Australians that communicate cultural narratives
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMA2D01
+##### AC9AMA2D01 {#ac9ama2d01}
 
 explore ways of using media technologies responsibly to capture and organise images, sounds, text and/or interactive elements
 
@@ -58,9 +58,9 @@ explore ways of using media technologies responsibly to capture and organise ima
 *  experimenting with ways that media artists communicate with audiences by combining text, symbols and images; for example, combining headlines, subtitles and digital images to communicate ideas or emotions
 *  using Viewpoints to develop questions as they experiment with media technologies, such as, “What happens if I take a photo up close to the object, and how does it change as I move further away?”, “How can I change the meaning of this image by adding different text headings?”
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMA2C01
+##### AC9AMA2C01 {#ac9ama2c01}
 
 use media languages and media technologies to construct representations
 
@@ -71,9 +71,9 @@ use media languages and media technologies to construct representations
 *  producing and presenting a media arts work for a particular purpose; for example, creating an advertisement that recommends appropriate behaviour when using cameras
 *  using features such as shot types in media arts works; for example, identifying long-shots, mid-shots and close-ups; discussing what the shots tell the audience about the story
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMA2P01
+##### AC9AMA2P01 {#ac9ama2p01}
 
 share media arts works with audiences in informal settings
 
@@ -83,7 +83,7 @@ share media arts works with audiences in informal settings
 *  considering relationships that peers may have with their work when creating, rehearsing and recording a radio play, and seeking permission to share it with another class
 *  exploring what permission means; for example, consulting relevant people such as cultural knowledge holders or using online safety resources, and deciding on a class set of rules for using and creating images, sounds and text in media arts works
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 2, students identify where they experience media arts. They describe where, why and/or how people across cultures, communities and/or other contexts experience media arts.
 

--- a/curriculum/arts-media-arts/years-3-and-4.md
+++ b/curriculum/arts-media-arts/years-3-and-4.md
@@ -1,6 +1,6 @@
-# The Arts - Media Arts - Years 3 and 4
+# Media Arts - Years 3 and 4 {#media-arts-years-3-and-4}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in The Arts builds on each student’s prior learning and experiences. Arts learning in this band continues to use purposeful and creative play-based activities that foster development of students’ identity and wellbeing, and their connection with and contribution to the world. Students further develop their capability and confidence in using subject-specific skills and creative and critical practices. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating (producing) media arts works in a range of forms to communicate ideas to audiences using media technologies and media languages
 6.  presenting media arts works they have created in informal settings such as spaces within the school.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMA4E01
+##### AC9AMA4E01 {#ac9ama4e01}
 
 explore where, why and how media arts is created and/or distributed across cultures, times, places and/or other contexts
 
@@ -36,7 +36,7 @@ explore where, why and how media arts is created and/or distributed across cultu
 *  using appropriate language to discuss the meaning of their own media arts works; for example, in writing or through an oral, visual or multimedia presentation
 *  investigating digital or analog storyboarding as a planning tool; for example, preparing a storyboard for a short film, stop motion or comic strip, to create a sequence of actions, changes or events; rearranging the sequence of boards, or adding and removing boards, to change the meaning or add new meaning to the narrative, and testing how a group of people responds
 
-##### AC9AMA4E02
+##### AC9AMA4E02 {#ac9ama4e02}
 
 explore how First Nations Australians use media arts to communicate their connection to and responsibility for Country/Place
 
@@ -49,9 +49,9 @@ explore how First Nations Australians use media arts to communicate their connec
 *  exploring how stories and ideas can communicate connection to and responsibility for Country/Place; for example, cultural stories of cyclic phenomena, knowledge of land, sea, sky and waterways, how First Nations Australians perceive themselves and their environment
 *  exploring a media arts work that includes images, sound and/or text and communicates the diversity of First Nations Australians’ cultures, such as an interactive map of First Nations Australian languages, considering, for example, how media technologies and languages are used to communicate and create a relationship with the viewer
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMA4D01
+##### AC9AMA4D01 {#ac9ama4d01}
 
 develop media production skills by exploring ways of shaping ideas using media technologies, images, sounds, text and/or interactive elements
 
@@ -62,9 +62,9 @@ develop media production skills by exploring ways of shaping ideas using media
 *  exploring media technologies and languages when creating sound effects or images to convey a mood or main idea of a story; for example, reviewing captured images, storyboarding, zooming in and out, deleting unwanted images, adding sound/text to images to create or support a story, considering how different options might be perceived by the intended audience
 *  using Viewpoints to develop questions to respond to their experiences as they work, such as, “In what ways does the meaning of the image change when I manipulate the sound effects?”, “Where is the suspense happening in this work, and how do I know?”, “Which images will best represent the story I am trying to tell?”
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMA4C01
+##### AC9AMA4C01 {#ac9ama4c01}
 
 use media languages, media technologies and production processes to construct representations that communicate ideas, perspectives and/or meaning
 
@@ -76,9 +76,9 @@ use media languages, media technologies and production processes to construc
 *  filming a short sequence that focuses on conflict by selecting camera angles, lighting and/or costume to convey meaning without dialogue
 *  collaborating with others to make a small publication to explore ideas that are significant in their lives; for example, a zine or new website, using collaged images and texts and drawings
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMA4P01
+##### AC9AMA4P01 {#ac9ama4p01}
 
 share media arts works in informal settings considering responsible media practice
 
@@ -87,7 +87,7 @@ share media arts works in informal settings considering responsible media practi
 *  seeking permission to take photos of class members; for example, documenting a school excursion for publication on the school intranet and acknowledging that this permission has been obtained when sharing the work
 *  considering media concepts, such as audience and relationships, when formatting and laying out a story, using available software and appropriate text conventions for a front-page news story or print advertisement
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 4, students describe the use of media languages and media technologies to construct representations in media arts works they experience and/or produce. They describe where, why and/or how media arts works are created and/or distributed across cultures, times, places, and/or other contexts.
 

--- a/curriculum/arts-media-arts/years-5-and-6.md
+++ b/curriculum/arts-media-arts/years-5-and-6.md
@@ -1,6 +1,6 @@
-# The Arts - Media Arts - Years 5 and 6
+# Media Arts - Years 5 and 6 {#media-arts-years-5-and-6}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, students continue to learn in and through the practices of The Arts subjects, building on their prior learning and experiences. They work creatively and purposefully, and continue to develop their connection with and contribution to the world as artists and as audiences. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  creating (producing) media arts works that communicate ideas using stand-alone media arts forms or creating media elements for use in multi-arts works
 6.  presenting/screening/exhibiting/distributing media arts works they have created and sharing ideas about the work with audiences.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMA6E01
+##### AC9AMA6E01 {#ac9ama6e01}
 
 explore ways that media languages and media technologies are used in media arts works and practices across cultures, times, places and/or other contexts
 
@@ -38,7 +38,7 @@ explore ways that media languages and media technologies are used in media arts 
 *  exploring how context influences the characters, stories and values portrayed in media arts works; for example, comparing online advertisements that convey safety messages
 *  discussing the role of media arts works in sharing cultural information about a group of people and their spirituality, and enhancing the value placed on people and the environment
 
-##### AC9AMA6E02
+##### AC9AMA6E02 {#ac9ama6e02}
 
 explore ways First Nations Australians use media arts to continue and revitalise cultures
 
@@ -48,9 +48,9 @@ explore ways First Nations Australians use media arts to continue and revitalise
 *  investigating the ways that First Nations Australian media artists embed themselves and their communities in media arts works in a range of representative forms as a visual declaration of identity, storytelling and resilience in the form of visibility; for example, exploring representations of First Nations Australians as superheroes in comics, popular culture and television
 *  using Viewpoints to develop questions that explore understandings about themes or issues in media arts works and considering what needs to be investigated further; for example, “What do I already know about this issue?”, “Is there more to this story than is being presented?”, “What questions would I ask the media artist about this product?”
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMA6D01
+##### AC9AMA6D01 {#ac9ama6d01}
 
 develop media production skills to communicate ideas, perspectives and/or meaning through manipulation of media languages, including images, sounds, texts and/or interactive elements, and media technologies
 
@@ -61,9 +61,9 @@ develop media production skills to communicate ideas, perspectives and/or meanin
 *  identifying story structures and technical or symbolic elements that contribute to the formation of genre in media arts works; for example, identifying shot type, sound quality, lighting and setting, and experimenting with ways to use this when planning media arts works
 *  creating a script for a radio production and documenting the appropriate permissions that may be required for music and voice talents in a real-world community radio setting
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMA6C01
+##### AC9AMA6C01 {#ac9ama6c01}
 
 use media languages, media technologies and production processes to construct media arts works that communicate ideas, perspectives and/or meaning for specific audiences
 
@@ -76,9 +76,9 @@ use media languages, media technologies and production processes to construct me
 *  creating a short genre film using chroma key, special effects, editing, sound effects, film language and other technology to enhance the end product
 *  using Viewpoints to develop questions when reflecting on their production process, such as “How can I adapt and manipulate story principles to make my intention clear?”, “What is working well in my storyboard?” and “Which areas do I need to improve?”
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMA6P01
+##### AC9AMA6P01 {#ac9ama6p01}
 
 present media arts works in informal and/or formal settings using responsible media practice
 
@@ -89,7 +89,7 @@ present media arts works in informal and/or formal settings using responsible me
 *  considering protocols for representing community or cultural stories in media arts works
 *  reflecting on how and why understandings of culture were used within their media arts works, and their effect on the audience
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 6, students explain how media languages and media technologies are used in media arts works they construct and/or experience. They describe how media arts works created across cultures, times, places and/or other contexts communicate ideas, perspectives and/or meanings. They describe how media arts can be used to continue and revitalise cultures.
 

--- a/curriculum/arts-media-arts/years-7-and-8.md
+++ b/curriculum/arts-media-arts/years-7-and-8.md
@@ -1,6 +1,6 @@
-# The Arts - Media Arts - Years 7 and 8
+# Media Arts - Years 7 and 8 {#media-arts-years-7-and-8}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in Media Arts builds on each student’s prior learning and experiences. Students learn in and through developing understanding and application of the Media Arts concepts: media technologies, representation, audience, institutions, media languages and relationships. They use production processes in purposeful and creative ways and continue to develop their connection with and contribution to the world as artist and as audiences. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  create (producing) media arts works in forms such as print, screen/moving image, audio and/or hybrid-/trans-disciplinary forms using production processes
 6.  presenting/screening/distributing media arts works they have produced to audiences; for example, for a specific target audience.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMA8E01
+##### AC9AMA8E01 {#ac9ama8e01}
 
 investigate the ways that media arts concepts are used in media arts works and practices across cultures, times, places and/or other contexts
 
@@ -35,7 +35,7 @@ investigate the ways that media arts concepts are used in media arts works and p
 *  analysing the way media languages are used to construct representations of people, places and concepts in media genres and products; for example, the ways that technical and symbolic codes are used to construct stereotypical representations of people, places or concepts in media arts works aimed at teenagers
 *  analysing the way audiences are positioned to respond to different representations constructed by technical and symbolic codes in media arts works, such as in the depiction of cultural or social groups and values in Australian film and television
 
-##### AC9AMA8E02
+##### AC9AMA8E02 {#ac9ama8e02}
 
 investigate the diversity of First Nations Australians’ media arts works and practices, considering culturally responsive approaches to Indigenous Cultural and Intellectual Property rights
 
@@ -47,9 +47,9 @@ investigate the diversity of First Nations Australians’ media arts works and p
 *  recognising how to select and use historical materials that accurately communicate First Nations Australians’ perspectives for including in media arts works, such as their resilience in response to the impacts of colonisation
 *  investigating issues relating to use of First Nations Australian languages or stories in lyrics and songs for screen-based works; for example, considering case studies that illustrate protocols relating to Indigenous Cultural and Intellectual Property rights
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMA8D01
+##### AC9AMA8D01 {#ac9ama8d01}
 
 develop media production skills throughout the production process to construct representations using media languages and media technologies
 
@@ -62,7 +62,7 @@ develop media production skills throughout the production process to construct r
 *  experimenting with established story principles, such as creating the opening scene to a documentary film that establishes a setting and location, or disrupting story principles through the manipulation of time so the narrative structure is not as an audience would expect
 *  combining established genre conventions to make a hybrid production; for example, exploring established media forms such as narrative, non-narrative, experimental, micro-documentary, trailers, music video, micro-short film and social media video campaign, or genres such as horror, western or comedy
 
-##### AC9AMA8D02
+##### AC9AMA8D02 {#ac9ama8d02}
 
 reflect on their own and others’ media arts works and practices to inform choices they make during the production process
 
@@ -75,9 +75,9 @@ reflect on their own and others’ media arts works and practices to inform choi
 *  using Viewpoints to develop reflective questions such as “How can I represent a range of views about this issue in my media arts work?”, “What do I need to change in the production processes to create a stronger connection with the audience?”
 *  exploring styles and representations particular to a country or region to inform their own practice and to develop their understanding of cultural appropriation and representation; for example, exploring the use of media conventions and languages in cartooning genres in Asia.
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMA8C01
+##### AC9AMA8C01 {#ac9ama8c01}
 
 design and structure media arts works to communicate ideas, perspectives and meaning for an intended audience
 
@@ -91,7 +91,7 @@ design and structure media arts works to communicate ideas, perspectives and mea
 *  experimenting with technical and symbolic elements to construct safe, legal, ethical and responsible representations of cultural or social groups and values
 *  trialling ways to combine established genre conventions to make a hybrid production; for example, exploring genres such as narrative, non-narrative, experimental, micro-documentary, trailer, music video, micro-short film and social media video campaign
 
-##### AC9AMA8C02
+##### AC9AMA8C02 {#ac9ama8c02}
 
 apply production processes and use media arts concepts to construct representations and produce media arts works that communicate ideas, perspectives and/or meaning for specific audiences using responsible media practice
 
@@ -103,9 +103,9 @@ apply production processes and use media arts concepts to construct representati
 *  producing a media arts work that represents ways of adapting habits or customs to build a more sustainable future for their community or to highlight how people are changing their behaviours to contribute to a just and equal society
 *  creating a news story in a print or digital format, focusing on an event they have been involved in, to communicate a perspective, using media languages to persuade their audience, and employing questions based on Viewpoints to consider how to manipulate aspects of the production for bias; for example, “Do the stories leave out or emphasise information?” or “Do the stories present the audience with obvious heroes and villains?” and “Why would media institutions engage in these practices?”
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMA8P01
+##### AC9AMA8P01 {#ac9ama8p01}
 
 present media arts works, using responsible media practices and considering potential relationships the work could create with audiences
 
@@ -115,7 +115,7 @@ present media arts works, using responsible media practices and considering pote
 *  reflecting on how relationships develop between media arts makers and their audiences, or across cohorts within the audience group, when planning when and how to present a media arts work they have made to an audience
 *  considering the impact of different audiences on the interpretation of and engagement with their media arts works; for example, presenting their media arts works in different contexts and evaluating the effectiveness of the response, such as using a school learning management platform to share work online with the school community, or sharing work at a fixed time and place such as a school exhibition
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of year 8, students analyse the use of media arts concepts to construct representations that communicate ideas, perspectives and/or meaning in media arts works they produce and/or experience. They evaluate use of media arts concepts in media arts works from across cultures, times, places and/or other contexts. They describe respectful approaches to creating and/or responding to media arts works.
 

--- a/curriculum/arts-media-arts/years-9-and-10.md
+++ b/curriculum/arts-media-arts/years-9-and-10.md
@@ -1,6 +1,6 @@
-# The Arts - Media Arts - Years 9 and 10
+# Media Arts - Years 9 and 10 {#media-arts-years-9-and-10}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in Media Arts continues to build on each student’s prior learning and experiences. Students learn in and through developing understanding and application of the Media Arts concepts: media technologies, representations, audiences, institutions, media languages and relationships. They use production processes in purposeful and creative ways and continue to develop their connection with and contribution to the world as artists and as audiences. They work individually and in collaboration with peers and teachers.
 
@@ -19,11 +19,11 @@ In this band, the focus is on students:
 5.  creating (producing) media arts works using production processes in forms such as print, screen/moving image, audio and/or hybrid/trans-disciplinary forms
 6.  presenting/screening/distributing media arts works they have produced to audiences, in informal and/or formal settings; for example, audiences that are known to the students and/or unfamiliar audiences.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMA10E01
+##### AC9AMA10E01 {#ac9ama10e01}
 
 investigate the ways that media artists use media arts concepts to construct representations in media arts works and practices across cultures, times, places and/or other contexts
 
@@ -38,7 +38,7 @@ investigate the ways that media artists use media arts concepts to construct rep
 *  identifying, describing and explaining the way technical and symbolic codes such as camera techniques, editing, sound, rhythm or mise-en-scène are manipulated in media arts works they have viewed or made to evoke audience responses such as excitement or fear, and/or to convey an intended meaning or position about an issue or idea, such as an opinion about climate change
 *  examining the role of media makers in perpetuating and/or challenging prevailing views on issues of contemporary relevance
 
-##### AC9AMA10E02
+##### AC9AMA10E02 {#ac9ama10e02}
 
 investigate the ways First Nations Australian media artists and/or producers celebrate and challenge multiple perspectives of Australian identity through media arts
 
@@ -50,9 +50,9 @@ investigate the ways First Nations Australian media artists and/or producers cel
 *  understanding the ways that media arts provide a voice for First Nations Australians through media institutions and forms such as film, television and online media platforms
 *  analysing the ways that First Nations Australian media artists use their practice to challenge and inform community debate and present multiple ways of understanding an issue; for example, exploring how First Nations Australians are caring for Country/Place and highlighting these issues through media arts
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMA10D01
+##### AC9AMA10D01 {#ac9ama10d01}
 
 experiment with ways to construct representations that reflect ideas, perspectives and/or meaning, and/or use of media conventions, media languages and media technologies
 
@@ -62,7 +62,7 @@ experiment with ways to construct representations that reflect ideas, perspectiv
 *  experimenting with use of mise-en-scène, camera work, sound, editing and media technologies in ways that are typically used in a genre, auteur or film movement
 *  manipulating technical and symbolic media codes and conventions of specific film, television or radio genres to produce a media arts work for a target audience; for example, creating a film trailer, film poster, short genre film or soundscape that communicates their understandings of the world around them
 
-##### AC9AMA10D02
+##### AC9AMA10D02 {#ac9ama10d02}
 
 reflect on their own or others’ media arts works and/or practices to refine and inform choices they make during stages of the production process
 
@@ -74,9 +74,9 @@ reflect on their own or others’ media arts works and/or practices to refine an
 *  using editing software to experiment with structuring sequences, and applying technical and symbolic codes and conventions, to create meaning for audiences; for example, adding filters, text, music, rhythm and pace to a suspense sequence, using teen flick genre conventions for font, music and split screen to create a sequence, or paying homage to an influential director by manipulating pace and rhythm to create suspense
 *  using Viewpoints to develop investigating questions when making decisions about how they will represent a theme, concept or idea, and considering possibilities for using or disrupting media conventions
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMA10C01
+##### AC9AMA10C01 {#ac9ama10c01}
 
 design and structure media arts works that examine and communicate ideas, perspectives and/or meaning
 
@@ -86,7 +86,7 @@ design and structure media arts works that examine and communicate ideas, perspe
 *  designing the camera work, sound, editing or mise-en-scène to construct alternative representations of people, places, ideas and events in a narrative media arts work such as a genre film, music video, documentary or animation
 *  examining the way technical and symbolic codes and conventions of specific film, television or radio genres have been used in a media arts work to communicate values, themes or ideas to an audience; using pre-production processes such as a shot list, shooting script, screenplay, treatment or storyboard to trial ideas, designing a different media arts work that communicates or challenges these values, themes or ideas; for example, a film trailer, short genre film or soundscape
 
-##### AC9AMA10C02
+##### AC9AMA10C02 {#ac9ama10c02}
 
 apply production processes and use media arts concepts to construct representations and produce media arts works that communicate ideas, perspectives and/or meaning, and confirm or challenge the expectations of specific audiences
 
@@ -97,9 +97,9 @@ apply production processes and use media arts concepts to construct representati
 *  using Viewpoints to frame questions and evaluate how their intentions are being communicated; for example, considering how and why meaning and experiences, political statements, critical theories and emotions have been used during post-production work
 *  creating multiple representations of the same person, place or concept in different media and for different intentions, considering audience interaction and the ways that media conventions can portray different perspectives
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMA10P01
+##### AC9AMA10P01 {#ac9ama10p01}
 
 present media arts works to audiences and plan approaches for creating relationships with audiences if/when media arts works are distributed in selected personal, community and/or institutional contexts using responsible media practice
 
@@ -110,7 +110,7 @@ present media arts works to audiences and plan approaches for creating relations
 *  using media technologies to design and produce a media arts work that promotes a community event, using a range of formats such as print and online formats; making decisions about time, technological access and ethical and economic constraints, and how the relationships their intended audience has with media impacts their understanding of media arts works
 *  investigating the relationships created between intended audiences and the media arts works they create, including the relationships that are created and formed between the audiences that come together from viewing their media arts works, and consider how these audiences can inform the creation of new media arts works
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In this band, learning in Media Arts continues to build on each student’s prior learning and experiences. Students learn in and through developing understanding and application of the Media Arts concepts: media technologies, representations, audiences, institutions, media languages and relationships. They use production processes in purposeful and creative ways and continue to develop their connection with and contribution to the world as artists and as audiences. They work individually and in collaboration with peers and teachers.
 

--- a/curriculum/arts-music/foundation-year.md
+++ b/curriculum/arts-music/foundation-year.md
@@ -1,6 +1,6 @@
-# The Arts - Music - Foundation Year
+# Music - Foundation Year {#music-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 In Foundation, learning in The Arts builds on the Early Years Learning Framework and each student’s prior learning and experiences. The curriculum allows for play-based approaches that integrate arts learning experiences across the 5 Arts subjects and/or specialist teaching. There are examples in the content elaborations for each subject and examples that span across the subjects.
 
@@ -15,11 +15,11 @@ In Foundation, learning in Music can involve students:
 *   using voice/vocalisation and instruments and elements of music such as duration/time (beat and rhythm), pitch and dynamics for composing and performing
 *   reflecting on their music experiences using language and/or in embodied ways.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMUFE01
+##### AC9AMUFE01 {#ac9amufe01}
 
 explore how and why the arts are important for people and communities
 
@@ -32,9 +32,9 @@ explore how and why the arts are important for people and communities
 *  exploring how illustrations/images in a text (fiction or non-fiction, print or screen) help to communicate narrative or information about characters, settings and/or mood
 *  listening to First Nations Australians talk about the importance of the arts for connecting to People, Culture and Country/Place; for example, using resources created or co-created by First Nations Australians
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMUFD01
+##### AC9AMUFD01 {#ac9amufd01}
 
 use play, imagination, arts knowledge, processes and/or skills to discover possibilities and develop ideas
 
@@ -48,9 +48,9 @@ use play, imagination, arts knowledge, processes and/or skills to discover poss
 *  exploring their speaking and singing voices and discovering ways they can use their voices/vocalisation to communicate ideas and feelings
 *  improvising movements to explain the steps in a process, and then using a camera to capture a series of images or a photographic story that can be displayed in the classroom to remind everybody about the process
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMUFC01
+##### AC9AMUFC01 {#ac9amufc01}
 
 create arts works that communicate ideas
 
@@ -63,9 +63,9 @@ create arts works that communicate ideas
 *  repurposing materials and objects such as clothing or packing boxes as starting points for imagining and developing scenes and scenarios; for example, using packing boxes to create an imagined environment or vehicle
 *  considering as a class the characters and situations associated with a story and then re-imagining them by asking questions of the story, such as: “What’s up?”, “What happens next?” or “What else might/could happen?" to support the development of their own socio-dramatic or miniature worlds play
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMUFP01
+##### AC9AMUFP01 {#ac9amufp01}
 
 share their arts works with audiences
 
@@ -79,7 +79,7 @@ share their arts works with audiences
 *  performing movement/dance sequences they have created for other groups in their class and introducing their work by describing their favourite moments in the sequence or explaining why they chose a particular movement
 *  using digital devices to record their arts explorations; for example, curating (selecting, ordering) a sequence of digital images (photos) to show the steps in a process; for example, images that show how they created new colours by mixing primary colours (using playdough or paint) and adding commentary that expresses their feelings, emotions and understandings
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Foundation, learning in The Arts builds on the Early Years Learning Framework and each student’s prior learning and experiences. The curriculum allows for play-based approaches that integrate arts learning experiences across the 5 Arts subjects and/or specialist teaching. There are examples in the content elaborations for each subject and examples that span across the subjects.
 

--- a/curriculum/arts-music/years-1-and-2.md
+++ b/curriculum/arts-music/years-1-and-2.md
@@ -1,6 +1,6 @@
-# The Arts - Music - Years 1 and 2
+# Music - Years 1 and 2 {#music-years-1-and-2}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in The Arts builds on each student’s prior learning and experiences. Students continue to learn through purposeful and creative play in structured learning programs designed to foster a strong sense of wellbeing and develop their connection with and contribution to the world. They work individually and in collaboration with peers and teachers drawing on their imagination, works of fiction, real-life experiences and learnings from across the curriculum to support their engagement in Arts learning as artists and as audiences.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  composing, singing and playing instruments, using the elements of music such as duration/time (beat and rhythm, tempo), pitch, dynamics and expression, texture and/or timbre
 6.  performing/sharing music they have learnt and/or composed in informal settings such as classroom presentations.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMU2E01
+##### AC9AMU2E01 {#ac9amu2e01}
 
 explore where, why and how people across cultures, communities and/or other contexts experience music
 
@@ -36,7 +36,7 @@ explore where, why and how people across cultures, communities and/or other cont
 *  discussing where, how and why they and their peers or family members experience music, and their music preferences; for example, compiling a playlist that combines their favourite music from the different generations in a family or creating a school playlist
 *  practising active listening skills; for example, moving with the beat and clapping rhythmic ideas or being aware of pitch and volume when they are singing/vocalising and/or playing instruments
 
-##### AC9AMU2E02
+##### AC9AMU2E02 {#ac9amu2e02}
 
 explore examples of music composed and/or performed by First Nations Australians
 
@@ -45,9 +45,9 @@ explore examples of music composed and/or performed by First Nations Australians
 *  exploring the diverse music styles represented in music composed and performed by First Nations Australians; for example, listening to music that is available through mainstream media; music performed at a local festival, by street performers, by choirs and/or orchestras; or music created or performed for events such as openings of cultural or community events or as part of a Welcome to Country, and asking questions such as “What instruments and voices can I hear?”, “How is this music communicating message/s about Country/Place?” or focusing exclusively on the music (the sound): “How is this music similar or different to other music I listen to?”
 *  exploring how the elements of music are used to create specific effects in screen-based or theatrical works that communicate First Nations Australian cultural knowledge; for example, viewing cartoons or animations that retell traditional stories and using Viewpoints to ask questions such as “How is texture being used to create tension in this part of the story?”, “How is melody being used to represent characters in this story?”, “How are tempo and dynamics being used to communicate the mood or feeling?”
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMU2D01
+##### AC9AMU2D01 {#ac9amu2d01}
 
 develop listening skills and skills for singing and playing instruments
 
@@ -61,9 +61,9 @@ develop listening skills and skills for singing and playing instruments
 *  developing understanding of what matching pitch means; for example, by using a digital tuner or closing eyes and gradually adjusting to match a partner’s pitch
 *  practising techniques for singing songs and playing classroom instruments
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMU2C01
+##### AC9AMU2C01 {#ac9amu2c01}
 
 select and combine elements of music when composing and practising music for performance
 
@@ -77,9 +77,9 @@ select and combine elements of music when composing and practising music for per
 *  practising music using accessible technologies; for example, using recordings to make decisions about dynamics or tempo
 *  writing lyrics for a chant/rap and improvising to develop rhythmic patterns they can use to perform the lyrics; for example, combining unison sections (voices alone) with multi-part sections (voices and body percussion or instruments)
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMU2P01
+##### AC9AMU2P01 {#ac9amu2p01}
 
 sing and play music in informal settings
 
@@ -91,7 +91,7 @@ sing and play music in informal settings
 *  listening intentionally and respectfully during performances and when invited, participating in the performance by using body percussion (clapping, tapping, stamping) or singing
 *  contributing to post-performance discussions; for example, sharing ideas about what the best part of the performance was or asking the performers questions such as, “How long have you been singing/playing as a group?” or “How did you get your instrument to …?”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 2, students identify where they experience music. They describe where, why and/or how people across cultures, communities and/or other contexts experience music.
 

--- a/curriculum/arts-music/years-3-and-4.md
+++ b/curriculum/arts-music/years-3-and-4.md
@@ -1,6 +1,6 @@
-# The Arts - Music - Years 3 and 4
+# Music - Years 3 and 4 {#music-years-3-and-4}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in The Arts builds on each student’s prior learning and experiences. Arts learning in this band continues to use purposeful and creative play-based activities that foster development of students’ identity and wellbeing and their connection with and contribution to the world. Students further develop their capability and confidence in using subject-specific skills and creative and critical practices. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  composing, singing and playing instruments using the elements of music such as duration/time (beat and rhythm, tempo, pulse), pitch, dynamics and expression, texture and/or timbre
 6.  performing music have learnt and/or composed in informal settings such as spaces within the school.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMU4E01
+##### AC9AMU4E01 {#ac9amu4e01}
 
 explore where, why and how music is composed and/or performed across cultures, times, places and/or other contexts
 
@@ -36,7 +36,7 @@ explore where, why and how music is composed and/or performed across cultures, t
 *  exploring ways of notating or documenting forms of music, such as graphic notation, lead-sheets (lyrics, melody and/or harmony/chords), using visual images or staff notation and/or using music terminology, identifying and explaining how each type of notation/documentation conveys information to performers
 *  exploring ways to make instruments from a range of materials; for example, using recycled/repurposed materials to construct instruments that produce sounds across a range of pitches and/or tone colours and effects; for example, cardboard tubes filled with cotton and rice, or food wrappers scrunched up loosely in recycled plastic bags; then using these instruments to create Foley sounds for a soundscape to accompany an exhibition of sculpture made from recycled/repurposed materials
 
-##### AC9AMU4E02
+##### AC9AMU4E02 {#ac9amu4e02}
 
 explore how First Nations Australians use music to communicate their connection to and responsibility for Country/Place
 
@@ -46,9 +46,9 @@ explore how First Nations Australians use music to communicate their connectio
 *  learning from First Nations Australians about how they use music to communicate their connection to, and responsibility for Country/Place, culture and people; for example, resources created or co-created by First Nations Australians, such as interviews/podcasts that feature First Nations Australians talking about their music and/or performances
 *  learning from First Nations Australians about the expectations and requirements of performers and audiences who are performing/experiencing music that communicates connection to, and responsibility for Country/Place, such as music used during a Welcome to Country
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMU4D01
+##### AC9AMU4D01 {#ac9amu4d01}
 
 develop listening skills and skills for manipulating elements of music when singing and playing instruments
 
@@ -61,9 +61,9 @@ develop listening skills and skills for manipulating elements of music when sing
 *  practising reading staff, graphic and/or invented notation as they rehearse and perform
 *  exploring options for representing sounds in a score; for example, inventing a graphic score to represent sounds of the environment or using a combination of staff notation and invented symbols; then using the score when rehearsing and making changes to ensure that it is accurate and useful/easy to follow in performance
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMU4C01
+##### AC9AMU4C01 {#ac9amu4c01}
 
 manipulate elements of music to communicate ideas, perspectives and/or meaning when composing and practising for performance
 
@@ -77,9 +77,9 @@ manipulate elements of music to communicate ideas, perspectives and/or meaning w
 *  combining composed and improvised sections to create a complete work; for example, composing a melody and accompaniment to create a theme song and combining with improvised/soundscape sections to accompany a reading/narration of a story they have written
 *  working in pairs or groups to create ostinatos or accompaniments; for example, using ukuleles or bucket drums and composing ostinatos or accompaniments for songs they are learning
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMU4P01
+##### AC9AMU4P01 {#ac9amu4p01}
 
 sing and play music they have learnt and/or composed in informal settings
 
@@ -90,7 +90,7 @@ sing and play music they have learnt and/or composed in informal settings
 *  planning how they will stage a performance and introduce their performances to audiences using spoken, written or audio-visual formats
 *  reading from notation and/or documentation such as a lead-sheet (lyrics and chords), staff or graphic notation that includes invented or learnt symbols when practising and performing music
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 4, students describe the use of elements of music in music they compose, perform and/or experience. They describe where, why and/or how music is composed and/or performed across cultures, times, places and/or other contexts.
 

--- a/curriculum/arts-music/years-5-and-6.md
+++ b/curriculum/arts-music/years-5-and-6.md
@@ -1,6 +1,6 @@
-# The Arts - Music - Years 5 and 6
+# Music - Years 5 and 6 {#music-years-5-and-6}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, students continue to learn in and through the practices of The Arts subjects, building on their prior learning and experiences. They work creatively and purposefully, and continue to develop their connection with and contribution to the world as artists and as audiences. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  composing and practising music for performance, manipulating the elements of music such as duration/time (including beat and rhythm, tempo, pulse, metre), pitch, dynamics and expression, texture, articulation (accent) and/or timbre to compose music; for example, songwriting, arranging a known melody or composing for an instrument they are learning, singing and playing instruments, and using aural skills to support these processes
 6.  performing music they have learnt and/or composed in informal and/or formal settings, such as spaces within the school including as appropriate, school-hosted digital spaces such as a school learning management system.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMU6E01
+##### AC9AMU6E01 {#ac9amu6e01}
 
 explore ways that the elements of music are combined in music across cultures, times, places and/or other contexts
 
@@ -37,7 +37,7 @@ explore ways that the elements of music are combined in music across cultures, t
 *  considering ways in which music is used in celebrations, ceremonies or rituals; for example, at their school or in their local community, and exploring ways the music is used to give structure to the occasion or to communicate themes such as identity or belonging
 *  demonstrating understanding of the form and structure of popular songs; for example, using parody to demonstrate the different structures used within popular song, discussing different processes for writing lyrics that tell a story, collaboratively generating ideas to create new lyrics to known music, rehearsing the re-imagined song (using aural, technical and expressive skills) and performing their song parody to their peers
 
-##### AC9AMU6E02
+##### AC9AMU6E02 {#ac9amu6e02}
 
 explore ways First Nations Australians use music to continue and revitalise culture
 
@@ -47,9 +47,9 @@ explore ways First Nations Australians use music to continue and revitalise c
 *  investigating music that First Nations Australian composers are creating for dance, drama, media arts or visual arts works that share cultural knowledge; for example, music for animations that share cultural knowledge about places, birds or animals
 *  investigating how First Nations Australian composers and/or performers share knowledge about their culture as part of performances; for example, acknowledging Country/Place before a performance, or sharing information about the language they are using in their song/performance or their inspiration for composing a song or instrumental work
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMU6D01
+##### AC9AMU6D01 {#ac9amu6d01}
 
 develop listening/aural skills and skills for manipulating elements of music to achieve expressive effects when composing, singing and playing instruments
 
@@ -61,9 +61,9 @@ develop listening/aural skills and skills for manipulating elements of music to 
 *  using digital tools to build skills such as accuracy and control; for example, using a digital tuner, using software to monitor articulation or dynamic range, or a digital metronome to monitor tempo
 *  practising techniques for singing and playing to develop technical skills in solo and ensemble music; for example, to accurately interpret rhythm and pitch
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMU6C01
+##### AC9AMU6C01 {#ac9amu6c01}
 
 manipulate elements of music and use compositional devices to communicate ideas, perspectives and/or meaning when composing and practising music for performance, and notate, document and/or record the music they compose
 
@@ -77,9 +77,9 @@ manipulate elements of music and use compositional devices to communicate ideas,
 *  using voice/vocalisation and sounds such as body percussion or drumming; for example, developing a song, chant or soundscape to accompany a Welcome to Country (for example, First Nations Australian students working with an Elder or a group of people who have permission to develop this part of a ceremony) or an Acknowledgement of Country (using correct protocols)
 *  using digital tools, voices and instruments to compose, notate, document music and/or record music; for example, combining loops constructed from melodic and/or rhythmic patterns with live performance, using voices and instruments or using notation software to create a score for performance by voice and instruments
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMU6P01
+##### AC9AMU6P01 {#ac9amu6p01}
 
 perform music in a range of forms they have learnt and/or composed in informal and/or formal settings
 
@@ -88,7 +88,7 @@ perform music in a range of forms they have learnt and/or composed in informal a
 *  providing and responding to feedback to refine performances and compositions; for example, discussing how the composer indicates dynamics in the music and how the performer/s interpret this information and how the performer/s communicate the mood of the music; for example, using tone colour/timbre and/or articulation (phrasing, staccato, legato)
 *  presenting performances via digital platforms including, if age-appropriate, interacting with audiences via platforms such as school intranet or website, and considering online safety protocols; for example, streaming or uploading recordings of performances and posing questions for the audience to respond to in a chat space
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 6, students explain how elements of music are manipulated in music they compose, perform and/or experience. They describe how music composed and/or performed across contexts, cultures, times and/or places communicates ideas, perspectives and/or meanings. They describe how music is used to continue and/or revitalise cultures.
 

--- a/curriculum/arts-music/years-7-and-8.md
+++ b/curriculum/arts-music/years-7-and-8.md
@@ -1,6 +1,6 @@
-# The Arts - Music - Years 7 and 8
+# Music - Years 7 and 8 {#music-years-7-and-8}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in Music builds on each student’s prior learning and experiences. Students learn in and through the music practices of listening, composing and performing. They use their music knowledge and skills in purposeful and creative ways, and continue to develop their connection with and contribution to the world as composers and performers and as audiences. They work individually and in collaboration with peers and teachers.
 
@@ -21,11 +21,11 @@ In this band, the focus is on students:
 5.  composing in forms and genres such as songwriting, solo and/or ensemble instrumental music, music production, arranging or re-imagining, and developing interpretations of solo and/or ensemble music works for performance, using aural skills and/or available digital tools as appropriate
 6.  presenting performances of music to audiences; for example, a specific target audience.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMU8E01
+##### AC9AMU8E01 {#ac9amu8e01}
 
 investigate the ways that composers and/or performers use the elements of music and/or compositional devices in music composed across cultures, times, places and/or other contexts
 
@@ -35,7 +35,7 @@ investigate the ways that composers and/or performers use the elements of music 
 *  listening to and evaluating how elements of music are manipulated in music composed by a range of composers, with the intention of drawing attention to social issues or values; for example, protest songs, nationalistic music, music that uses “folk”/traditional tunes in re-imagined ways, songs with lyrics that focus on themes such as identity or belonging
 *  researching and discussing the influence of social, cultural and historical developments relating to specific styles, forms or traditions and incorporating these into their performance and/or compositions; for example, conventions relating to forms such as 32-bar song form, genres such as chamber music, or traditions such as singer-songwriter
 
-##### AC9AMU8E02
+##### AC9AMU8E02 {#ac9amu8e02}
 
 investigate the diversity of music composed and/or performed by First Nations Australians, considering culturally responsive approaches to Indigenous Cultural and Intellectual Property rights
 
@@ -45,9 +45,9 @@ investigate the diversity of music composed and/or performed by First Nations Au
 *  exploring how protocols for protecting Indigenous Cultural and Intellectual Property rights exist to help students make ethical choices about how they use music, as listeners or creators; for example, by asking questions such as, “Who wrote this music?”, “May I use ideas from this song, and do I need permission to do so?”
 *  investigating issues relating to the use of First Nations Australian languages or stories in lyrics and songs or music for screen-based works; for example, considering case studies that illustrate protocols relating to Indigenous Cultural and Intellectual Property rights
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMU8D01
+##### AC9AMU8D01 {#ac9amu8d01}
 
 develop and practise listening/aural skills and vocal and/or instrumental skills/techniques for manipulating elements of music to achieve expressive effects
 
@@ -60,7 +60,7 @@ develop and practise listening/aural skills and vocal and/or instrumental sk
 *  using a listening diary/journal format to document ideas for compositions, interpretations, re-imaginings or performances
 *  writing/notating a chart or lead-sheet to record ideas from a songwriting workshop or using software to write additional parts such as a bassline to accompany a melody
 
-##### AC9AMU8D02
+##### AC9AMU8D02 {#ac9amu8d02}
 
 reflect on their own and others’ music to inform choices they make as composers and performers about how they will manipulate elements of music and/or compositional devices
 
@@ -69,9 +69,9 @@ reflect on their own and others’ music to inform choices they make as composer
 *  practising ways to use aural/visual cues when playing or singing in an ensemble; for example, chords or phrases that indicate place within a structure (aural) or gestures indicating tempo or entries (visual)
 *  using focused listening and selected aural skills to evaluate the use of elements of music when listening to a recording for the purpose of making decisions about how they will interpret the music
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMU8C01
+##### AC9AMU8C01 {#ac9amu8c01}
 
 interpret music in a variety of forms and/or styles, manipulating elements of music and employing relevant vocal/instrumental techniques
 
@@ -81,7 +81,7 @@ interpret music in a variety of forms and/or styles, manipulating elements of mu
 *  using student and teacher set goals as a focus for practising and rehearsing a range of solo and/or ensemble music
 *  manipulating sound quality by applying understanding of the range of sounds/timbres that different instruments and voice types can produce; for example, manipulating dynamics and timbre in voice or acoustic or digital instruments to create a specific effect
 
-##### AC9AMU8C02
+##### AC9AMU8C02 {#ac9amu8c02}
 
 compose using the elements of music and compositional devices to communicate ideas, perspectives and/or meaning, and notate, document and/or record the music
 
@@ -94,9 +94,9 @@ compose using the elements of music and compositional devices to communicate ide
 *  arranging a familiar music piece into a different music style by manipulating the elements of music to convey meaning, and documenting the arrangement in a form that is appropriate, considering the style and the preferences of the musicians who might be performing the arrangement; for example, arranging an instrumental work for choral performance
 *  developing an arrangement or re-imagining of an existing melody/tune by improvising, using given material such as a melody, riff or chord progression
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMU8P01
+##### AC9AMU8P01 {#ac9amu8p01}
 
 perform music using relevant vocal and/or instrumental techniques and performance skills
 
@@ -107,7 +107,7 @@ perform music using relevant vocal and/or instrumental techniques and performanc
 *  planning performances, rehearsing and performing their own vocal and/or instrumental compositions, individually or in a group, paying attention to expressive skills that convey stylistic understanding, such as articulation and accents
 *  planning and presenting an in-school performance, attending to how they manipulate elements of music and use vocal/instrumental techniques to convey stylistic understanding
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8, students analyse how the elements of music and/or compositional devices are manipulated in music they compose, perform and/or experience. They evaluate the ways music from across cultures, times, places and/or other contexts communicates ideas, perspectives and/or meaning. They describe respectful approaches to composing, performing and/or responding to music.
 

--- a/curriculum/arts-music/years-9-and-10.md
+++ b/curriculum/arts-music/years-9-and-10.md
@@ -1,6 +1,6 @@
-# The Arts - Music - Years 9 and 10
+# Music - Years 9 and 10 {#music-years-9-and-10}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in Music continues to build on each student’s prior learning and experiences as students develop their capability and confidence across the practices of Music: listening, composing and performing. They continue to use music knowledge and skills in purposeful and creative ways that are informed by their engagement with the work of living composers and performers from local, regional, national and global contexts such as countries or regions in Asia, including use of music in multi-arts, trans-disciplinary or hybrid forms. This awareness of diverse music practices, genres and/or styles informs their own music practices. They work collaboratively with peers and teachers.
 
@@ -19,11 +19,11 @@ In this band, the focus is on students:
 5.  composing in genres/forms such as songwriting, solo and/or ensemble instrumental music, music production, arranging or re-imagining, and developing interpretations of solo and/or ensemble music works for performance, using aural skills and/or available digital tools as appropriate
 6.  presenting performances to audiences; for example, for a specific target audience.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AMU10E01
+##### AC9AMU10E01 {#ac9amu10e01}
 
 investigate composers’ and/or performers’ use of elements of music, compositional devices and/or vocal/instrumental techniques in music from a range of cultures, times, places and/or other contexts
 
@@ -36,7 +36,7 @@ investigate composers’ and/or performers’ use of elements of music, composit
 *  discussing and evaluating the influence of music on the development of personal or social identity (for example ways music is used to influence or create a sense of belonging), and analysing how different traditions, styles and contexts affect the way people respond to the music; then using this analysis to inform the creation of a new piece of music
 *  using Viewpoints to ask questions, such as, “How has the rise of technology changed music styles or the ways composers and performers work?” or “How has technology impacted on audiences, the music industry and the way we consume music?” when considering how composers and/or performers develop their personal style and/or work collaboratively
 
-##### AC9AMU10E02
+##### AC9AMU10E02 {#ac9amu10e02}
 
 investigate the ways that First Nations Australian performers and/or composers celebrate and challenge multiple perspectives of Australian identity through music
 
@@ -46,9 +46,9 @@ investigate the ways that First Nations Australian performers and/or composers c
 *  evaluating intentions/motivations in music composed by and/or performed by First Nations Australians that challenges people to take action on issues such as climate change, environmental protection, social justice, racism or youth homelessness; for example, music presented in a themed performance program
 *  using and annotating a map of First Nations Australian language groups to identify where First Nations Australian composers and/or performers are working and providing short descriptions of their music
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AMU10D01
+##### AC9AMU10D01 {#ac9amu10d01}
 
 develop, practise and refine the use of listening/aural skills and style-specific vocal instrumental skills/techniques to interpret music and communicate expressive effects
 
@@ -58,7 +58,7 @@ develop, practise and refine the use of listening/aural skills and style-specifi
 *  mapping a planned approach to interpret dynamics; for example, using observations from another performance or analysis of the work, and identifying sections/points where the loudest and softest dynamics will be employed; then practising to realise the plan
 *  developing technical and expressive facility and control when using voice and/or instrument/s; for example, undertaking a systematic approach to developing and extending vocal or instrumental skills
 
-##### AC9AMU10D02
+##### AC9AMU10D02 {#ac9amu10d02}
 
 reflect on their own and others’ music to inform choices they make as composers and performers about how they will interpret and/or manipulate elements of music and/or compositional devices
 
@@ -68,9 +68,9 @@ reflect on their own and others’ music to inform choices they make as composer
 *  using focused listening, aural or memory skills to identify, sing or play and/or notate/document music ideas, such as pitch and rhythm patterns, intervals and common chord progressions, for future use in compositions and/or performances
 *  developing and refining use of aural skills relating to tuning/intonation that they can use in real-time to improve levels of accuracy and control when performing
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AMU10C01
+##### AC9AMU10C01 {#ac9amu10c01}
 
 interpret music in a variety of forms and styles, manipulating the elements of music and/or compositional devices, and using style-specific vocal/instrumental techniques to communicate ideas, perspectives and/or meaning
 
@@ -80,7 +80,7 @@ interpret music in a variety of forms and styles, manipulating the elements of m
 *  identifying stylistic conventions relevant to music they are learning, planning and practising to apply the conventions (as relevant) in their performance of music in that/those styles; for example, using information from composer/s, performers or analysis undertaken by other musicians or commentators
 *  selecting, interpreting and practising a performance program that focuses on a particular theme (social or historical), music style or the work of a composer or performer/s; for example, a solo or ensemble program
 
-##### AC9AMU10C02
+##### AC9AMU10C02 {#ac9amu10c02}
 
 compose music, manipulating and combining elements of music and compositional devices relevant to chosen styles and/or forms to communicate ideas, perspectives and/or meaning and notate, document and/or record the music
 
@@ -92,9 +92,9 @@ compose music, manipulating and combining elements of music and compositional d
 *  experimenting with ways to combine and manipulate the elements of music and using style-specific compositional devices to develop and shape or extend compositions
 *  analysing how elements of music are typically used in a music style and using findings as a guide when arranging or re-imagining music
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AMU10P01
+##### AC9AMU10P01 {#ac9amu10p01}
 
 rehearse and present planned performances of music they have learnt and/or composed, using relevant vocal/instrumental techniques and performance skills
 
@@ -104,7 +104,7 @@ rehearse and present planned performances of music they have learnt and/or compo
 *  rehearsing and presenting planned performances, and then reflecting on and evaluating how each performance may have been different, which was more successful with audiences, and why
 *  planning and presenting performances in a range of physical or virtual spaces, including providing audiences with information about the music, the performers and the ideas that the performers are intending to communicate
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In this band, learning in Music continues to build on each student’s prior learning and experiences as students develop their capability and confidence across the practices of Music: listening, composing and performing. They continue to use music knowledge and skills in purposeful and creative ways that are informed by their engagement with the work of living composers and performers from local, regional, national and global contexts such as countries or regions in Asia, including use of music in multi-arts, trans-disciplinary or hybrid forms. This awareness of diverse music practices, genres and/or styles informs their own music practices. They work collaboratively with peers and teachers.
 

--- a/curriculum/arts-visual-arts/foundation-year.md
+++ b/curriculum/arts-visual-arts/foundation-year.md
@@ -1,6 +1,6 @@
-# The Arts - Visual Arts - Foundation Year
+# Visual Arts - Foundation Year {#visual-arts-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 In Foundation, learning in The Arts builds on the Early Years Learning Framework and each student’s prior learning and experiences. The curriculum allows for play-based approaches that integrate arts learning experiences across the 5 Arts subjects and/or specialist teaching. There are examples in the content elaborations for each subject and examples that span across the subjects.
 
@@ -15,11 +15,11 @@ In Foundation, learning in Visual Arts can involve students:
 *   creating artworks that are planned and/or created intuitively and expressively
 *   sharing their artworks and their experiences.
 
-## Strands
+## Strands {#strands}
 
-### Exploring and responding
+### Exploring and responding {#exploring-and-responding}
 
-##### AC9AVAFE01
+##### AC9AVAFE01 {#ac9avafe01}
 
 explore how and why the arts are important for people and communities
 
@@ -32,9 +32,9 @@ explore how and why the arts are important for people and communities
 *  exploring how illustrations/images in a text (fiction or non-fiction, print or screen) help to communicate narrative or information about characters, settings and/or mood
 *  listening to First Nations Australians talk about the importance of the arts for connecting to people, culture and Country/Place; for example, using resources created or co-created by First Nations Australians
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AVAFD01
+##### AC9AVAFD01 {#ac9avafd01}
 
 use play, imagination, arts knowledge, processes and/or skills to discover possibilities and develop ideas
 
@@ -48,9 +48,9 @@ use play, imagination, arts knowledge, processes and/or skills to discover poss
 *  exploring their speaking and singing voices and discovering ways they can use their voices/vocalisation to communicate ideas and feelings
 *  improvising movements to explain the steps in a process, and then using a camera to capture a series of images or a photographic story that can be displayed in the classroom to remind everybody about the process
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AVAFC01
+##### AC9AVAFC01 {#ac9avafc01}
 
 create arts works that communicate ideas
 
@@ -63,9 +63,9 @@ create arts works that communicate ideas
 *  repurposing materials and objects such as clothing or packing boxes as starting points for imagining and developing scenes and scenarios; for example, using packing boxes to create an imagined environment or vehicle
 *  considering as a class the characters and situations associated with a story and then re-imagining them by asking questions of the story, such as “What’s up?”, “What happens next?” or “What else might/could happen?" to support the development of their own socio-dramatic or miniature worlds play
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AVAFP01
+##### AC9AVAFP01 {#ac9avafp01}
 
 share their arts works with audiences
 
@@ -79,7 +79,7 @@ share their arts works with audiences
 *  performing movement/dance sequences they have created for other groups in their class and introducing their work by describing their favourite moments in the sequence or explaining why they chose a particular movement
 *  using digital devices to record their arts explorations; for example, curating (selecting, ordering) a sequence of digital images (photos) to show the steps in a process; for example, images that show how they created new colours by mixing primary colours (using playdough or paint) and adding commentary that expresses their feelings, emotions and understandings
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Foundation, learning in The Arts builds on the Early Years Learning Framework and each student’s prior learning and experiences. The curriculum allows for play-based approaches that integrate arts learning experiences across the 5 Arts subjects and/or specialist teaching. There are examples in the content elaborations for each subject and examples that span across the subjects.
 

--- a/curriculum/arts-visual-arts/years-1-and-2.md
+++ b/curriculum/arts-visual-arts/years-1-and-2.md
@@ -1,6 +1,6 @@
-# The Arts - Visual Arts - Years 1 and 2
+# Visual Arts - Years 1 and 2 {#visual-arts-years-1-and-2}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in The Arts builds on each student’s prior learning and experiences. Students continue to learn through purposeful and creative play in structured learning programs designed to foster a strong sense of wellbeing, and develop their connection with and contribution to the world. They work individually and in collaboration with peers and teachers, drawing on their imaginations, works of fiction, real-life experiences and learnings from across the curriculum to support their engagement in arts learning, as artists and as audiences.
 
@@ -9,23 +9,19 @@ Students explore artworks that they experience at home, school and/or through fa
 In this band, the focus is on students:
 
 1.  exploring and responding to
+    *   artworks, artists’ practices and arts experiences across cultures, communities and/or other contexts, using visual arts practices and inquiry
+    *   examples of artworks and arts practices of First Nations Australians
+2.  developing creative and critical practices and skills
+    *   creative practices for using visual conventions, visual arts processes and materials
+    *   critical practices for observing, reflecting on and responding to artworks and practices they experience, including their own visual arts practice
+3.  creating artworks in a range of 2D, 3D and/or 4D (time-based) forms using available materials and/or digital tools
+4.  presenting/sharing artworks in informal settings such as classroom presentations.
 
-*   artworks, artists’ practices and arts experiences across cultures, communities and/or other contexts, using visual arts practices and inquiry
-*   examples of artworks and arts practices of First Nations Australians
+## Strands {#strands}
 
-3.  developing creative and critical practices and skills
+### Exploring and responding {#exploring-and-responding}
 
-*   creative practices for using visual conventions, visual arts processes and materials
-*   critical practices for observing, reflecting on and responding to artworks and practices they experience, including their own visual arts practice
-
-5.  creating artworks in a range of 2D, 3D and/or 4D (time-based) forms using available materials and/or digital tools
-6.  presenting/sharing artworks in informal settings such as classroom presentations.
-
-## Strands
-
-### Exploring and responding
-
-##### AC9AVA2E01
+##### AC9AVA2E01 {#ac9ava2e01}
 
 explore where, why and how people across cultures, communities and/or other contexts experience visual arts
 
@@ -36,7 +32,7 @@ explore where, why and how people across cultures, communities and/or other cont
 *  using Viewpoints to co-develop questions to explore an artist and their practice; for example, “Who is the artist?”, “When and where was this artwork created?”, “What materials and techniques might this artist have used?”
 *  identifying similarities and differences in artworks that represent subject matter or ideas they may be exploring in other learning areas; for example, exploring artworks that represent significant events from different times such as celebrations, or subject matter such as living creatures and their relationships with their environment
 
-##### AC9AVA2E02
+##### AC9AVA2E02 {#ac9ava2e02}
 
 explore examples of visual arts created by First Nations Australians
 
@@ -47,9 +43,9 @@ explore examples of visual arts created by First Nations Australians
 *  observing how visual conventions are used in artworks and designs created by First Nations Australians; for example, exploring colours, symbols and patterns used in artworks with representatives of the First Nations Australian community or through resources that are created or co-created by First Nations Australians
 *  exploring artworks that represent First Nations Australians’ interpretations of the night sky, co-creating symbols and/or designs to represent shapes and patterns that can be seen at different times of the year with First Nations Australians who have cultural authority
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AVA2D01
+##### AC9AVA2D01 {#ac9ava2d01}
 
 experiment and play with visual conventions, visual arts processes and materials
 
@@ -61,9 +57,9 @@ experiment and play with visual conventions, visual arts processes and materials
 *  examining artworks and trialling “layer + layer + layer” as a way of building surfaces, colour, texture and interest; for example, experimenting to create a layered world with pastels, then watercolour, ink and wax, and once the experiment is completed, identifying how each material could be used in a future artwork
 *  exploring visual conventions using a wide range of materials; for example, creating lines using media such as pastels, chalk, paint, ripped paper, textiles and markers; or going on a “line hunt” to identify and photograph the different lines they see around their school environment using a digital camera, or creating rubbings
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AVA2C01
+##### AC9AVA2C01 {#ac9ava2c01}
 
 use visual conventions, visual arts processes and materials to create artworks
 
@@ -75,9 +71,9 @@ use visual conventions, visual arts processes and materials to create artworks
 *  using 3D construction (sculpture) methods to represent subject matter or ideas being explored in another learning area; for example, building on their understanding of living things as a starting point to use modelling materials such as potato clay and found objects to represent the life cycle of an insect
 *  using a combination of digital art and analog art-making, such as using photography or drawing apps for painting and drawing, to create a collaged abstract work that represents feelings and emotions; for example, responding with colour, line and shape to music to create work that communicates how the music makes them feel
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AVA2P01
+##### AC9AVA2P01 {#ac9ava2p01}
 
 share artworks and/or visual arts practice in informal settings
 
@@ -87,7 +83,7 @@ share artworks and/or visual arts practice in informal settings
 *  using an everyday object as the starting point, drawing the object, then personifying it by adding character qualities, attributes and a name; then taking it in turns to match each student’s artwork with the appropriate object, explaining how they arrived at their decision
 *  deciding on an appropriate audience and ways to share their artworks; for example, sharing with the class a work-in-progress or posting their work on a school learning management system to allow their families to see and appreciate it
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 2, students identify where they experience visual arts. They describe where, why and/or how people across cultures, communities and/or other contexts experience visual arts.
 

--- a/curriculum/arts-visual-arts/years-3-and-4.md
+++ b/curriculum/arts-visual-arts/years-3-and-4.md
@@ -1,6 +1,6 @@
-# The Arts - Visual Arts - Years 3 and 4
+# Visual Arts - Years 3 and 4 {#visual-arts-years-3-and-4}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in The Arts builds on each student’s prior learning and experiences. Arts learning in this band continues to use purposeful and creative play-based activities that foster development of students’ identity and wellbeing, and their connection with and contribution to the world. Students further develop their capability and confidence in using subject-specific skills, and creative and critical practices. They work individually and in collaboration with peers and teachers.
 
@@ -9,23 +9,19 @@ Students continue to explore artworks that they experience at home, school or th
 In this band, the focus is on students:
 
 1.  exploring and responding to
+    *   artworks and experiences that showcase where, why and/or how visual arts are created across cultures, times, places and/or other contexts.
+    *   examples of artworks created by First Nations Australians that communicate connection to and responsibility for Country/Place
+2.  developing creative and critical practices and skills
+    *   creative practices for using visual conventions, visual arts processes and materials
+    *   critical practices by observing, reflecting on and responding to artworks and visual arts practices they experience, including their own visual arts practice
+3.  creating artworks in a range of 2D, 3D and/or 4D (time-based) forms using available materials (including available digital tools)
+4.  presenting/sharing artworks in informal settings such as spaces within the school.
 
-*   artworks and experiences that showcase where, why and/or how visual arts are created across cultures, times, places and/or other contexts.
-*   examples of artworks created by First Nations Australians that communicate connection to and responsibility for Country/Place
+## Strands {#strands}
 
-3.  developing creative and critical practices and skills
+### Exploring and responding {#exploring-and-responding}
 
-*   creative practices for using visual conventions, visual arts processes and materials
-*   critical practices by observing, reflecting on and responding to artworks and visual arts practices they experience, including their own visual arts practice
-
-5.  creating artworks in a range of 2D, 3D and/or 4D (time-based) forms using available materials (including available digital tools)
-6.  presenting/sharing artworks in informal settings such as spaces within the school.
-
-## Strands
-
-### Exploring and responding
-
-##### AC9AVA4E01
+##### AC9AVA4E01 {#ac9ava4e01}
 
 explore where, why and how visual arts are created and/or presented across cultures, times, places and/or other contexts
 
@@ -38,7 +34,7 @@ explore where, why and how visual arts are created and/or presented across cu
 *  identifying ways that artworks by different artists can present multiple perspectives of the same event and discussing how these works can develop social awareness; for example, accessing and comparing artists and artworks that explore sustainability, such as land art, artworks using recycled materials that represent the effects of climate on the environment
 *  describing and categorising visual features and cultural works around the school, such as artworks, craft works, design or architectural features, memorials, murals or displays according to their purpose; for example, social, decorative, architectural, functional, cultural
 
-##### AC9AVA4E02
+##### AC9AVA4E02 {#ac9ava4e02}
 
 explore how First Nations Australians use visual arts to communicate their connection to and responsibility for Country/Place
 
@@ -50,9 +46,9 @@ explore how First Nations Australians use visual arts to communicate their conne
 *  considering what their own cultural connections are as individuals; for example, considering place, language, family customs, values and beliefs and how, as an artist, they can use Viewpoints questions to map ways to use visual arts processes, subject matter and visual conventions to create artworks that communicate their personal connection to place. A typical question is, “Where do I feel most connected to my family, and what symbols, colours, shapes and subject matter could I create to represent this connection?”
 *  exploring visual conventions, symbols or patterns with representatives of a First Nations Australian community, or resources that are created or co-created by First Nations Australians; for example, exploring artworks that share cultural accounts of Country/Place
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AVA4D01
+##### AC9AVA4D01 {#ac9ava4d01}
 
 experiment with a range of ways to use visual conventions, visual arts processes and materials
 
@@ -63,9 +59,9 @@ experiment with a range of ways to use visual conventions, visual arts processes
 *  learning to use visual arts language when describing and documenting their thinking and learning; for example, developing questions based on Viewpoints, and using arrows and short statements to annotate their visual experiments (“What media did I use?”, “What worked well?”, “What went wrong, and how could I explore other options next time?”) or creating a sound file of their learning and thinking to accompany their experimentations when they present “work-in-progress”
 *  manipulating and experimenting with combinations of various materials and technologies to create visual effects; for example, using crosshatching to create tone, or using design elements to focus the viewer’s attention on a composition and using Viewpoints to reflect on the effectiveness of their experimentation ("What was I trying to achieve?", "What did I learn from pushing the boundaries of the materials and processes?")
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AVA4C01
+##### AC9AVA4C01 {#ac9ava4c01}
 
 use visual conventions, visual arts processes and materials to create artworks that communicate ideas, perspectives and/or meaning
 
@@ -77,9 +73,9 @@ use visual conventions, visual arts processes and materials to create artworks t
 *  using Viewpoints to develop questions as they experiment with composition to arrange visual conventions, subject matter and materials based on a designated area and deliberately changing the meaning of a visual story; for example, “What happens if I make the subject fill the frame?”, “Can I change the meaning of my work by using darker or lighter tones?”
 *  combining their understanding of visual conventions and visual arts processes to create different meaning in an artwork; for example, using a range of 2D media such as charcoal and coloured pastels to create gradation of tone in their artwork and using Viewpoints to develop questions as they work, such as “In what ways can I use colour to change the feeling of this artwork?”, “How does using darker tones contrasting with lighter ones create an illusion of depth?”
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AVA4P01
+##### AC9AVA4P01 {#ac9ava4p01}
 
 share and/or display artworks and/or visual arts practice in informal settings
 
@@ -90,7 +86,7 @@ share and/or display artworks and/or visual arts practice in informal settings
 *  discussing and documenting the ideas, themes and meaning/s of their artwork; for example, taking the form of a written or spoken artist statement, and exploring different ways of presenting their artwork and artist statement (possibly via multimedia)
 *  identifying and explaining their own and other artists' choices in art-making, including visual arts processes, visual conventions and materials
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 4, students describe the use of visual conventions, visual arts processes and materials in artworks they create and/or experience. They describe where, why and/or how visual artists create and/or display artworks across cultures, times, places and/or other contexts.
 

--- a/curriculum/arts-visual-arts/years-5-and-6.md
+++ b/curriculum/arts-visual-arts/years-5-and-6.md
@@ -1,6 +1,6 @@
-# The Arts - Visual Arts - Years 5 and 6
+# Visual Arts - Years 5 and 6 {#visual-arts-years-5-and-6}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, students continue to learn in and through the practices of The Arts subjects, building on their prior learning and experiences. They work creatively and purposefully and continue to develop their connection with and contribution to the world as artists and as audiences. They work individually and in collaboration with peers and teachers.
 
@@ -9,23 +9,19 @@ Students engage with artworks, artists, practices across cultures, times, places
 In this band, the focus is on students:
 
 1.  exploring and responding to
+    *   artworks from local, regional, national and global cultures, times, places and/or other contexts that show how artists communicate ideas, perspectives and/or meaning through their visual arts practice
+    *   artworks and visual arts practices that showcase ways that First Nations Australians are continuing and revitalising cultures
+2.  developing creative and critical practices and skills
+    *   creative practices for using visual conventions, visual arts processes and materials
+    *   critical practices by observing, reflecting on and responding to artworks and practices they experience, including their own visual arts practice
+3.  creating artworks in a range of 2D, 3D and/or 4D (time-based) forms using available materials and/or digital tools
+4.  presenting artworks and practices in available informal and/or formal settings, including, as appropriate, school-hosted digital spaces such as a school learning management system.
 
-*   artworks from local, regional, national and global cultures, times, places and/or other contexts that show how artists communicate ideas, perspectives and/or meaning through their visual arts practice
-*   artworks and visual arts practices that showcase ways that First Nations Australians are continuing and revitalising cultures
+## Strands {#strands}
 
-3.  developing creative and critical practices and skills
+### Exploring and responding {#exploring-and-responding}
 
-*   creative practices for using visual conventions, visual arts processes and materials
-*   critical practices by observing, reflecting on and responding to artworks and practices they experience, including their own visual arts practice
-
-5.  creating artworks in a range of 2D, 3D and/or 4D (time-based) forms using available materials and/or digital tools
-6.  presenting artworks and practices in available informal and/or formal settings, including, as appropriate, school-hosted digital spaces such as a school learning management system.
-
-## Strands
-
-### Exploring and responding
-
-##### AC9AVA6E01
+##### AC9AVA6E01 {#ac9ava6e01}
 
 explore ways that visual conventions, visual arts processes and materials are combined to communicate ideas, perspectives and/or meaning in visual arts across cultures, times, places and/or other contexts
 
@@ -36,7 +32,7 @@ explore ways that visual conventions, visual arts processes and materials are co
 *  using Viewpoints to develop questions to examine, compare and contrast what they notice in an artwork; for example, as a class, critically navigating multiple perspectives of the same artwork and questioning why they see these works so differently
 *  examining audio descriptions as an accessible way for people with impaired vision to enjoy visual arts; for example, listening to a series of descriptions of artworks by Australian artists in Australian institutions, selecting an artwork that they are interested in and creating an audio description of their own
 
-##### AC9AVA6E02
+##### AC9AVA6E02 {#ac9ava6e02}
 
 explore ways that First Nations Australians use visual arts to continue and revitalise cultures
 
@@ -47,9 +43,9 @@ explore ways that First Nations Australians use visual arts to continue and revi
 *  using Viewpoints to question understandings about artists and artworks, and explore what needs to be investigated further, such as “What do I already know about this artist?”, “What do I need to learn to have a better understanding about this artist, their Country/Place and culture?”, “What knowledge can I share with others?”, “What questions would I ask the artist about this artwork?”
 *  investigating how meaning and purpose are communicated in artworks and design created or co-created by First Nations Australians; for example, learning about how visual conventions are used in artworks and designs, such as textiles and fashion, to share cultural knowledge with the broader community
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AVA6D01
+##### AC9AVA6D01 {#ac9ava6d01}
 
 experiment with, document and reflect on ways to use a range of visual conventions, visual arts processes, and materials
 
@@ -61,9 +57,9 @@ experiment with, document and reflect on ways to use a range of visual conven
 *  making informed choices about using various combinations of representational elements appropriate for a concept or subject matter; for example, exploring and reflecting on observational and gestural drawing processes as different ways to describe an object or figure, or combining materials such as imaginative drawing over realistic photographs to elaborate on and create new meaning
 *  exploring different approaches to working in 3D forms, such as developing a range of techniques in modelling using materials such as earthenware clay or modelling clay; developing skills in hand-building and surface decoration to reflect on ways to communicate ideas, subject matter and meaning
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AVA6C01
+##### AC9AVA6C01 {#ac9ava6c01}
 
 use visual conventions, visual arts processes and materials to plan and create artworks that communicate ideas, perspectives and/or meaning
 
@@ -75,9 +71,9 @@ use visual conventions, visual arts processes and materials to plan and create a
 *  creating artworks that are the product of ideas they have developed through experimentation and planning; making choices about how to use visual art conventions, materials and techniques that best communicate their intentions
 *  forming modular patterns, images or letters with grid paper or an online digital system to combine glyphs, pixels and shapes; for example, removing the grid and transforming it to another form such as a poster or template for printmaking
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AVA6P01
+##### AC9AVA6P01 {#ac9ava6p01}
 
 select and present documentation of visual arts practice, and display artworks in informal and/or formal settings
 
@@ -90,7 +86,7 @@ select and present documentation of visual arts practice, and display artworks i
 *  considering artworks that represent a spatial awareness in digital or physical forms; for example, experimenting with Augmented Reality to place collage, objects or forms in space as a layer over what we see as “reality” digitally, or by arranging objects in physical space with transparent attachments, and producing a short moving image work to map how the visual assets change depending on point of view of the audience
 *  creating a set of art labels to accompany artworks in a class exhibition of student work; for example, labels that inform audiences about the artist and their intentions, an exhibition introduction, advertising material and reviews
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 6, students explain the ways that visual conventions, visual arts processes and materials are used in artworks they create and/or experience. They describe how artworks created across cultures, times, places and/or other contexts communicate ideas, perspectives and/or meaning. They describe how visual arts are used to continue and revitalise cultures.
 

--- a/curriculum/arts-visual-arts/years-7-and-8.md
+++ b/curriculum/arts-visual-arts/years-7-and-8.md
@@ -1,6 +1,6 @@
-# The Arts - Visual Arts - Years 7 and 8
+# Visual Arts - Years 7 and 8 {#visual-arts-years-7-and-8}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in Visual Arts builds on each student’s prior learning and experiences. Students learn in and through visual arts practices. They use visual arts processes and available analog/physical and/or digital materials in purposeful and creative ways, and continue to develop their connection with and contribution to the world as artists and as audiences. They work individually and in collaboration with peers and teachers.
 
@@ -9,23 +9,19 @@ Students explore visual arts in local, regional, national and global contexts, s
 In this band, the focus is on students:
 
 1.  exploring and responding to
+    *   artworks and visual arts practices across cultures, times, places and/or other contexts; for example, through exploration of works in physical or virtual spaces or engagement with artists
+    *   the diversity of visual arts created by First Nations Australians and how this work demonstrates respect for Indigenous Cultural and Intellectual Property rights
+2.  developing practices and skills
+    *   creative practices and skills for developing ideas, themes and their visual arts practice
+    *   critical practices by taking opportunities to reflect on, evaluate or respond to their own work or the work of others; for example, developing intentions for artworks based on exploration, inquiry and research
+3.  creating artworks in 2D, 3D and/or 4D (time-based forms) and/or multi-disciplinary forms to communicate ideas and intentions using visual conventions, visual arts processes and materials
+4.  presenting artworks to audiences, in physical and/or virtual spaces; for example, for a specific target audience.
 
-*   artworks and visual arts practices across cultures, times, places and/or other contexts; for example, through exploration of works in physical or virtual spaces or engagement with artists
-*   the diversity of visual arts created by First Nations Australians and how this work demonstrates respect for Indigenous Cultural and Intellectual Property rights
+## Strands {#strands}
 
-3.  developing practices and skills
+### Exploring and responding {#exploring-and-responding}
 
-*   creative practices and skills for developing ideas, themes and their visual arts practice
-*   critical practices by taking opportunities to reflect on, evaluate or respond to their own work or the work of others; for example, developing intentions for artworks based on exploration, inquiry and research
-
-5.  creating artworks in 2D, 3D and/or 4D (time-based forms) and/or multi-disciplinary forms to communicate ideas and intentions using visual conventions, visual arts processes and materials
-6.  presenting artworks to audiences, in physical and/or virtual spaces; for example, for a specific target audience.
-
-## Strands
-
-### Exploring and responding
-
-##### AC9AVA8E01
+##### AC9AVA8E01 {#ac9ava8e01}
 
 investigate ways that visual conventions, visual arts processes and materials are manipulated to represent ideas, perspectives and/or meaning in artworks created across cultures, times, places and/or other contexts
 
@@ -37,7 +33,7 @@ investigate ways that visual conventions, visual arts processes and materials ar
 *  investigating and trialling techniques and visual arts processes used by artists, thinking about whether these processes and technologies have changed over time, and how they can have an impact on art-making
 *  exploring the ways that artists are inspired and influenced by the practice of artists from other countries or cultures they have relationships with; for example, the reciprocal influence and impact between Australian and Asian artists and their practices
 
-##### AC9AVA8E02
+##### AC9AVA8E02 {#ac9ava8e02}
 
 investigate the diversity of First Nations Australians’ artworks and arts practices, considering culturally responsive approaches to Indigenous Cultural and Intellectual Property rights
 
@@ -47,9 +43,9 @@ investigate the diversity of First Nations Australians’ artworks and arts prac
 *  investigating an example of cultural appropriation where it has been found that First Nations Australian Indigenous Cultural and Intellectual Property rights have been denied and identifying how this situation could have been approached respectfully; for example, a situation where an artist used symbols, techniques or styles that carry cultural knowledge without gaining permission from the knowledge holders
 *  exploring how visual artists can respect Indigenous Cultural and Intellectual Property rights when using historical or other background materials that accurately communicate First Nations Australians’ perspectives, such as their resilience in response to the impacts of colonisation; for example, by using protocols or guidelines from education authorities or those that are endorsed by First Nations Australian organisations
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AVA8D01
+##### AC9AVA8D01 {#ac9ava8d01}
 
 experiment with visual conventions, visual arts processes and materials to develop skills
 
@@ -63,7 +59,7 @@ experiment with visual conventions, visual arts processes and materials to devel
 *  exploring the ways that a range of artists use materials, visual conventions and visual art processes to communicate their concepts; for example, investigating how artists use choices of materials and visual arts processes when working on a similar concept and how this impacts the viewer response, or experimenting with these approaches to consider how they might approach the same concept
 *  observing the different ways that artists respond to sensory stimuli, such as emotions, feelings or material properties, to generate ideas and directions for their own works; for example, being guided by the tactile qualities of a material as inspiration for practical exploration
 
-##### AC9AVA8D02
+##### AC9AVA8D02 {#ac9ava8d02}
 
 reflect on the ways that they and other artists respond to influences to inform choices they make in their own visual arts practice
 
@@ -75,9 +71,9 @@ reflect on the ways that they and other artists respond to influences to inform 
 *  reflecting on the work of others and their own explorations when developing an understanding of visual conventions and how they might be manipulated to communicate meaning in artworks; for example, learning about colour theory and applying this to develop compositions that explore harmonious or contrasting colour palettes
 *  building on their understanding of composition to explore multiple ways to represent space and depth in an artwork; for example, experimenting with proportion and scale, positive and negative space in 3D work, or exploring the use of linear, aerial and atmospheric perspective, and reflecting on how they may apply this understanding to create the illusion of space
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AVA8C01
+##### AC9AVA8C01 {#ac9ava8c01}
 
 generate, document and develop ideas for artworks
 
@@ -89,7 +85,7 @@ generate, document and develop ideas for artworks
 *  recording and documenting their research into a subject or theme using their own images or images from other sources, written annotations and comments, or evaluations
 *  exploring ways that artists, designers, architects or craftspeople communicate ideas and meaning in their work, using written discussions, annotated images, debates or digital presentations
 
-##### AC9AVA8C02
+##### AC9AVA8C02 {#ac9ava8c02}
 
 select and manipulate visual conventions, visual arts processes and/or materials to create artworks that represent ideas, perspectives and/or meaning
 
@@ -102,9 +98,9 @@ select and manipulate visual conventions, visual arts processes and/or materials
 *  applying their knowledge and understanding of visual arts processes, materials and techniques to create artworks; for example, demonstrating understanding of relief printing and the technical skills needed to create an edition of prints, or creating artworks using skills developed in exploring digital tools, such as photographic manipulation applications or digital drawing programs
 *  representing ideas in their artworks through considered use of visual conventions, such as using modulated and directional lines in a composition to create a sense of movement, or breaking a rhythmic pattern to create discord
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AVA8P01
+##### AC9AVA8P01 {#ac9ava8p01}
 
 curate and present examples of their visual arts practice to accompany exhibits of their artworks to communicate ideas, perspectives and/or meaning to audiences
 
@@ -117,7 +113,7 @@ curate and present examples of their visual arts practice to accompany exhibits 
 *  describing the artistic vision of artists from different contexts, cultures, times and places, particularly referencing the meaning that their artworks convey
 *  using hex editors to explore information included in encrypted artworks and create their own encrypted information in their own artworks to communicate ideas, perspectives and/or meaning to audience
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8, students analyse how visual conventions, visual arts processes and materials are manipulated in artworks they create and/or experience. They evaluate the ways that visual artists across cultures, times, places and/or other contexts communicate ideas, perspectives and/or meaning through their visual arts practice. They describe respectful approaches to creating and/or responding to artworks.
 

--- a/curriculum/arts-visual-arts/years-9-and-10.md
+++ b/curriculum/arts-visual-arts/years-9-and-10.md
@@ -1,29 +1,25 @@
-# The Arts - Visual Arts - Years 9 and 10
+# Visual Arts - Years 9 and 10 {#visual-arts-years-9-and-10}
 
-## Level Description
+## Level Description {#level-description}
 
 In this band, learning in Visual Arts continues to build on each student’s prior learning and experiences as students develop their capability and confidence across the practices of Visual Arts. They continue to use visual conventions, visual arts processes and materials in purposeful and creative ways that are informed by their engagement with the work of living visual artists, visual arts practices and arts spaces in local, regional, national and global contexts such as countries or regions in Asia, including use of visual arts in multi-arts, trans-disciplinary or hybrid forms. This awareness of the diversity of visual arts practices, forms, styles and representations informs their own visual arts practice. They work collaboratively with peers and teachers.
 
 In this band, the focus is on students:
 
 1.  exploring and responding to
+    *   artworks and visual arts practices from across cultures, times, places and/or other contexts; for example, through exploration of works in physical or virtual spaces or engagement with artists
+    *   ways artworks created by First Nations Australians celebrate and challenge multiple perspectives of Australian identity
+2.  developing practices and skills
+    *   building and extending creative practices and skills for visual arts practice, developing ideas and intentions, creating representations, and developing skills and techniques in specific visual arts processes
+    *   building and extending critical practices by taking opportunities to reflect, evaluate or respond to their own work and the work of others; for example, considering how to apply knowledge of visual arts practices in their work
+3.  creating artworks to communicate ideas, perspectives and meaning in 2D, 3D and/or 4D (time-based forms) and/or multi-disciplinary forms to communicate ideas and intentions using visual arts practices and materials
+4.  presenting artworks and practices to audiences; for example, curating exhibits of their work, as individual artists or by working collaboratively. This can include designing and preparing a space or developing supporting material such as artist statements.
 
-*   artworks and visual arts practices from across cultures, times, places and/or other contexts; for example, through exploration of works in physical or virtual spaces or engagement with artists
-*   ways artworks created by First Nations Australians celebrate and challenge multiple perspectives of Australian identity
+## Strands {#strands}
 
-3.  developing practices and skills
+### Exploring and responding {#exploring-and-responding}
 
-*   building and extending creative practices and skills for visual arts practice, developing ideas and intentions, creating representations, and developing skills and techniques in specific visual arts processes
-*   building and extending critical practices by taking opportunities to reflect, evaluate or respond to their own work and the work of others; for example, considering how to apply knowledge of visual arts practices in their work
-
-5.  creating artworks to communicate ideas, perspectives and meaning in 2D, 3D and/or 4D (time-based forms) and/or multi-disciplinary forms to communicate ideas and intentions using visual arts practices and materials
-6.  presenting artworks and practices to audiences; for example, curating exhibits of their work, as individual artists or by working collaboratively. This can include designing and preparing a space or developing supporting material such as artist statements.
-
-## Strands
-
-### Exploring and responding
-
-##### AC9AVA10E01
+##### AC9AVA10E01 {#ac9ava10e01}
 
 investigate the ways that artists across cultures, times, places and/or other contexts develop personal expression in their visual arts practice to represent, communicate and/or challenge ideas, perspectives and/or meaning
 
@@ -35,7 +31,7 @@ investigate the ways that artists across cultures, times, places and/or other co
 *  selecting different critical viewpoints to develop explanations about artists’ approaches and works at different times and in different contexts
 *  exploring the development of a visual arts form over time, considering the impact of globalisation, cultural practices, and new discoveries in materials and technologies; for example, wood block printing or photography
 
-##### AC9AVA10E02
+##### AC9AVA10E02 {#ac9ava10e02}
 
 investigate the ways that First Nations Australian artists celebrate and challenge multiple perspectives of Australian identity through their artworks and visual arts practice
 
@@ -47,9 +43,9 @@ investigate the ways that First Nations Australian artists celebrate and challen
 *  understanding ways that the arts provide opportunities for First Nations Australian artists and designers to continue and develop their culture
 *  investigating how First Nations Australian visual artists are caring for Country/Place, culture and people through the visual arts; for example, by working with representatives of the First Nations Australian community to explore how local groups are caring for the local environment and highlighting these issues through visual arts projects, such as campaigns that focus on environmental issues
 
-### Developing practices and skills
+### Developing practices and skills {#developing-practices-and-skills}
 
-##### AC9AVA10D01
+##### AC9AVA10D01 {#ac9ava10d01}
 
 experiment with visual conventions, visual arts processes and materials to refine skills and develop personal expression
 
@@ -61,7 +57,7 @@ experiment with visual conventions, visual arts processes and materials to refin
 *  documenting and evaluating their investigations of visual art processes, visual conventions and materials in a diary, portfolio or digital journal; for example, annotating the processes used and using Viewpoints to develop questions to deepen their understanding of the concepts explored or processes used, such as "Have I pushed and explored this idea, medium or technique as far as I can?", "What is the problem, and how can I find multiple possible solutions?", "What happens when I …?”, “What did I learn from this …?”, “How can it inform my future art-making?"
 *  drawing lines, shapes and arrows drawn over photocopies of artworks and using a code to demonstrate their understanding of the way the artist has composed the artwork to communicate meaning; for example, using lines to trace over an artwork to show composition techniques, such as rule of thirds, creating movement using diagonal and or curved lines, repetition and pattern, or the use of visual hierarchy to indicate how the viewer’s eye follows the layout of a designed product
 
-##### AC9AVA10D02
+##### AC9AVA10D02 {#ac9ava10d02}
 
 reflect on the way they and other visual artists respond to influences to inspire, develop and resolve choices they make in their own visual arts practice
 
@@ -73,9 +69,9 @@ reflect on the way they and other visual artists respond to influences to inspir
 *  exploring current issues that are of importance to them, such as global or local issues, as a starting point for generating and reflecting on ideas for artworks that explore themes/concepts such as sustainable futures, wellbeing and emotional health, or human rights issues
 *  investigating the ways that artists use their visual arts practice to explore, examine, resolve or represent personal experiences and expressions as a starting point to understand how they can use their own visual arts practice to explore and respectfully/safely represent personal issues, such as self-awareness, emotional awareness and personal wellbeing
 
-### Creating and making
+### Creating and making {#creating-and-making}
 
-##### AC9AVA10C01
+##### AC9AVA10C01 {#ac9ava10c01}
 
 evaluate critical feedback when planning, developing and refining their visual arts practice
 
@@ -86,7 +82,7 @@ evaluate critical feedback when planning, developing and refining their visual a
 *  evaluating and responding to feedback on works in process from teachers and peers, in discussions or reviews, and documenting their decisions and responses in written, oral or multimedia, physical or digital journals/diaries
 *  collaborating with other students, groups or agencies, such as community groups, to generate ideas for artworks on design or artistic projects for curated exhibitions or events
 
-##### AC9AVA10C02
+##### AC9AVA10C02 {#ac9ava10c02}
 
 select and manipulate visual conventions, visual arts processes and/or materials to create artworks that reflect personal expression, and represent and/or challenge, ideas, perspectives and/or meaning
 
@@ -98,9 +94,9 @@ select and manipulate visual conventions, visual arts processes and/or materials
 *  creating their own artworks in response to a specific subject, theme or idea, using material, techniques and conventions in intentional, interpretative and personal ways
 *  applying their knowledge and understanding of visual arts processes and materials to create artworks; for example, demonstrating understanding of sculptural techniques, space and form to create a site-specific 3D work, or a range of painting techniques to create the illusion of texture and form in a landscape painting
 
-### Presenting and performing
+### Presenting and performing {#presenting-and-performing}
 
-##### AC9AVA10P01
+##### AC9AVA10P01 {#ac9ava10p01}
 
 evaluate art exhibits to inform the curation and exhibition of their own and/or others’ artworks and/or visual arts practice
 
@@ -113,7 +109,7 @@ evaluate art exhibits to inform the curation and exhibition of their own and
 *  developing responses to exhibitions of work; for example, in written/oral/multimedia explanations or reviews, digital forms of presentations or in verbal/vocal discussions
 *  constructing explanations of how artists, designers, architects or craftspeople communicate ideas and meaning in artworks, written discussions, annotated images, debates or digital presentations; evaluating options/preferences and using similar approaches when creating their own work, and creating an artist statement or curatorial statement
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In this band, learning in Visual Arts continues to build on each student’s prior learning and experiences as students develop their capability and confidence across the practices of Visual Arts. They continue to use visual conventions, visual arts processes and materials in purposeful and creative ways that are informed by their engagement with the work of living visual artists, visual arts practices and arts spaces in local, regional, national and global contexts such as countries or regions in Asia, including use of visual arts in multi-arts, trans-disciplinary or hybrid forms. This awareness of the diversity of visual arts practices, forms, styles and representations informs their own visual arts practice. They work collaboratively with peers and teachers.
 

--- a/curriculum/english/foundation-year.md
+++ b/curriculum/english/foundation-year.md
@@ -1,6 +1,6 @@
-# English - Foundation Year
+# English - Foundation Year {#english-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -12,13 +12,13 @@ Foundation students develop their reading in a text-rich environment through eng
 
 Foundation students create short imaginative and informative texts that may include pictorial representations, short statements, performances and short recounts, for a small range of purposes and audiences.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9EFLA01
+##### AC9EFLA01 {#ac9efla01}
 
 explore how language is used differently at home and school depending on the relationships between people
 
@@ -26,7 +26,7 @@ explore how language is used differently at home and school depending on the rel
 *  asking relevant questions, and expressing requests and opinions in ways that suit the contexts
 *  learning to use language according to the relationship between people; for example, between a parent and a child, a teacher and a student, siblings or friends, shopkeepers and customers
 
-##### AC9EFLA02
+##### AC9EFLA02 {#ac9efla02}
 
 explore different ways of using language to express preferences, likes and dislikes
 
@@ -34,9 +34,9 @@ explore different ways of using language to express preferences, likes and disli
 *  recognising how feelings and preferences might be communicated in speech and gesture
 *  recognising the ways emotions and feelings can be conveyed in visual and media texts; for example, in advertising and animations
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9EFLA03
+##### AC9EFLA03 {#ac9efla03}
 
 understand that texts can take many forms such as signs, books and digital texts
 
@@ -46,7 +46,7 @@ understand that texts can take many forms such as signs, books and digital texts
 *  identifying different forms of texts in school, home and community settings; for example, crossing signs, hand washing signs, directions and product labels
 *  understanding that many First Nations Australians’ stories are oral narrations and cultural accounts, and may be represented as or with images
 
-##### AC9EFLA04
+##### AC9EFLA04 {#ac9efla04}
 
 understand conventions of print and screen, including how books and simple digital texts are usually organised
 
@@ -56,9 +56,9 @@ understand conventions of print and screen, including how books and simple digit
 *  discussing the placement of images and words in text
 *  indicating the title of a book and where to start reading
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9EFLA05
+##### AC9EFLA05 {#ac9efla05}
 
 recognise that sentences are key units for expressing ideas
 
@@ -66,14 +66,14 @@ recognise that sentences are key units for expressing ideas
 *  learning that word order in sentences is important for meaning; for example, “The boy sat on the dog.” “The dog sat on the boy.”
 *  recognising the difference between a sentence fragment and a sentence; for example, “after school”, “Dad will pick me up after school.”
 
-##### AC9EFLA06
+##### AC9EFLA06 {#ac9efla06}
 
 recognise that sentences are made up of groups of words that work together in particular ways to make meaning
 
 **Elaborations**
 *  learning how words in a sentence relate to one another; for example, connecting a cat (noun) to ate (verb), or black (adjective) to a cat (noun)
 
-##### AC9EFLA07
+##### AC9EFLA07 {#ac9efla07}
 
 explore the contribution of images and words to meaning in stories and informative texts
 
@@ -81,7 +81,7 @@ explore the contribution of images and words to meaning in stories and informati
 *  recognising that texts can be interpreted differently when only the words or only the images are read or viewed
 *  identifying where written text is reflected in accompanying images and where written text is not captured in images
 
-##### AC9EFLA08
+##### AC9EFLA08 {#ac9efla08}
 
 recognise and develop awareness of vocabulary used in familiar contexts related to everyday experiences, personal interests and topics taught at school
 
@@ -90,18 +90,18 @@ recognise and develop awareness of vocabulary used in familiar contexts related 
 *  identifying words for a topic studied at school; for example, words relevant to the topic of families
 *  expanding vocabulary through informal interactions and planned experiences with adults and peers, texts, images, and artefacts or objects
 
-##### AC9EFLA09
+##### AC9EFLA09 {#ac9efla09}
 
 identify punctuation as a feature of written text different from letters; recognise that capital letters are used for names, and that capital letters also signal the beginning of sentences while punctuation marks signal the end
 
 **Elaborations**
 *  commenting on capital letters encountered in everyday texts; for example, “That’s the letter that starts my name.” “The name of my family and my town have capital letters.”
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9EFLE01
+##### AC9EFLE01 {#ac9efle01}
 
 share ideas about stories, poems and images in literature, reflecting on experiences that are similar or different to their own by engaging with texts by First Nations Australian, and wide-ranging Australian and world authors and illustrators
 
@@ -112,9 +112,9 @@ share ideas about stories, poems and images in literature, reflecting on experie
 *  engaging with texts that portray Australian family life in different settings across Australia; for example, suburban and remote settings
 *  identifying some features of culture that are revealed by characters and events in stories; for example, dress, food and daily routines
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9EFLE02
+##### AC9EFLE02 {#ac9efle02}
 
 respond to stories and share feelings and thoughts about their events and characters
 
@@ -122,9 +122,9 @@ respond to stories and share feelings and thoughts about their events and charac
 *  using drawing and beginning forms of writing to express personal responses to stories, poems or films
 *  discussing events and characters in texts, and connecting them to their own experiences
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9EFLE03
+##### AC9EFLE03 {#ac9efle03}
 
 recognise different types of literary texts and identify features including events, characters, and beginnings and endings
 
@@ -134,7 +134,7 @@ recognise different types of literary texts and identify features including even
 *  identifying how stories are told in poetry
 *  identifying typical features of fairytales such as princes and princesses or the moral of the story
 
-##### AC9EFLE04
+##### AC9EFLE04 {#ac9efle04}
 
 explore and replicate the rhythms and sound patterns of literary texts such as poems, rhymes and songs
 
@@ -143,9 +143,9 @@ explore and replicate the rhythms and sound patterns of literary texts such as p
 *  reciting rhymes with actions
 *  exploring rhythms used in poems by First Nations Australians
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9EFLE05
+##### AC9EFLE05 {#ac9efle05}
 
 retell and adapt familiar literary texts through play, performance, images or writing
 
@@ -153,11 +153,11 @@ retell and adapt familiar literary texts through play, performance, images or wr
 *  drawing and role-playing characters or events
 *  sequencing pictures, which may involve using digital tools, to retell a story
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9EFLY01
+##### AC9EFLY01 {#ac9efly01}
 
 identify some familiar texts, such as stories and informative texts, and their purpose
 
@@ -166,9 +166,9 @@ identify some familiar texts, such as stories and informative texts, and their p
 *  using book covers to group imaginative and informative texts
 *  grouping texts according to topic; for example, grouping a set of texts, which may include informative and imaginative texts, about farm animals
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9EFLY02
+##### AC9EFLY02 {#ac9efly02}
 
 interact in informal and structured situations by listening while others speak and using features of voice including volume levels
 
@@ -179,9 +179,9 @@ interact in informal and structured situations by listening while others speak a
 *  participating in informal interaction situations; for example, play-based experiences that involve the imaginative use of spoken language
 *  listening to and following instructions
 
-#### Analysing, interpreting and evaluating 
+#### Analysing, interpreting and evaluating  {#analysing-interpreting-and-evaluating}
 
-##### AC9EFLY03
+##### AC9EFLY03 {#ac9efly03}
 
 identify some differences between imaginative and informative texts
 
@@ -190,7 +190,7 @@ identify some differences between imaginative and informative texts
 *  identifying and selecting texts for information purposes and commenting on how the text might help with a task
 *  comparing images in imaginative texts with images in informative texts
 
-##### AC9EFLY04
+##### AC9EFLY04 {#ac9efly04}
 
 read decodable and authentic texts using developing phonic knowledge, and monitor meaning using context and emerging grammatical knowledge
 
@@ -199,7 +199,7 @@ read decodable and authentic texts using developing phonic knowledge, and monito
 *  attempting to work out unknown words by using phonic decoding and knowledge of high-frequency words
 *  pausing or asking for support when meaning breaks down
 
-##### AC9EFLY05
+##### AC9EFLY05 {#ac9efly05}
 
 use comprehension strategies such as visualising, predicting, connecting, summarising and questioning to understand and discuss texts listened to, viewed or read independently
 
@@ -210,9 +210,9 @@ use comprehension strategies such as visualising, predicting, connecting, summar
 *  retelling events from First Nations Australians’ stories and cultural accounts in sequence
 *  predicting what might happen in a text based on the title and cover
 
-#### Creating texts
+#### Creating texts {#creating-texts}
 
-##### AC9EFLY06
+##### AC9EFLY06 {#ac9efly06}
 
 create and participate in shared editing of short written texts to record and report ideas and events using some learnt vocabulary, basic sentence boundary punctuation and spelling some consonant–vowel–consonant words correctly
 
@@ -222,7 +222,7 @@ create and participate in shared editing of short written texts to record and re
 *  “reading” their own texts back to an experienced writer
 *  participating in shared editing by circling the capital letters at the beginning of sentences
 
-##### AC9EFLY07
+##### AC9EFLY07 {#ac9efly07}
 
 create and deliver short spoken texts to report ideas and events to peers, using features of voice such as appropriate volume
 
@@ -231,7 +231,7 @@ create and deliver short spoken texts to report ideas and events to peers, using
 *  sharing personal responses to ideas and events experienced through texts
 *  using visual prompts to practise staying on topic or to sequence ideas
 
-##### AC9EFLY08
+##### AC9EFLY08 {#ac9efly08}
 
 form most lower-case and upper-case letters using learnt letter formations
 
@@ -239,9 +239,9 @@ form most lower-case and upper-case letters using learnt letter formations
 *  following clear demonstrations of how to construct each letter; for example, where to start and in which direction to write
 *  developing a functional pencil grip/grasp
 
-#### Phonic and word knowledge
+#### Phonic and word knowledge {#phonic-and-word-knowledge}
 
-##### AC9EFLY09
+##### AC9EFLY09 {#ac9efly09}
 
 recognise and generate rhyming words, alliteration patterns, syllables and sounds (phonemes) in spoken words (phonological awareness)
 
@@ -250,7 +250,7 @@ recognise and generate rhyming words, alliteration patterns, syllables and sound
 *  identifying patterns of alliteration in spoken words; for example, “helpful Henry”
 *  identifying syllables in spoken words; for example, clapping the rhythm of “Mon-day”, “Ja-cob” or “Si-en-na”
 
-##### AC9EFLY10
+##### AC9EFLY10 {#ac9efly10}
 
 segment sentences into individual words; orally blend and segment single-syllable spoken words; isolate, blend and manipulate phonemes in single-syllable words (phonological awareness)
 
@@ -259,7 +259,7 @@ segment sentences into individual words; orally blend and segment single-syllabl
 *  saying the word when given the sounds; for example, “l-i-p” (“lip”) or “m-u-n-ch” (“munch”)
 *  saying the new word when the beginning phoneme/medial/end phoneme in a word is replaced with a different phoneme; for example, “run” becomes “fun”, or “fun” becomes “fan”
 
-##### AC9EFLY11
+##### AC9EFLY11 {#ac9efly11}
 
 recognise and name all upper- and lower-case letters (graphs) and know the most common sound that each letter represents
 
@@ -268,20 +268,20 @@ recognise and name all upper- and lower-case letters (graphs) and know the most 
 *  matching upper- and lower-case letters
 *  identifying sounds for upper- and lower-case letters
 
-##### AC9EFLY12
+##### AC9EFLY12 {#ac9efly12}
 
 write consonant–vowel–consonant (CVC) words by representing sounds with the appropriate letters, and blend sounds associated with letters when reading CVC words
 
 **Elaborations**
 
-##### AC9EFLY13
+##### AC9EFLY13 {#ac9efly13}
 
 use knowledge of letters and sounds to spell words
 
 **Elaborations**
 *  making plausible spelling choices using letter–sound correspondences and morphemic knowledge
 
-##### AC9EFLY14
+##### AC9EFLY14 {#ac9efly14}
 
 read and write some high-frequency words and other familiar words
 
@@ -289,14 +289,14 @@ read and write some high-frequency words and other familiar words
 *  knowing how to read and write some high-frequency words recognised in shared texts and texts being read independently; for example, “and”, “my”, “is”, “the” and “go”
 *  knowing how to read and write some familiar words; for example, their name, the name of a character or the name of their school
 
-##### AC9EFLY15
+##### AC9EFLY15 {#ac9efly15}
 
 understand that words are units of meaning and can be made of more than one meaningful part
 
 **Elaborations**
 *  learning that words are made up of meaningful parts; for example, “dogs” has 2 meaningful parts: “dog” and “s” meaning more than one
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Foundation, students listen to texts, interact with others and create short spoken texts, including retelling stories. They share thoughts and preferences, retell events and report information or key ideas to an audience. They use language features including words and phrases from learning and texts. They listen for and identify rhymes, letter patterns and sounds (phonemes) in words. They orally blend and segment phonemes in single-syllable words.
 

--- a/curriculum/english/year-1.md
+++ b/curriculum/english/year-1.md
@@ -1,6 +1,6 @@
-# English - Year 1
+# English - Year 1 {#english-year-1}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Teaching and learning programs should balance and integrate all 3 strands. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -14,13 +14,13 @@ Year 1 students develop their reading in a text-rich environment through engagem
 
 Year 1 students create short texts whose purposes may be imaginative, informative and persuasive. These texts may explain simple procedures, recount real or imagined events or experiences, report and describe learning area content, retell stories, express opinions, and describe real or imagined people, places or things for an audience.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9E1LA01
+##### AC9E1LA01 {#ac9e1la01}
 
 understand how language, facial expressions and gestures are used to interact with others when asking for and providing information, making offers, exclaiming, requesting and giving commands
 
@@ -30,7 +30,7 @@ understand how language, facial expressions and gestures are used to interact wi
 *  viewing short films and discussing how characters use words and body language to convey emotions
 *  learning the difference between closed questions; for example, “Are you ready?”, and open questions; for example, “What made this text so exciting?”
 
-##### AC9E1LA02
+##### AC9E1LA02 {#ac9e1la02}
 
 explore language to provide reasons for likes, dislikes and preferences
 
@@ -38,9 +38,9 @@ explore language to provide reasons for likes, dislikes and preferences
 *  using words including “because” to introduce reasons for likes, dislikes and preferences
 *  exploring comparative words (adjectives) to express the degree of preference; for example, “better”, “faster”
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9E1LA03
+##### AC9E1LA03 {#ac9e1la03}
 
 explore how texts are organised according to their purpose, such as to recount, narrate, express opinion, inform, report and explain
 
@@ -49,7 +49,7 @@ explore how texts are organised according to their purpose, such as to recount, 
 *  becoming familiar with the typical stages of types of texts; for example, recount and procedure
 *  recognising that the structure of a text may include words and pictures; for example, an informative text may include words, illustrations and diagrams
 
-##### AC9E1LA04
+##### AC9E1LA04 {#ac9e1la04}
 
 explore how repetition, rhyme and rhythm create cohesion in simple poems, chants and songs
 
@@ -57,16 +57,16 @@ explore how repetition, rhyme and rhythm create cohesion in simple poems, chants
 *  identifying patterns of repetition in texts; for example, repetition of sentence patterns such as “Have you seen …”
 *  discussing different poems and identifying rhyme; for example, end of line rhyme
 
-##### AC9E1LA05
+##### AC9E1LA05 {#ac9e1la05}
 
 understand how print and screen texts are organised using features such as page numbers, tables of content, headings and titles, navigation buttons, swipe screens, verbal commands, links and images
 
 **Elaborations**
 *  comparing the layout of print and digital texts; for example, the layout of print and images in an information book and the layout of information in an online text
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9E1LA06
+##### AC9E1LA06 {#ac9e1la06}
 
 understand that a simple sentence consists of a single independent clause representing a single event or idea
 
@@ -74,7 +74,7 @@ understand that a simple sentence consists of a single independent clause repres
 *  knowing that a single event or idea can include a process, a happening or a state (verb), the participant or who or what is involved (noun group/phrase), and the surrounding circumstances (adverb group/phrase); for example, “Teddy (participant: who or what is involved) read (process: a happening) the book (participant: who or what is involved) in the library (circumstance: where he read).”
 *  understanding that simple sentences answer questions such as, “what is happening?” and “who or what is involved?” along with details such as “where?”, “when?”, “how?”
 
-##### AC9E1LA07
+##### AC9E1LA07 {#ac9e1la07}
 
 understand that words can represent people, places and things (nouns, including pronouns), happenings and states (verbs), qualities (adjectives) and details such as when, where and how (adverbs)
 
@@ -82,7 +82,7 @@ understand that words can represent people, places and things (nouns, including 
 *  understanding that words or groups of words can represent the participants (nouns; for example, people, places, things) that are involved in various activities or processes (verbs of doing, saying, thinking, being) and the details or circumstances surrounding the activity (adjectives and adverbs that answer “when?”, “where?”, “how?”)
 *  recognising how a sentence can be made more specific by adding adjectives, adverbs and precise verbs
 
-##### AC9E1LA08
+##### AC9E1LA08 {#ac9e1la08}
 
 compare how images in different types of texts contribute to meaning
 
@@ -92,7 +92,7 @@ compare how images in different types of texts contribute to meaning
 *  understanding that some images convey meaning that is not included in the accompanying written text; for example, a diagram shows information about how parts of a plant are connected, which is not explained in the print text
 *  exploring images in stories and cultural accounts by First Nations Australian authors and discussing the impact this may have
 
-##### AC9E1LA09
+##### AC9E1LA09 {#ac9e1la09}
 
 recognise the vocabulary of learning area topics
 
@@ -101,7 +101,7 @@ recognise the vocabulary of learning area topics
 *  using appropriate vocabulary for an Acknowledgement of Country at assemblies and other school events using protocols to recognise the Traditional Owners of Country or Place
 *  identifying words for topics studied at school; for example, vocabulary used for weather and seasons
 
-##### AC9E1LA10
+##### AC9E1LA10 {#ac9e1la10}
 
 understand that written language uses punctuation such as full stops, question marks and exclamation marks, and uses capital letters for familiar proper nouns
 
@@ -111,11 +111,11 @@ understand that written language uses punctuation such as full stops, question m
 *  writing different types of sentences; for example, statements and questions, and discussing appropriate punctuation
 *  identifying and using capital letters to name places and holidays
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9E1LE01
+##### AC9E1LE01 {#ac9e1le01}
 
 discuss how language and images are used to create characters, settings and events in literature by First Nations Australian, and wide-ranging Australian and world authors and illustrators
 
@@ -124,9 +124,9 @@ discuss how language and images are used to create characters, settings and even
 *  discussing how characters, settings and events are described or depicted in literature by First Nations Australian authors and illustrators
 *  discussing the events associated with Australian animal characters and what is learnt about their characters in picture books from wide-ranging Australian authors
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9E1LE02
+##### AC9E1LE02 {#ac9e1le02}
 
 discuss literary texts and share responses by making connections with students’ own experiences
 
@@ -136,9 +136,9 @@ discuss literary texts and share responses by making connections with students�
 *  expressing responses to characters and events in stories using drawing and role-play
 *  identifying who is telling the story in different texts
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9E1LE03
+##### AC9E1LE03 {#ac9e1le03}
 
 discuss plot, character and setting, which are features of stories
 
@@ -147,7 +147,7 @@ discuss plot, character and setting, which are features of stories
 *  discussing whether features of settings including time (year, season) and place (country or city) are realistic or imagined
 *  discussing how plots develop, including beginnings (orientation), how the problem (complication) is introduced and solved (resolution)
 
-##### AC9E1LE04
+##### AC9E1LE04 {#ac9e1le04}
 
 listen to and discuss poems, chants, rhymes and songs, and imitate and invent sound patterns including alliteration and rhyme
 
@@ -156,9 +156,9 @@ listen to and discuss poems, chants, rhymes and songs, and imitate and invent so
 *  exploring poetry, chants and songs from Asian cultures
 *  listening to haiku poems about familiar topics such as nature and the seasons
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9E1LE05
+##### AC9E1LE05 {#ac9e1le05}
 
 orally retell or adapt a familiar story using plot and characters, language features including vocabulary, and structure of a familiar text, through role-play, writing, drawing or digital tools
 
@@ -167,11 +167,11 @@ orally retell or adapt a familiar story using plot and characters, language feat
 *  imitating a characteristic piece of speech or dialogue, or the attitudes or expressions of favourite characters in texts
 *  retelling key events in stories using oral language, visual arts, digital tools or performance
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9E1LY01
+##### AC9E1LY01 {#ac9e1ly01}
 
 discuss different texts and identify some features that indicate their purposes
 
@@ -179,9 +179,9 @@ discuss different texts and identify some features that indicate their purposes
 *  discussing a range of texts encountered in school and in the community, and identifying their purpose
 *  recognising that types of texts with similar purposes usually have predictable structures
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9E1LY02
+##### AC9E1LY02 {#ac9e1ly02}
 
 use interaction skills including turn-taking, speaking clearly, using active listening behaviours and responding to the contributions of others, and contributing ideas and questions
 
@@ -192,9 +192,9 @@ use interaction skills including turn-taking, speaking clearly, using active lis
 *  interacting appropriately with peers, teachers and visitors
 *  formulating different types of questions to ask a speaker, such as open and closed questions and “when”, “why” and “how” questions
 
-#### Analysing, interpreting and evaluating 
+#### Analysing, interpreting and evaluating  {#analysing-interpreting-and-evaluating}
 
-##### AC9E1LY03
+##### AC9E1LY03 {#ac9e1ly03}
 
 describe some similarities and differences between imaginative, informative and persuasive texts
 
@@ -202,7 +202,7 @@ describe some similarities and differences between imaginative, informative and 
 *  comparing and discussing texts, identifying some features that distinguish those that “tell stories” from those that “give opinions”
 *  selecting texts for a particular purpose or task; for example, a website that will give information about a learning area topic, a book that will tell a story about an animal
 
-##### AC9E1LY04
+##### AC9E1LY04 {#ac9e1ly04}
 
 read decodable and authentic texts using developing phonic knowledge, phrasing and fluency, and monitoring meaning using context and grammatical knowledge
 
@@ -210,7 +210,7 @@ read decodable and authentic texts using developing phonic knowledge, phrasing a
 *  recognising most high-frequency words when reading a text
 *  self-correcting or asking for assistance when meaning breaks down
 
-##### AC9E1LY05
+##### AC9E1LY05 {#ac9e1ly05}
 
 use comprehension strategies such as visualising, predicting, connecting, summarising and questioning when listening, viewing and reading to build literal and inferred meaning by drawing on vocabulary and growing knowledge of context and text structures
 
@@ -221,9 +221,9 @@ use comprehension strategies such as visualising, predicting, connecting, summar
 *  drawing inferences and explaining inferences using clues from the text
 *  making connections with existing knowledge and personal experiences
 
-#### Creating texts
+#### Creating texts {#creating-texts}
 
-##### AC9E1LY06
+##### AC9E1LY06 {#ac9e1ly06}
 
 create and re-read to edit short written and/or multimodal texts to report on a topic, express an opinion or recount a real or imagined event, using grammatically correct simple sentences, some topic-specific vocabulary, sentence boundary punctuation and correct spelling of some one- and two-syllable words
 
@@ -235,7 +235,7 @@ create and re-read to edit short written and/or multimodal texts to report on a 
 *  beginning to use dictionaries and resources to check and correct spelling
 *  identifying words that might not be spelt correctly
 
-##### AC9E1LY07
+##### AC9E1LY07 {#ac9e1ly07}
 
 create and deliver short oral and/or multimodal presentations on personal and learnt topics, which include an opening, middle and concluding statement; some topic-specific vocabulary and appropriate gesture, volume and pace
 
@@ -246,23 +246,23 @@ create and deliver short oral and/or multimodal presentations on personal and le
 *  experimenting with volume and pace for particular purposes; for example, presenting information, retelling stories, and reciting rhymes and poems
 *  giving reasons why the class should learn a particular game
 
-##### AC9E1LY08
+##### AC9E1LY08 {#ac9e1ly08}
 
 write words using unjoined lower-case and upper-case letters
 
 **Elaborations**
 *  continuing to develop a functional pencil grip/grasp
 
-#### Phonic and word knowledge
+#### Phonic and word knowledge {#phonic-and-word-knowledge}
 
-##### AC9E1LY09
+##### AC9E1LY09 {#ac9e1ly09}
 
 segment words into separate phonemes (sounds) including consonant blends or clusters at the beginnings and ends of words (phonological awareness)
 
 **Elaborations**
 *  saying sounds in order for a given spoken word; for example, “s-p-oo-n” and “f-i-s-t”
 
-##### AC9E1LY10
+##### AC9E1LY10 {#ac9e1ly10}
 
 orally manipulate phonemes in spoken words by addition, deletion and substitution of initial, medial and final phonemes to generate new words (phonological awareness)
 
@@ -271,7 +271,7 @@ orally manipulate phonemes in spoken words by addition, deletion and substitutio
 *  substituting medial sounds in spoken words to make new words; for example, “pin”, “pen”, “pan”
 *  substituting final sounds in spoken words; for example, substitute the “t” in “pet” with “g” to form a new word “peg”
 
-##### AC9E1LY11
+##### AC9E1LY11 {#ac9e1ly11}
 
 use short vowels, common long vowels, consonant blends and digraphs to write words, and blend these to read one- and two-syllable words
 
@@ -279,7 +279,7 @@ use short vowels, common long vowels, consonant blends and digraphs to write wor
 *  using knowledge of letters and sounds to write words with short vowels; for example, “man”, and common long vowel sounds; for example, “time”
 *  using knowledge of letter sounds to write single-syllable words with consonant digraphs and consonant blends; for example, “wish” and “rest”
 
-##### AC9E1LY12
+##### AC9E1LY12 {#ac9e1ly12}
 
 understand that a letter can represent more than one sound and that a syllable must contain a vowel sound
 
@@ -287,21 +287,21 @@ understand that a letter can represent more than one sound and that a syllable m
 *  recognising that letters can have more than one sound; for example, the letter “u” in “cut”, “put”, “use” and the letter “a” in “cat”, “father”, “any”
 *  recognising sounds that can be produced by different letters; for example, the “s” sound in “sat” and “cent”
 
-##### AC9E1LY13
+##### AC9E1LY13 {#ac9e1ly13}
 
 spell one- and two-syllable words with common letter patterns
 
 **Elaborations**
 *  writing one- and two-syllable words containing known blends; for example, “bl” and “st”
 
-##### AC9E1LY14
+##### AC9E1LY14 {#ac9e1ly14}
 
 read and write an increasing number of high-frequency words
 
 **Elaborations**
 *  learning an increasing number of high-frequency words and reading them independently; for example, “one”, “have” and “pretty”
 
-##### AC9E1LY15
+##### AC9E1LY15 {#ac9e1ly15}
 
 recognise and know how to use grammatical morphemes to create word families
 
@@ -309,7 +309,7 @@ recognise and know how to use grammatical morphemes to create word families
 *  building word families from common morphemes; for example, “play”, “plays”, “playing”, “played”, “playground”
 *  using morphemes to read words; for example, by recognising the base word in words such as “walk-ed”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 1, students interact with others, and listen to and create short spoken texts including recounts of stories. They share ideas and retell or adapt familiar stories, recount or report on events or experiences, and express opinions using a small number of details from learnt topics, topics of interest or texts. They sequence ideas and use language features including topic-specific vocabulary and features of voice.
 

--- a/curriculum/english/year-10.md
+++ b/curriculum/english/year-10.md
@@ -1,6 +1,6 @@
-# English - Year 10
+# English - Year 10 {#english-year-10}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Teaching and learning programs should balance and integrate all 3 strands. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -14,13 +14,13 @@ Literary texts that support and extend students in Year 10 as independent reader
 
 Year 10 students create a range of texts whose purposes may be aesthetic, imaginative, reflective, informative, persuasive, analytical and/or critical; for example, narratives, arguments that include analytical expositions and discussions, analysis and responses that include personal reflections, reviews and critical responses for a range of audiences.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9E10LA01
+##### AC9E10LA01 {#ac9e10la01}
 
 understand how language can have inclusive and exclusive social effects, and can empower or disempower people
 
@@ -31,7 +31,7 @@ understand how language can have inclusive and exclusive social effects, and can
 *  identifying language that appeals to shared cultural knowledge, values and beliefs
 *  identifying examples of language that are inclusive or marginalising
 
-##### AC9E10LA02
+##### AC9E10LA02 {#ac9e10la02}
 
 understand that language used to evaluate, implicitly or explicitly reveals an individual's values
 
@@ -39,9 +39,9 @@ understand that language used to evaluate, implicitly or explicitly reveals an i
 *  identifying explicit expressions of values when evaluating
 *  identifying subtle or implied values communicated through language; for example, using a term such as “teenager” to refer to an individual rather than using a specific name
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9E10LA03
+##### AC9E10LA03 {#ac9e10la03}
 
 analyse text structures and language features and evaluate their effectiveness in achieving their purpose
 
@@ -50,7 +50,7 @@ analyse text structures and language features and evaluate their effectiveness i
 *  analysing the text structures and language features of reviews from different sources, and evaluating their effectiveness
 *  analysing and experimenting with combinations of graphics, text and sound in the production of multimodal texts such as documentaries, media reports, online magazines and digital books to influence audience responses
 
-##### AC9E10LA04
+##### AC9E10LA04 {#ac9e10la04}
 
 understand how paragraph structure can be varied to create cohesion, and paragraphs and images can be integrated for different purposes
 
@@ -59,9 +59,9 @@ understand how paragraph structure can be varied to create cohesion, and paragra
 *  examining the integration of paragraphs and images on websites for effect
 *  evaluating the effect of the integration of paragraphs and images in graphic novels
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9E10LA05
+##### AC9E10LA05 {#ac9e10la05}
 
 analyse and evaluate the effectiveness of particular sentence structures to express and craft ideas
 
@@ -70,7 +70,7 @@ analyse and evaluate the effectiveness of particular sentence structures to expr
 *  recognising how authors sometimes use verbless clauses for effect; for example, “And what about the other woman? With her dark glasses and briefcase.”
 *  recognising that a sentence can begin with a coordinating conjunction for stylistic effect; for example, “And she went on planning how she would manage it.”
 
-##### AC9E10LA06
+##### AC9E10LA06 {#ac9e10la06}
 
 analyse how meaning and style are achieved through syntax
 
@@ -79,21 +79,21 @@ analyse how meaning and style are achieved through syntax
 *  analysing how logical relations between ideas are built up by combining independent with dependent clauses indicating cause, result, manner, concession, condition, and so on; for example, “Although the poet was not generally well received by critics during her life (concession), her reputation grew substantially after her death.”
 *  considering how abstraction in a noun group allows for greater generalisation of complex ideas in a sentence; for example, “He focused on the political, religious, social and economic elements of the society in his thesis.”
 
-##### AC9E10LA07
+##### AC9E10LA07 {#ac9e10la07}
 
 evaluate the features of still and moving images, and the effects of those choices on representations
 
 **Elaborations**
 *  examining features of visual texts that create nuance in representations; for example, analysing the use of light and dark, and evaluating the impact of light and dark on representing duplicity
 
-##### AC9E10LA08
+##### AC9E10LA08 {#ac9e10la08}
 
 use an expanded technical and academic vocabulary for precision when writing academic texts
 
 **Elaborations**
 *  identifying the meaning of an increasing range of technical vocabulary; for example, using specific terms about rhythm such as “iambic pentameter” when analysing poetry
 
-##### AC9E10LA09
+##### AC9E10LA09 {#ac9e10la09}
 
 understand how authors use and experiment with punctuation
 
@@ -102,11 +102,11 @@ understand how authors use and experiment with punctuation
 *  examining an author’s use of ellipses to create tentativeness in a character’s speech
 *  reviewing the use of punctuation to represent emotions; for example, the use of multiple exclamation marks or punctuation emojis
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9E10LE01
+##### AC9E10LE01 {#ac9e10le01}
 
 analyse representations of individuals, groups and places and evaluate how they reflect their context in literary texts by First Nations Australian, and wide-ranging Australian and world authors
 
@@ -115,9 +115,9 @@ analyse representations of individuals, groups and places and evaluate how they 
 *  analysing how stories written by First Nations Australian authors contemporise or modernise traditional stories and evaluating the responses of contemporary audiences
 *  analysing how humour is used to represent the underdog in Australian texts and evaluating how the underdog reflects the context
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9E10LE02
+##### AC9E10LE02 {#ac9e10le02}
 
 reflect on and extend others’ interpretations of and responses to literature
 
@@ -126,23 +126,23 @@ reflect on and extend others’ interpretations of and responses to literature
 *  presenting arguments based on close textual analysis to support an interpretation of a text; for example, writing an essay or creating a set of director’s notes
 *  creating personal reading lists in a variety of genres and explaining why texts qualify for inclusion on a particular list
 
-##### AC9E10LE03
+##### AC9E10LE03 {#ac9e10le03}
 
 analyse how the aesthetic qualities associated with text structures, language features, literary devices and visual features, and the context in which these texts are experienced, influence audience response
 
 **Elaborations**
 *  examining a range of texts and evaluating the effect of text structures and language features; for example, determining whether the narrative position of a child evokes reader sympathy towards an event or issue
 
-##### AC9E10LE04
+##### AC9E10LE04 {#ac9e10le04}
 
 evaluate the social, moral or ethical positions represented in literature
 
 **Elaborations**
 *  identifying and analysing ethical positions on a significant issue, including values and/or principles involved, and evaluating the strengths and weaknesses of the position presented
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9E10LE05
+##### AC9E10LE05 {#ac9e10le05}
 
 analyse how text structure, language features, literary devices and intertextual connections shape interpretations of texts
 
@@ -150,14 +150,14 @@ analyse how text structure, language features, literary devices and intertextual
 *  examining a range of short poems, a short story, or extracts from a novel or film to find and discuss examples of how language devices layer meaning and influence the responses of listeners, viewers or readers
 *  examining satirical representations of events or ideas and determining how satire shapes interpretations and responses
 
-##### AC9E10LE06
+##### AC9E10LE06 {#ac9e10le06}
 
 compare and evaluate how “voice” as a literary device is used in different types of texts, such as poetry, novels and film, to evoke emotional responses
 
 **Elaborations**
 *  comparing the “voice” of protest in a range of poems or songs and evaluating how different voices evoke a response
 
-##### AC9E10LE07
+##### AC9E10LE07 {#ac9e10le07}
 
 analyse and evaluate the aesthetic qualities of texts
 
@@ -165,9 +165,9 @@ analyse and evaluate the aesthetic qualities of texts
 *  using terms associated with literary text analysis; for example, “stanza”, “figurative language”, “symbolism” and “soundtrack”, when evaluating aspects that are valued and that contain aesthetic qualities
 *  analysing and evaluating the use of literary devices; for example, commenting on the effect of symbolism in a text
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9E10LE08
+##### AC9E10LE08 {#ac9e10le08}
 
 create and edit literary texts with a sustained “voice”, selecting and adapting text structures, literary devices, and language, auditory and visual features for purposes and audiences
 
@@ -177,11 +177,11 @@ create and edit literary texts with a sustained “voice”, selecting and adapt
 *  creating and editing a suite of short texts that focus on a key idea expressed in different voices
 *  describing choices of text structures, literary devices, language, auditory or visual features made in a literary text and reflecting on the effect of those choices
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9E10LY01
+##### AC9E10LY01 {#ac9e10ly01}
 
 analyse and evaluate how people, places, events and concepts are represented in texts and reflect contexts
 
@@ -189,25 +189,25 @@ analyse and evaluate how people, places, events and concepts are represented in 
 *  evaluating stereotypes of people, places, events and concepts, and expressing opinions on these representations in the contexts for which they are created
 *  analysing representations of events and issues in First Nations Australian media
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9E10LY02
+##### AC9E10LY02 {#ac9e10ly02}
 
 listen to spoken texts and explain the purposes and effects of text structures and language features, and use interaction skills to discuss and present an opinion about these texts
 
 **Elaborations**
 *  analysing spoken and multimodal features of media texts and discussing the effects of these features; for example, presenting an opinion on the combination of words and sound in creating mood
 
-#### Analysing, interpreting and evaluating 
+#### Analysing, interpreting and evaluating  {#analysing-interpreting-and-evaluating}
 
-##### AC9E10LY03
+##### AC9E10LY03 {#ac9e10ly03}
 
 analyse and evaluate how language features are used to implicitly or explicitly represent values, beliefs and attitudes
 
 **Elaborations**
 *  analysing social or political cartoons to identify the implicit and explicit values, beliefs and attitudes expressed
 
-##### AC9E10LY04
+##### AC9E10LY04 {#ac9e10ly04}
 
 analyse and evaluate how authors organise ideas in texts to achieve a purpose
 
@@ -216,7 +216,7 @@ analyse and evaluate how authors organise ideas in texts to achieve a purpose
 *  evaluating how ideas in an online review are organised and its success in achieving its purpose
 *  comparing the organisation of ideas in political pamphlets and determining the impact of each
 
-##### AC9E10LY05
+##### AC9E10LY05 {#ac9e10ly05}
 
 integrate comprehension strategies such as visualising, predicting, connecting, summarising, monitoring, questioning and inferring to analyse and interpret complex and abstract ideas
 
@@ -225,9 +225,9 @@ integrate comprehension strategies such as visualising, predicting, connecting, 
 *  interpreting how visual features represent abstract concepts in advertising, such as the representation of parenthood in advertisements
 *  summarising the qualities and interpreting the role of a character archetype in a range of texts and analysing the importance of this archetype
 
-#### Creating texts
+#### Creating texts {#creating-texts}
 
-##### AC9E10LY06
+##### AC9E10LY06 {#ac9e10ly06}
 
 plan, create, edit and publish written and multimodal texts, organising, expanding and developing ideas through experimenting with text structures, language features, literary devices and multimodal features for specific purposes and audiences in ways that may be imaginative, reflective, informative, persuasive, analytical and/or critical
 
@@ -238,7 +238,7 @@ plan, create, edit and publish written and multimodal texts, organising, expandi
 *  reviewing, editing and refining their own and others’ texts for accuracy of grammar, spelling and punctuation, and to achieve particular purposes and address specific audiences through control and organisation of content, sentence structures, vocabulary choices and visual features
 *  reflecting on the effect of choices made in a written or multimodal text and how these choices may be changed or developed in future texts
 
-##### AC9E10LY07
+##### AC9E10LY07 {#ac9e10ly07}
 
 plan, create, rehearse and deliver spoken and multimodal presentations by experimenting with rhetorical devices, and the organisation and development of ideas, to engage audiences for different purposes in ways that may be imaginative, reflective, informative, persuasive, analytical and/or critical
 
@@ -247,15 +247,15 @@ plan, create, rehearse and deliver spoken and multimodal presentations by experi
 *  creating spoken multimodal texts that manipulate rhetorical devices to compel listeners to act
 *  discussing and negotiating with peers in debates and panel discussions about issues related to a text
 
-#### Word knowledge
+#### Word knowledge {#word-knowledge}
 
-##### AC9E10LY08
+##### AC9E10LY08 {#ac9e10ly08}
 
 use knowledge of the spelling system to spell words and to manipulate standard spelling for particular effects
 
 **Elaborations**
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 10, students interact with others, and listen to and create spoken and multimodal texts including literary texts. With a range of purposes and for audiences, they discuss ideas and responses to representations, making connections and providing substantiation. They select and experiment with text structures to organise and develop ideas. They select, vary and experiment with language features including rhetorical and literary devices, and experiment with multimodal features and features of voice.
 

--- a/curriculum/english/year-2.md
+++ b/curriculum/english/year-2.md
@@ -1,6 +1,6 @@
-# English - Year 2
+# English - Year 2 {#english-year-2}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Teaching and learning programs should balance and integrate all 3 strands. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -14,13 +14,13 @@ The range of literary texts for Foundation to Year 10 comprises the oral narrati
 
 Year 2 students create texts whose purposes may be imaginative, informative and persuasive. Texts created may include recounts of stories and experiences, reports and explanations of learning area content, explanations of simple processes, and expressions of opinions about texts or experiences, including supporting reasons. These texts are created for an audience.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9E2LA01
+##### AC9E2LA01 {#ac9e2la01}
 
 investigate how interpersonal language choices vary depending on the context, including the different roles taken on in interactions
 
@@ -29,7 +29,7 @@ investigate how interpersonal language choices vary depending on the context, in
 *  exploring First Nations Australian cultural protocols in Welcome to Country and Acknowledgement of Country, and the greeting words used by local First Nations Australians
 *  exploring how familiarity with a group or individual influences language choices
 
-##### AC9E2LA02
+##### AC9E2LA02 {#ac9e2la02}
 
 explore how language can be used for appreciating texts and providing reasons for preferences
 
@@ -38,9 +38,9 @@ explore how language can be used for appreciating texts and providing reasons fo
 *  exploring verbs used to express degree of preference; for example, “liked”, “preferred”, “enjoyed”
 *  identifying First Nations Australian language words specific to Country/Place that help the reader to be specific when appreciating the setting in a text
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9E2LA03
+##### AC9E2LA03 {#ac9e2la03}
 
 identify how texts across the curriculum are organised differently and use language features depending on purposes
 
@@ -49,7 +49,7 @@ identify how texts across the curriculum are organised differently and use langu
 *  identifying that different types of texts might have different forms; for example, an expression of opinion might be in the form of a poster, email or brochure
 *  identifying the organisation and language features in texts such as narratives, recounts, information reports, simple procedures, expression of opinion and responses to texts (including poetry), and discuss their purposes
 
-##### AC9E2LA04
+##### AC9E2LA04 {#ac9e2la04}
 
 understand how texts are made cohesive by using personal and possessive pronouns and by omitting words that can be inferred
 
@@ -60,7 +60,7 @@ understand how texts are made cohesive by using personal and possessive pronouns
 *  identifying words left out that can be inferred from the surrounding text; for example, “Xanthe went to school. She had a lovely day.” (at school is inferred)
 *  using personal and possessive pronouns to link entities previously mentioned in the text
 
-##### AC9E2LA05
+##### AC9E2LA05 {#ac9e2la05}
 
 navigate print and screen texts using chapters, tables of contents, indexes, side-bar menus, drop-down menus or links
 
@@ -68,16 +68,16 @@ navigate print and screen texts using chapters, tables of contents, indexes, sid
 *  recognising how numbered chapters, organisation of tables of content and alphabetical order of indexes operate to support access to information
 *  exploring how the navigation tools of different websites can be used to locate information
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9E2LA06
+##### AC9E2LA06 {#ac9e2la06}
 
 understand that connections can be made between ideas by using a compound sentence with 2 or more independent clauses usually linked by a coordinating conjunction
 
 **Elaborations**
 *  using coordinating conjunctions; for example, “and”, “but”, “so” to construct compound sentences; for example, “The wolf huffed / and he puffed / and he blew the house down!”
 
-##### AC9E2LA07
+##### AC9E2LA07 {#ac9e2la07}
 
 understand that in sentences nouns may be extended into noun groups using articles and adjectives, and verbs may be expressed as verb groups
 
@@ -87,7 +87,7 @@ understand that in sentences nouns may be extended into noun groups using articl
 *  building extended verb groups using verbs; for example, “was touched”
 *  investigating how noun groups can be built up by asking questions about the noun such as “how many?”, “what’s it like?”, “what type?”; for example, “two pairs of old walking shoes”
 
-##### AC9E2LA08
+##### AC9E2LA08 {#ac9e2la08}
 
 understand that images add to or multiply the meanings of a text
 
@@ -95,7 +95,7 @@ understand that images add to or multiply the meanings of a text
 *  identifying images and graphics in a text that add ideas or information not included in the written text; for example, a map or table in a factual text or an illustration in a story, which gives clues about the setting
 *  identifying visual representations of characters’ actions, reactions, speech and thought processes in narratives, and considering how these images add to or multiply the meaning of accompanying words
 
-##### AC9E2LA09
+##### AC9E2LA09 {#ac9e2la09}
 
 experiment with and begin to make conscious choices of vocabulary to suit the topic
 
@@ -105,7 +105,7 @@ experiment with and begin to make conscious choices of vocabulary to suit the to
 *  exploring language used to describe characters in narratives, including nouns; for example, “magician”, “wizard”, “sorcerer”, and adjectives such as “gentle”, “timid” or “frightened”
 *  identifying words from First Nations Australians’ languages relevant to a topic
 
-##### AC9E2LA10
+##### AC9E2LA10 {#ac9e2la10}
 
 recognise that capital letters are used in titles and commas are used to separate items in lists
 
@@ -113,11 +113,11 @@ recognise that capital letters are used in titles and commas are used to separat
 *  identifying how capital letters are used in the titles of texts
 *  identifying commas used in lists in a variety of types of texts; for example, “This class has students who speak Vietnamese, Thai and Arabic at home.”
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9E2LE01
+##### AC9E2LE01 {#ac9e2le01}
 
 discuss how characters and settings are connected in literature created by First Nations Australian, and wide-ranging Australian and world authors and illustrators
 
@@ -126,9 +126,9 @@ discuss how characters and settings are connected in literature created by First
 *  recognising recurring characters in particular settings in texts by First Nations Australian authors
 *  exploring the way wide-ranging Australian authors and illustrators depict the Australian outback and the associated characters
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9E2LE02
+##### AC9E2LE02 {#ac9e2le02}
 
 identify features of literary texts, such as characters and settings, and give reasons for personal preferences
 
@@ -136,9 +136,9 @@ identify features of literary texts, such as characters and settings, and give r
 *  discussing preferences for stories set in familiar or unfamiliar worlds, or about characters whose lives are like or unlike their own
 *  discussing their feelings about the positive and negative behaviours of non-human characters, such as animals
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9E2LE03
+##### AC9E2LE03 {#ac9e2le03}
 
 discuss the characters and settings of a range of texts and identify how language is used to present these features in different ways
 
@@ -147,16 +147,16 @@ discuss the characters and settings of a range of texts and identify how languag
 *  identifying and comparing verb groups used to convey actions, emotions and dialogue in a range of literary texts
 *  identifying the language used to describe the landscape in First Nations Australians’ stories
 
-##### AC9E2LE04
+##### AC9E2LE04 {#ac9e2le04}
 
 identify, reproduce and experiment with rhythmic sound and word patterns in poems, chants, rhymes or songs
 
 **Elaborations**
 *  exploring poems, chants, rhymes or songs from different home languages of class members
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9E2LE05
+##### AC9E2LE05 {#ac9e2le05}
 
 create and edit literary texts by adapting structures and language features of familiar literary texts through drawing, writing, performance and digital tools
 
@@ -164,11 +164,11 @@ create and edit literary texts by adapting structures and language features of f
 *  inventing some speech, dialogue or behaviour for a favourite character, which may include the use of video and audio tools, for an alternative event or outcome in the original text
 *  reviewing and developing sentences; for example, adding prepositional phrases such as “with a long tail” to improve descriptions
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9E2LY01
+##### AC9E2LY01 {#ac9e2ly01}
 
 identify how similar topics and information are presented in different types of texts
 
@@ -176,9 +176,9 @@ identify how similar topics and information are presented in different types of 
 *  reading a poem, narrative and informative text about lifecycles and discussing what is learnt
 *  exploring recipes presented on food packets, in recipe books, in short video clips and in a digital form, noting their shared purpose
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9E2LY02
+##### AC9E2LY02 {#ac9e2ly02}
 
 use interaction skills when engaging with topics, actively listening to others, receiving instructions and extending own ideas, speaking appropriately, expressing and responding to opinions, making statements, and giving instructions
 
@@ -188,9 +188,9 @@ use interaction skills when engaging with topics, actively listening to others, 
 *  asking relevant questions and making connections with personal experiences and the contributions of others
 *  understanding how to disagree or respectfully offer an alternative
 
-#### Analysing, interpreting and evaluating 
+#### Analysing, interpreting and evaluating  {#analysing-interpreting-and-evaluating}
 
-##### AC9E2LY03
+##### AC9E2LY03 {#ac9e2ly03}
 
 identify the purpose and audience of imaginative, informative and persuasive texts
 
@@ -198,7 +198,7 @@ identify the purpose and audience of imaginative, informative and persuasive tex
 *  identifying the purpose of texts written by First Nations Australian authors
 *  identifying the audience of advertisements and signs
 
-##### AC9E2LY04
+##### AC9E2LY04 {#ac9e2ly04}
 
 read texts with phrasing and fluency, using phonic and word knowledge, and monitoring meaning by re-reading and self-correcting
 
@@ -206,7 +206,7 @@ read texts with phrasing and fluency, using phonic and word knowledge, and monit
 *  using phonic (sound–letter) and morphemic knowledge, and knowledge of high-frequency words when decoding text
 *  monitoring own reading, self-correcting or reading back, re-reading when meaning does not make sense
 
-##### AC9E2LY05
+##### AC9E2LY05 {#ac9e2ly05}
 
 use comprehension strategies such as visualising, predicting, connecting, summarising, monitoring and questioning to build literal and inferred meaning
 
@@ -219,9 +219,9 @@ use comprehension strategies such as visualising, predicting, connecting, summar
 *  using prior knowledge to make and confirm predictions when reading a text
 *  using graphic organisers to represent the connections between characters, order of events or sequence of information
 
-#### Creating texts
+#### Creating texts {#creating-texts}
 
-##### AC9E2LY06
+##### AC9E2LY06 {#ac9e2ly06}
 
 create and edit short imaginative, informative and persuasive written and/or multimodal texts for familiar audiences, using text structure appropriate to purpose, simple and compound sentences, noun groups and verb groups, topic-specific vocabulary, simple punctuation and common 2-syllable words
 
@@ -233,7 +233,7 @@ create and edit short imaginative, informative and persuasive written and/or mul
 *  editing by adding, deleting or changing vocabulary to improve a text; for example, replacing an everyday noun with a topic-specific one
 *  reviewing sentences for grammatical accuracy; for example, use of pronouns
 
-##### AC9E2LY07
+##### AC9E2LY07 {#ac9e2ly07}
 
 create, rehearse and deliver short oral and/or multimodal presentations for familiar audiences and purposes, using text structure appropriate to purpose and topic-specific vocabulary, and varying tone, volume and pace
 
@@ -242,16 +242,16 @@ create, rehearse and deliver short oral and/or multimodal presentations for fami
 *  sequencing ideas, points or events appropriately
 *  adjusting volume and tone when speaking in more formal situations
 
-##### AC9E2LY08
+##### AC9E2LY08 {#ac9e2ly08}
 
 write words legibly and with growing fluency using unjoined upper-case and lower-case letters
 
 **Elaborations**
 *  consolidating a functional pencil grip/grasp
 
-#### Phonic and word knowledge
+#### Phonic and word knowledge {#phonic-and-word-knowledge}
 
-##### AC9E2LY09
+##### AC9E2LY09 {#ac9e2ly09}
 
 manipulate more complex sounds in spoken words and use knowledge of blending, segmenting, phoneme deletion and phoneme substitution to read and write words
 
@@ -259,7 +259,7 @@ manipulate more complex sounds in spoken words and use knowledge of blending, se
 *  blending and segmenting sounds in words; for example, “b-r-o-th-er” or “c-l-ou-d-y”
 *  deleting and substituting sounds (phonemes) in spoken words to form new words; for example, delete the initial “scr” in “scratch” and substitute new initial sounds (phonemes) to form words such as “catch”, “batch” and “hatch”; substituting a medial sound (phoneme) to form a new word; for example, “stack” becomes “stick”
 
-##### AC9E2LY10
+##### AC9E2LY10 {#ac9e2ly10}
 
 use phoneme–grapheme (sound–letter/s) matches, including vowel digraphs, less common long vowel patterns, consonant clusters and silent letters when reading and writing words of one or more syllables, including compound words
 
@@ -268,7 +268,7 @@ use phoneme–grapheme (sound–letter/s) matches, including vowel digraphs, les
 *  providing the sounds for less common letter–sound matches; for example, “ight”, and using them in writing
 *  reading words with vowel digraphs (“ee”, “oo”, “ai”, “ay”, “ea”)
 
-##### AC9E2LY11
+##### AC9E2LY11 {#ac9e2ly11}
 
 use knowledge of spelling patterns and morphemes to read and write words whose spelling is not completely predictable from their sounds, including high-frequency words
 
@@ -276,7 +276,7 @@ use knowledge of spelling patterns and morphemes to read and write words whose s
 *  using known words and knowledge of spelling patterns and morphemes to write unknown words; for example, “one”, “once”, “only” and “lone”
 *  using context to read the correct word when an unknown word has more than one plausible pronunciation
 
-##### AC9E2LY12
+##### AC9E2LY12 {#ac9e2ly12}
 
 build morphemic word families using knowledge of prefixes and suffixes
 
@@ -284,7 +284,7 @@ build morphemic word families using knowledge of prefixes and suffixes
 *  using morphemic knowledge of words to spell unknown words; for example, “one”, “once”, “cover”, “covering”, “uncover”
 *  writing unknown words using morphemic knowledge; for example, using the known word “friend” to write “friendly” and “friendship”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 2, students interact with others, and listen to and create spoken texts including stories. They share ideas, topic knowledge and appreciation of texts when they recount, inform or express an opinion, including details from learnt topics, topics of interest or texts. They organise and link ideas, and use language features including topic-specific vocabulary and features of voice.
 

--- a/curriculum/english/year-3.md
+++ b/curriculum/english/year-3.md
@@ -1,6 +1,6 @@
-# English - Year 3
+# English - Year 3 {#english-year-3}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -14,13 +14,13 @@ The range of literary texts for Foundation to Year 10 comprises the oral narrati
 
 Year 3 students create imaginative, informative and persuasive types of texts, which may include narratives, procedures, performances, reports, reviews, poetry and argument for particular purposes and audiences.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9E3LA01
+##### AC9E3LA01 {#ac9e3la01}
 
 understand that cooperation with others depends on shared understanding of social conventions, including turn-taking language, which vary according to the degree of formality
 
@@ -28,7 +28,7 @@ understand that cooperation with others depends on shared understanding of socia
 *  recognising and using collaborative language in group and pair work; for example, initiating a topic, changing a topic through negotiation, affirming other speakers and building on their comments, asking relevant questions, providing useful feedback, prompting, and checking individual and group understanding
 *  understanding some First Nations Australian cultural protocols, cultural practices, specific roles, and ways of interacting and speaking
 
-##### AC9E3LA02
+##### AC9E3LA02 {#ac9e3la02}
 
 understand how the language of evaluation and emotion, such as modal verbs, can be varied to be more or less forceful
 
@@ -37,9 +37,9 @@ understand how the language of evaluation and emotion, such as modal verbs, can 
 *  recognising how choice of adverbs, nouns and verbs present different evaluations of characters in texts
 *  exploring examples of language that demonstrate a range of emotions and positions, and building a vocabulary to express judgements about characters or events; for example, “the wizard was cunning, expert, inventive”
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9E3LA03
+##### AC9E3LA03 {#ac9e3la03}
 
 describe how texts across the curriculum use different language features and structures relevant to their purpose
 
@@ -47,7 +47,7 @@ describe how texts across the curriculum use different language features and str
 *  identifying the stages of a basic argument such as introduction, argument one, argument 2 and conclusion
 *  describing the typical text structure and language features of factual recounts, autobiographies, information reports, narratives, personal responses to literary texts (with reasons), sequential explanations, verse poetry and simple arguments, and describe their purposes
 
-##### AC9E3LA04
+##### AC9E3LA04 {#ac9e3la04}
 
 understand that paragraphs are a key organisational feature of the stages of written texts, grouping related information together
 
@@ -56,7 +56,7 @@ understand that paragraphs are a key organisational feature of the stages of wri
 *  recognising that paragraphs in narrative texts vary in length and do not always follow a predictable structure
 *  examining models of well-constructed paragraphs and identifying their features
 
-##### AC9E3LA05
+##### AC9E3LA05 {#ac9e3la05}
 
 identify the purpose of layout features in print and digital texts and the words used for navigation
 
@@ -65,9 +65,9 @@ identify the purpose of layout features in print and digital texts and the words
 *  discussing words used as headings and subheadings in digital and print information texts
 *  discussing words used for chapter headings in narratives
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9E3LA06
+##### AC9E3LA06 {#ac9e3la06}
 
 understand that a clause is a unit of grammar usually containing a subject and a verb that need to agree
 
@@ -75,7 +75,7 @@ understand that a clause is a unit of grammar usually containing a subject and a
 *  identifying clauses in texts by locating verbs and the key words that link to the verbs; for example, “While the cat slept, the mouse scurried across the path.”
 *  identifying that a singular subject has a singular verb and a plural subject has a plural verb; for example, “The girls play cricket.” “The girl plays cricket.”
 
-##### AC9E3LA07
+##### AC9E3LA07 {#ac9e3la07}
 
 understand how verbs represent different processes for doing, feeling, thinking, saying and relating
 
@@ -85,7 +85,7 @@ understand how verbs represent different processes for doing, feeling, thinking,
 *  exploring the use of relating verbs in constructing definitions and descriptions; for example, identifying the relating verb “is” or “are”, “has” or “have” in descriptions of animals
 *  identifying different types of verbs and the way they control meaning in a clause
 
-##### AC9E3LA08
+##### AC9E3LA08 {#ac9e3la08}
 
 understand that verbs are anchored in time through tense
 
@@ -93,7 +93,7 @@ understand that verbs are anchored in time through tense
 *  learning how time is represented through the tense of a verb; for example, “She arrived.” “She is arriving.” and adverbials of time; for example, “She arrived yesterday.” “She is arriving in the morning.”
 *  learning that tenses for some verbs are formed by changing the word; for example, “She catches the ball.” “She caught the ball.”
 
-##### AC9E3LA09
+##### AC9E3LA09 {#ac9e3la09}
 
 identify how images extend the meaning of a text
 
@@ -101,7 +101,7 @@ identify how images extend the meaning of a text
 *  recognising how the relationship between characters can be depicted in images through the positioning of the characters; for example, facing each other or facing away from each other, the distance between them, the relative size, one character looking up (or down) at the other (power relationships), facial expressions and body gestures
 *  recognising how images construct a relationship with the viewer through direct gaze into the viewer's eyes, inviting involvement, and how close-ups are more engaging than distanced images, which can suggest alienation or loneliness
 
-##### AC9E3LA10
+##### AC9E3LA10 {#ac9e3la10}
 
 extend topic-specific and technical vocabulary and know that words can have different meanings in different contexts
 
@@ -111,7 +111,7 @@ extend topic-specific and technical vocabulary and know that words can have diff
 *  identifying words that have different meanings in different contexts; for example, “warm temperature” and “warm character”
 *  extending vocabulary by adding prefixes and suffixes to base words; for example, “different”, “differently” and “difference”
 
-##### AC9E3LA11
+##### AC9E3LA11 {#ac9e3la11}
 
 understand that apostrophes signal missing letters in contractions, and apostrophes are used to show singular and plural possession
 
@@ -120,11 +120,11 @@ understand that apostrophes signal missing letters in contractions, and apostrop
 *  using apostrophes to show singular possession; for example, “my friend’s book” and “the princess’s shoe”
 *  using apostrophes to show plural possession; for example, “the bees’ hive” and the “princesses’ shoes”
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9E3LE01
+##### AC9E3LE01 {#ac9e3le01}
 
 discuss characters, events and settings in different contexts in literature by First Nations Australian, and wide-ranging Australian and world authors and illustrators
 
@@ -134,9 +134,9 @@ discuss characters, events and settings in different contexts in literature by F
 *  discussing similarities and differences in the way the wolf is portrayed in different versions of children’s stories by wide-ranging world authors
 *  exploring the ways Australian settings are portrayed in stories
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9E3LE02
+##### AC9E3LE02 {#ac9e3le02}
 
 discuss connections between personal experiences and character experiences in literary texts and share personal preferences
 
@@ -144,9 +144,9 @@ discuss connections between personal experiences and character experiences in li
 *  discussing relevant prior knowledge and past experiences to make meaningful connections to the people, places, events, issues and ideas in texts
 *  selecting and discussing favourite texts and explaining reasons for assigning greater or lesser merit to particular texts or types of texts
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9E3LE03
+##### AC9E3LE03 {#ac9e3le03}
 
 discuss how an author uses language and illustrations to portray characters and settings in texts, and explore how the settings and events influence the mood of the narrative
 
@@ -154,7 +154,7 @@ discuss how an author uses language and illustrations to portray characters and 
 *  identifying and discussing how the use of descriptive language creates setting and influences atmosphere, and draws readers into events that follow; for example, “The castle loomed dark and forbidding.”
 *  discussing the language used to describe the traits of characters in stories, their actions and motivations; for example, “Claire was so lonely; she desperately wanted a pet, so she hatched a plan to get what she wanted.”
 
-##### AC9E3LE04
+##### AC9E3LE04 {#ac9e3le04}
 
 discuss the effects of some literary devices used to enhance meaning and shape the reader’s reaction, including rhythm and onomatopoeia in poetry and prose
 
@@ -162,9 +162,9 @@ discuss the effects of some literary devices used to enhance meaning and shape t
 *  discussing the effects of imagery in texts; for example, the use of imagery related to nature in haiku poems
 *  generating questions to discuss effects; for example, “Why does the poet use onomatopoeia in this line of the poem?”
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9E3LE05
+##### AC9E3LE05 {#ac9e3le05}
 
 create and edit imaginative texts, using or adapting language features, characters, settings, plot structures and ideas encountered in literary texts
 
@@ -173,11 +173,11 @@ create and edit imaginative texts, using or adapting language features, characte
 *  adapting texts read, viewed and listened to by changing the setting or revising an ending
 *  discussing characters encountered in literary texts and sharing ideas about how those characters may be a model for their own writing
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9E3LY01
+##### AC9E3LY01 {#ac9e3ly01}
 
 recognise how texts can be created for similar purposes but different audiences
 
@@ -185,9 +185,9 @@ recognise how texts can be created for similar purposes but different audiences
 *  identifying the ways in which a safety campaign varies depending on its audience; for example, comparing how a road safety campaign for adults driving is different to a road safety campaign for children crossing the road
 *  identifying how the instructions for assembling and using toys vary according to the age of the user
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9E3LY02
+##### AC9E3LY02 {#ac9e3ly02}
 
 use interaction skills to contribute to conversations and discussions to share information and ideas
 
@@ -197,9 +197,9 @@ use interaction skills to contribute to conversations and discussions to share i
 *  learning the specific speaking or listening skills of different group roles; for example, group leader, note taker and reporter
 *  using language appropriately in different situations; for example, explaining a procedure to a group, engaging in a game with friends
 
-#### Analysing, interpreting and evaluating 
+#### Analysing, interpreting and evaluating  {#analysing-interpreting-and-evaluating}
 
-##### AC9E3LY03
+##### AC9E3LY03 {#ac9e3ly03}
 
 identify the audience and purpose of imaginative, informative and persuasive texts through their use of language features and/or images
 
@@ -208,7 +208,7 @@ identify the audience and purpose of imaginative, informative and persuasive tex
 *  identifying features of advertisements that target children
 *  identifying the purpose of an imaginative text; for example, identifying the purpose of a fable
 
-##### AC9E3LY04
+##### AC9E3LY04 {#ac9e3ly04}
 
 read a range of texts using phonic, semantic and grammatical knowledge to read accurately and fluently, re-reading and self-correcting when required
 
@@ -216,7 +216,7 @@ read a range of texts using phonic, semantic and grammatical knowledge to read a
 *  using phonic knowledge, word knowledge, vocabulary and grammatical knowledge to read unknown words
 *  reading a wider range of texts from different learning areas, including chapter books and informative texts
 
-##### AC9E3LY05
+##### AC9E3LY05 {#ac9e3ly05}
 
 use comprehension strategies when listening and viewing to build literal and inferred meaning, and begin to evaluate texts by drawing on a growing knowledge of context, text structures and language features
 
@@ -228,9 +228,9 @@ use comprehension strategies when listening and viewing to build literal and inf
 *  drawing inferences, using evidence from the text and prior knowledge and experience; for example, making predictions about a character's likely actions or about the content of tabbed pages on a website
 *  determining the relevance of a text for a particular task
 
-#### Creating texts
+#### Creating texts {#creating-texts}
 
-##### AC9E3LY06
+##### AC9E3LY06 {#ac9e3ly06}
 
 plan, create, edit and publish imaginative, informative and persuasive written and multimodal texts, using visual features, appropriate form and layout, with ideas grouped in simple paragraphs, mostly correct tense, topic-specific vocabulary and correct spelling of most high-frequency and phonetically regular words
 
@@ -243,7 +243,7 @@ plan, create, edit and publish imaginative, informative and persuasive written a
 *  using print and online dictionaries, and spellcheck to edit spelling, realising that spellcheck accuracy depends on understanding the word function; for example, “there” or “their” and “rain” or “reign”
 *  checking for correct use of apostrophes for contractions and to indicate possession
 
-##### AC9E3LY07
+##### AC9E3LY07 {#ac9e3ly07}
 
 plan, create, rehearse and deliver short oral and/or multimodal presentations to inform, express opinions or tell stories, using a clear structure, details to elaborate ideas, topic-specific and precise vocabulary, visual features, and appropriate tone, pace, pitch and volume
 
@@ -253,15 +253,15 @@ plan, create, rehearse and deliver short oral and/or multimodal presentations to
 *  adjusting tone and pace to purpose and audience
 *  explaining ideas to a peer when planning a presentation
 
-##### AC9E3LY08
+##### AC9E3LY08 {#ac9e3ly08}
 
 write words using joined letters that are clearly formed and consistent in size
 
 **Elaborations**
 
-#### Phonic and word knowledge
+#### Phonic and word knowledge {#phonic-and-word-knowledge}
 
-##### AC9E3LY09
+##### AC9E3LY09 {#ac9e3ly09}
 
 understand how to apply knowledge of phoneme–grapheme (sound–letter) relationships, syllables, and blending and segmenting to fluently read and write multisyllabic words with more complex letter patterns
 
@@ -269,7 +269,7 @@ understand how to apply knowledge of phoneme–grapheme (sound–letter) relatio
 *  reading and writing more complex words with consonant digraphs and consonant blends; for example, “shrinking”, “against” and “rocket”
 *  reading and writing consonant digraphs representing different sounds; for example, “machine”, “change” and “school”
 
-##### AC9E3LY10
+##### AC9E3LY10 {#ac9e3ly10}
 
 understand how to apply knowledge of common base words, prefixes, suffixes and generalisations for adding a suffix to a base word to read and comprehend new multimorphemic words
 
@@ -277,7 +277,7 @@ understand how to apply knowledge of common base words, prefixes, suffixes and g
 *  understanding how to use knowledge of prefixes to change the meaning of a base word; for example, “undone”, “remove” and “misunderstand”
 *  using generalisations for adding a suffix to a base word to form a plural or past tense; for example, to make a word plural when it ends in “ss”, “sh”, “ch” or “z”, add “es”
 
-##### AC9E3LY11
+##### AC9E3LY11 {#ac9e3ly11}
 
 use phoneme–grapheme (sound–letter) relationships and less common letter patterns to spell words
 
@@ -285,14 +285,14 @@ use phoneme–grapheme (sound–letter) relationships and less common letter pat
 *  using phonic knowledge to explore less common letter patterns after short vowels; for example, words that end in “dge”, “badge”, “edge” and “fridge”
 *  using phonic knowledge and knowledge of letter patterns to spell words with 3-letter blends; for example, “str-ip”
 
-##### AC9E3LY12
+##### AC9E3LY12 {#ac9e3ly12}
 
 recognise and know how to write most high-frequency words including some homophones
 
 **Elaborations**
 *  using context and syntactic knowledge to spell homophones; for example, “break” or “brake” and “ate” or “eight”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 3, students interact with others, and listen to and create spoken and/or multimodal texts including stories. They relate ideas; express opinion, preferences and appreciation of texts; and include relevant details from learnt topics, topics of interest or texts. They group, logically sequence and link ideas. They use language features including topic-specific vocabulary, and/or visual features and features of voice.
 

--- a/curriculum/english/year-4.md
+++ b/curriculum/english/year-4.md
@@ -1,6 +1,6 @@
-# English - Year 4
+# English - Year 4 {#english-year-4}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -14,13 +14,13 @@ Literary texts that support and extend students in Year 4 as independent readers
 
 Year 4 students create a range of imaginative, informative and persuasive types of texts that may include narratives, performances, reports, reviews, poetry and arguments for particular purposes and audiences.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9E4LA01
+##### AC9E4LA01 {#ac9e4la01}
 
 explore language used to develop relationships in formal and informal situations
 
@@ -30,7 +30,7 @@ explore language used to develop relationships in formal and informal situations
 *  recognising the importance of using inclusive language
 *  exploring cultural respects for First Nations Australian Elders, and greeting conventions between First Nations Australians
 
-##### AC9E4LA02
+##### AC9E4LA02 {#ac9e4la02}
 
 identify the subjective language of opinion and feeling, and the objective language of factual reporting
 
@@ -38,9 +38,9 @@ identify the subjective language of opinion and feeling, and the objective langu
 *  identifying ways thinking verbs are used to express opinions; for example, “I think”, “I believe”, and ways summary verbs are used to report findings; for example, “we concluded”
 *  comparing statements that have similar information presented objectively and subjectively; for example, “The man has 6 cats.” “The man has too many noisy cats.”
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9E4LA03
+##### AC9E4LA03 {#ac9e4la03}
 
 identify how texts across the curriculum have different language features and are typically organised into characteristic stages depending on purposes
 
@@ -50,7 +50,7 @@ identify how texts across the curriculum have different language features and ar
 *  recognising that poems have different purposes that influence the organisation into characteristic stages; for example, poems that tell stories, poems that describe and poems that reflect on aspects of life
 *  recognising the difference between a text’s form such as a poster, email or list and its organisation into stages depending on its social purpose
 
-##### AC9E4LA04
+##### AC9E4LA04 {#ac9e4la04}
 
 identify how text connectives including temporal and conditional words, and topic word associations are used to sequence and connect ideas
 
@@ -59,7 +59,7 @@ identify how text connectives including temporal and conditional words, and topi
 *  recognising how authors use text connectives to create links between sentences; for example, “however”, “therefore”, “nevertheless” and “in addition”
 *  recognising how text connectives link sections of a text, providing sequences through time; for example, “firstly”, “then”, “next” and “finally”
 
-##### AC9E4LA05
+##### AC9E4LA05 {#ac9e4la05}
 
 identify text navigation features of online texts that enhance readability including headlines, drop-down menus, links, graphics and layout
 
@@ -67,9 +67,9 @@ identify text navigation features of online texts that enhance readability inclu
 *  investigating the features used for texts such as headings and subheadings in print text, home pages and subpages in digital texts, and how these help the reader select text for a purpose
 *  comparing the features of texts on similar topics online
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9E4LA06
+##### AC9E4LA06 {#ac9e4la06}
 
 understand that complex sentences contain one independent clause and at least one dependent clause typically joined by a subordinating conjunction to create relationships, such as time and causality
 
@@ -77,21 +77,21 @@ understand that complex sentences contain one independent clause and at least on
 *  creating richer, more specific sentences by including information about place, time, manner, cause or condition in a dependent clause; for example, “Denise found a cocoon.”  becomes “Denise decided to keep an eye on the cocoon until the butterfly emerged.”
 *  creating more precise and detailed sentences by adding adverbial clauses; for example, “They crossed the mountain range.” becomes “Although the path was overgrown, they crossed the mountain range.”
 
-##### AC9E4LA07
+##### AC9E4LA07 {#ac9e4la07}
 
 investigate how quoted (direct) and reported (indirect) speech are used
 
 **Elaborations**
 *  investigating examples of quoted (direct) speech; for example, “He said, ‘I’ll go to the park today.’” and reported (indirect) speech; for example, “He told me he was going to the park today.” and why they have been used in different contexts
 
-##### AC9E4LA08
+##### AC9E4LA08 {#ac9e4la08}
 
 understand how adverb groups/phrases and prepositional phrases work in different ways to provide circumstantial details about an activity
 
 **Elaborations**
 *  investigating in texts how adverb groups/phrases and prepositional phrases can provide details of the circumstances surrounding a happening or state; for example, “At midnight (time) he rose slowly (manner) from the chair (place) and went upstairs (place).”
 
-##### AC9E4LA09
+##### AC9E4LA09 {#ac9e4la09}
 
 understand past, present and future tenses and their impact on meaning in a sentence
 
@@ -99,14 +99,14 @@ understand past, present and future tenses and their impact on meaning in a sent
 *  understanding the tense that types of texts are commonly written in; for example, informative texts are usually written in present tense
 *  identifying the tense in texts they read
 
-##### AC9E4LA10
+##### AC9E4LA10 {#ac9e4la10}
 
 explore the effect of choices when framing an image, placement of elements in the image and salience on composition of still and moving images in texts
 
 **Elaborations**
 *  examining visual and multimodal texts, building a vocabulary to describe visual elements and techniques such as framing, composition and salience, and beginning to understand how these choices influence viewer response
 
-##### AC9E4LA11
+##### AC9E4LA11 {#ac9e4la11}
 
 expand vocabulary by exploring a range of synonyms and antonyms, and using words encountered in a range of sources
 
@@ -115,7 +115,7 @@ expand vocabulary by exploring a range of synonyms and antonyms, and using words
 *  determining or clarifying the shades of meaning of synonyms and antonyms
 *  using words encountered in texts that are formed from a First Nations Australian language; for example, Woomba Woomba or Toowoom was the place referred to by First Nations Australians on the Darling Downs and then the name was referred to as Toowoomba by the drovers
 
-##### AC9E4LA12
+##### AC9E4LA12 {#ac9e4la12}
 
 understand that punctuation signals dialogue through quotation marks and that dialogue follows conventions for the use of capital letters, commas and boundary punctuation
 
@@ -123,11 +123,11 @@ understand that punctuation signals dialogue through quotation marks and that di
 *  identifying the use of quotation marks, capital letters, commas and boundary punctuation to signal dialogue in texts
 *  using punctuated dialogue in own writing
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9E4LE01
+##### AC9E4LE01 {#ac9e4le01}
 
 recognise similar storylines, ideas and relationships in different contexts in literary texts by First Nations Australian, and wide-ranging Australian and world authors
 
@@ -137,9 +137,9 @@ recognise similar storylines, ideas and relationships in different contexts in l
 *  discussing how everyday life, such as mealtimes and family relationships, is depicted in particular historical and cultural contexts in texts by wide-ranging world authors
 *  recognising similar storylines and ideas in literature by First Nations Australian authors
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9E4LE02
+##### AC9E4LE02 {#ac9e4le02}
 
 describe the effects of text structures and language features in literary texts when responding to and sharing opinions
 
@@ -148,9 +148,9 @@ describe the effects of text structures and language features in literary texts 
 *  sharing responses to texts using appropriate language to talk specifically about grammar and literature; for example, “The use of the noun groups to describe the character really helps to create images for the reader.”
 *  using language appropriate to a text such as “flashback”, “tension” and “resolution” when sharing opinions about plot structure
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9E4LE03
+##### AC9E4LE03 {#ac9e4le03}
 
 discuss how authors and illustrators make stories engaging by the way they develop character, setting and plot tensions
 
@@ -160,7 +160,7 @@ discuss how authors and illustrators make stories engaging by the way they devel
 *  identifying moments in the plot where characters are faced with choices, and commenting on how the author makes the reader care about their decisions and the consequences
 *  identifying how illustrations contribute to the meaning of stories by First Nations Australian authors
 
-##### AC9E4LE04
+##### AC9E4LE04 {#ac9e4le04}
 
 examine the use of literary devices and deliberate word play in literary texts, including poetry, to shape meaning
 
@@ -169,9 +169,9 @@ examine the use of literary devices and deliberate word play in literary texts, 
 *  discussing poetic language, including adjectives that engage readers emotionally and bring the poet’s subject matter to life
 *  exploring emotive language in texts by First Nations Australian poets and authors
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9E4LE05
+##### AC9E4LE05 {#ac9e4le05}
 
 create and edit literary texts by developing storylines, characters and settings
 
@@ -179,11 +179,11 @@ create and edit literary texts by developing storylines, characters and settings
 *  creating texts using a range of sentence types, including dialogue and literary devices
 *  collaborating with a peer to edit literary texts by sharing feedback about choices made to develop storylines, characters and settings
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9E4LY01
+##### AC9E4LY01 {#ac9e4ly01}
 
 compare texts from different times with similar purposes and audiences to identify similarities and differences in their depictions of events
 
@@ -191,9 +191,9 @@ compare texts from different times with similar purposes and audiences to identi
 *  viewing documentaries and news footage from different periods, comparing the purpose and audience; for example, coverage of major sporting events
 *  comparing the texts used to communicate between family members, noting similarities and differences as a result of changing technology
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9E4LY02
+##### AC9E4LY02 {#ac9e4ly02}
 
 listen for key points and information to carry out tasks and contribute to discussions, acknowledging another opinion, linking a response to the topic, and sharing and extending ideas and information
 
@@ -201,9 +201,9 @@ listen for key points and information to carry out tasks and contribute to discu
 *  making notes about a task, asking questions to clarify or follow up information, and seeking assistance if required
 *  developing speaking and listening behaviours including acknowledging and extending others’ contributions, presenting ideas and opinions clearly and coherently
 
-#### Analysing, interpreting and evaluating 
+#### Analysing, interpreting and evaluating  {#analysing-interpreting-and-evaluating}
 
-##### AC9E4LY03
+##### AC9E4LY03 {#ac9e4ly03}
 
 identify the characteristic features used in imaginative, informative and persuasive texts to meet the purpose of the text
 
@@ -212,14 +212,14 @@ identify the characteristic features used in imaginative, informative and persua
 *  identifying how authors use techniques, such as headings, italics and bold text, to support readers or viewers to navigate specific texts
 *  identifying visual features such as images and layout used in informative texts to complement, add to or shape understanding of a topic
 
-##### AC9E4LY04
+##### AC9E4LY04 {#ac9e4ly04}
 
 read different types of texts, integrating phonic, semantic and grammatical knowledge to read accurately and fluently, re-reading and self-correcting when needed
 
 **Elaborations**
 *  reading increasingly complex texts using established word identification strategies, knowledge of the topic and understanding of text structure and language features
 
-##### AC9E4LY05
+##### AC9E4LY05 {#ac9e4ly05}
 
 use comprehension strategies such as visualising, predicting, connecting, summarising, monitoring and questioning to build literal and inferred meaning, to expand topic knowledge and ideas, and evaluate texts
 
@@ -232,9 +232,9 @@ use comprehension strategies such as visualising, predicting, connecting, summar
 *  connecting the use of colours, images, symbols and patterns in texts by First Nations Australian authors and illustrators
 *  evaluating an author’s use of evidence to support arguments
 
-#### Creating texts
+#### Creating texts {#creating-texts}
 
-##### AC9E4LY06
+##### AC9E4LY06 {#ac9e4ly06}
 
 plan, create, edit and publish written and multimodal imaginative, informative and persuasive texts, using visual features, relevant linked ideas, complex sentences, appropriate tense, synonyms and antonyms, correct spelling of multisyllabic words and simple punctuation
 
@@ -245,7 +245,7 @@ plan, create, edit and publish written and multimodal imaginative, informative a
 *  using grammatical features including different types of verb groups, noun groups and adverb groups/phrases for effective descriptions and details according to purpose
 *  revising written texts to improve the selection of words used to connect ideas and improve the cohesion of the text
 
-##### AC9E4LY07
+##### AC9E4LY07 {#ac9e4ly07}
 
 plan, create, rehearse and deliver structured oral and/or multimodal presentations to report on a topic, tell a story, recount events or present an argument using subjective and objective language, complex sentences, visual features, tone, pace, pitch and volume
 
@@ -255,15 +255,15 @@ plan, create, rehearse and deliver structured oral and/or multimodal presentatio
 *  choosing a variety of appropriate words and phrases, including descriptive words and some technical vocabulary, to communicate meaning accurately
 *  rehearsing a presentation with a peer and sharing feedback about tone, pace, pitch and volume appropriate to audience
 
-##### AC9E4LY08
+##### AC9E4LY08 {#ac9e4ly08}
 
 write words using clearly formed joined letters, with developing fluency and automaticity
 
 **Elaborations**
 
-#### Phonic and word knowledge
+#### Phonic and word knowledge {#phonic-and-word-knowledge}
 
-##### AC9E4LY09
+##### AC9E4LY09 {#ac9e4ly09}
 
 understand how to use and apply phonological and morphological knowledge to read and write multisyllabic words with more complex letter combinations, including a variety of vowel sounds and known prefixes and suffixes
 
@@ -271,7 +271,7 @@ understand how to use and apply phonological and morphological knowledge to read
 *  recognising unstressed vowels in multisyllabic words and how these vowel sounds are written; for example, “builder” and “animal”
 *  using phonic and morphemic knowledge to read and write multisyllabic words with more complex letter combinations; for example, “straightaway” and “thoughtful”
 
-##### AC9E4LY10
+##### AC9E4LY10 {#ac9e4ly10}
 
 understand how to use knowledge of letter patterns, including double letters, spelling generalisations, morphological word families, common prefixes and suffixes, and word origins, to spell more complex words
 
@@ -279,14 +279,14 @@ understand how to use knowledge of letter patterns, including double letters, sp
 *  applying generalisations for adding affixes; for example, “hope” – “hoping”, “begin” – “beginning”, “country” – “countries”
 *  building morphemic word families and exploring word origins; for example, "tricycle", "tripod" and "triangle"
 
-##### AC9E4LY11
+##### AC9E4LY11 {#ac9e4ly11}
 
 read and write high-frequency words including homophones and know how to use context to identify correct spelling
 
 **Elaborations**
 *  recognising that contextual and syntactical clues can be used to determine the use of homophones; for example, “We grow wheat on our farm.” “The train trip will take about an hour.”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 4, students interact with others, and listen to and create spoken and/or multimodal texts including stories. They share and extend ideas, opinions and information with audiences, using relevant details from learnt topics, topics of interest or texts. They use text structures to organise and link ideas. They use language features including subjective and objective language, topic-specific vocabulary and literary devices, and/or visual features and features of voice.
 

--- a/curriculum/english/year-5.md
+++ b/curriculum/english/year-5.md
@@ -1,6 +1,6 @@
-# English - Year 5
+# English - Year 5 {#english-year-5}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -16,13 +16,13 @@ Year 5 students create a range of imaginative, informative and persuasive types 
 
 From Year 5 onwards, students continue to develop legible handwriting.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9E5LA01
+##### AC9E5LA01 {#ac9e5la01}
 
 understand that language is selected for social contexts and that it helps to signal social roles and relationships
 
@@ -31,16 +31,16 @@ understand that language is selected for social contexts and that it helps to si
 *  identifying ways in which cultures differ in making and responding to common requests; for example, periods of silence, degrees of formality
 *  identifying some cultural protocols and communication processes of First Nations Australians
 
-##### AC9E5LA02
+##### AC9E5LA02 {#ac9e5la02}
 
 understand how to move beyond making bare assertions by taking account of differing ideas or opinions and authoritative sources
 
 **Elaborations**
 *  recognising that a bare assertion (for example, “It's the best film this year.”) often needs to be tempered by: using the “impersonal it” to distance oneself (for example, “It could be said that it is the best film this year.”); recruiting anonymous support (for example, “It is generally agreed that it is the best film this year.”); indicating a general source of the opinion (for example, “Most critics agree that it is the best film this year.”); specifying the source of the opinion (for example, “Reviewers for The Reel Film stated that it is the best film this year.”) and reflecting on the effect of these different choices
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9E5LA03
+##### AC9E5LA03 {#ac9e5la03}
 
 describe how spoken, written and multimodal texts use language features and are typically organised into characteristic stages and phases, depending on purposes in texts
 
@@ -49,7 +49,7 @@ describe how spoken, written and multimodal texts use language features and are 
 *  recognising that paragraphs vary in their function and how they are organised in a text and between different types of texts; for example, the differences between paragraphs in a narrative, an argument and a procedure
 *  describing the stages and phases, and purposes of narratives, historical recounts, procedural recounts, causal explanations, discussions of alternative positions on an issue, information reports, reviews and types of poems
 
-##### AC9E5LA04
+##### AC9E5LA04 {#ac9e5la04}
 
 understand how texts can be made cohesive by using the starting point of a sentence or paragraph to give prominence to the message and to guide the reader through the text
 
@@ -58,23 +58,23 @@ understand how texts can be made cohesive by using the starting point of a sente
 *  recognising that a sequence of clauses may use different tenses but remain connected through a topic; for example, “Snakes were a problem in Australia. However, urban sprawl is ruining their habitats and they are now a protected species.”
 *  recognising that sentence openers signal what the sentence will be about, and the rest of the sentence typically elaborates on the sentence opener by providing new information
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9E5LA05
+##### AC9E5LA05 {#ac9e5la05}
 
 understand that the structure of a complex sentence includes a main clause and at least one dependent clause, and understand how writers can use this structure for effect
 
 **Elaborations**
 *  knowing that complex sentences make connections between ideas to provide a reason; for example, “He jumped up because the bell rang.”; state a purpose; for example, “She raced home to confront her brother.”; express a condition; for example, “It will break if you push it.”; make a concession; for example, “She finished her work even though she was feeling tired.”; link 2 ideas in terms of various time relations; for example, “Nero fiddled while Rome burned.”
 
-##### AC9E5LA06
+##### AC9E5LA06 {#ac9e5la06}
 
 understand how noun groups can be expanded in a variety of ways to provide a fuller description of a person, place, thing or idea
 
 **Elaborations**
 *  learning how to expand a description by combining a related set of nouns and adjectives; for example, “Two old brown cattle dogs”
 
-##### AC9E5LA07
+##### AC9E5LA07 {#ac9e5la07}
 
 explain how the sequence of images in print, digital and film texts has an effect on meaning
 
@@ -84,7 +84,7 @@ explain how the sequence of images in print, digital and film texts has an effec
 *  viewing a short film or segment from a film without sound and comparing interpretations after viewing with sound
 *  recognising how the sequence of images in texts by First Nations Australian authors create meaning
 
-##### AC9E5LA08
+##### AC9E5LA08 {#ac9e5la08}
 
 understand how vocabulary is used to express greater precision of meaning, including through the use of specialist and technical terms, and explore the history of words
 
@@ -92,7 +92,7 @@ understand how vocabulary is used to express greater precision of meaning, inclu
 *  using precise words for naming; for example, instead of “mammal” or “whale”, using “humpback whale”
 *  exploring Greek and Latin roots in commonly used words; for example, the Greek root word “tele” meaning distant in words such as “telephone” and “teleport”
 
-##### AC9E5LA09
+##### AC9E5LA09 {#ac9e5la09}
 
 use commas to indicate prepositional phrases, and apostrophes where there is multiple possession
 
@@ -102,11 +102,11 @@ use commas to indicate prepositional phrases, and apostrophes where there is mul
 *  learning that when there is more than one owner, the apostrophe is usually used for the last owner in the list; for example, “the cat and kitten’s bowls”
 *  using commas to signal a prepositional phrase; for example, “On Saturday, before it rained we went to the beach.”
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9E5LE01
+##### AC9E5LE01 {#ac9e5le01}
 
 identify aspects of literary texts that represent details or information about historical, social and cultural contexts in literature by First Nations Australian, and wide-ranging Australian and world authors
 
@@ -116,9 +116,9 @@ identify aspects of literary texts that represent details or information about h
 *  exploring aspects of literature that represent historical context in texts by First Nations Australian authors
 *  exploring characters and concepts in ballads from different times by wide-ranging Australian authors
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9E5LE02
+##### AC9E5LE02 {#ac9e5le02}
 
 present an opinion on a literary text using specific terms about literary devices, text structures and language features, and reflect on the viewpoints of others
 
@@ -126,9 +126,9 @@ present an opinion on a literary text using specific terms about literary device
 *  posing and discussing questions, such as “Should characters have behaved as they did?” and “How did the author support or challenge your belief about the characters?”, and beginning to make judgements about the dilemmas characters face
 *  identifying language features such as use of dialogue and rich descriptive language, and presenting an opinion about their effect on readers
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9E5LE03
+##### AC9E5LE03 {#ac9e5le03}
 
 recognise that the point of view in a literary text influences how readers interpret and respond to events and characters
 
@@ -136,7 +136,7 @@ recognise that the point of view in a literary text influences how readers inter
 *  comparing texts narrated from a first person and third person point of view, and discussing what information the audience can access and how this influences the audience’s sympathies
 *  discussing why an author might choose a particular point of view
 
-##### AC9E5LE04
+##### AC9E5LE04 {#ac9e5le04}
 
 examine the effects of imagery, including simile, metaphor and personification, and sound devices in narratives, poetry and songs
 
@@ -144,9 +144,9 @@ examine the effects of imagery, including simile, metaphor and personification, 
 *  discussing how figurative language including simile and metaphor can make use of a comparison between different things
 *  discussing how, by appealing to the imagination, figurative language provides new ways of looking at the world
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9E5LE05
+##### AC9E5LE05 {#ac9e5le05}
 
 create and edit literary texts, experimenting with figurative language, storylines, characters and settings from texts students have experienced
 
@@ -154,11 +154,11 @@ create and edit literary texts, experimenting with figurative language, storylin
 *  drawing upon fiction elements in a range of model texts; for example, main idea, characterisation, setting (time and place) and devices; for example, figurative language (simile, metaphor, personification), to experiment with new, creative ways of communicating ideas, experiences and stories in literary texts
 *  creating a visual map, which may include digital mind maps, of figurative language, storylines, characters and settings in a text that may inspire their own writing
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9E5LY01
+##### AC9E5LY01 {#ac9e5ly01}
 
 describe the ways in which a text reflects the time and place in which it was created
 
@@ -166,9 +166,9 @@ describe the ways in which a text reflects the time and place in which it was cr
 *  describing how ideas in texts are conveyed by vocabulary, including idiomatic expressions, and that these can change according to time and place
 *  describing how ideas in texts reflect the social expectations of the time and place in which they were created
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9E5LY02
+##### AC9E5LY02 {#ac9e5ly02}
 
 use appropriate interaction skills including paraphrasing and questioning to clarify meaning, make connections to own experience, and present and justify an opinion or idea
 
@@ -178,9 +178,9 @@ use appropriate interaction skills including paraphrasing and questioning to cla
 *  using strategies for discussion, such as speaking clearly, pausing, asking questions and linking students’ own responses to the contributions of others
 *  choosing vocabulary and sentence structures for particular purposes including formal and informal contexts, to report and explain new concepts and topics, to offer an opinion and to persuade others
 
-#### Analysing, interpreting and evaluating 
+#### Analysing, interpreting and evaluating  {#analysing-interpreting-and-evaluating}
 
-##### AC9E5LY03
+##### AC9E5LY03 {#ac9e5ly03}
 
 explain characteristic features used in imaginative, informative and persuasive texts to meet the purpose of the text
 
@@ -188,7 +188,7 @@ explain characteristic features used in imaginative, informative and persuasive 
 *  explaining how the features of a text advocating community action; for example, action on a local area preservation issue, are used to meet the purpose of the text
 *  explaining how characters are used to deliver the message in persuasive texts; for example, explaining how characters are used to present persuasive messages about health issues in advertising, considering why characters have been used instead of real people
 
-##### AC9E5LY04
+##### AC9E5LY04 {#ac9e5ly04}
 
 navigate and read texts for specific purposes, monitoring meaning using strategies such as skimming, scanning and confirming
 
@@ -197,7 +197,7 @@ navigate and read texts for specific purposes, monitoring meaning using strategi
 *  skimming and scanning to check the pertinence of particular information to students’ topic and task
 *  using sign-posting features such as headings and subheadings, and homepages and subpages to read texts
 
-##### AC9E5LY05
+##### AC9E5LY05 {#ac9e5ly05}
 
 use comprehension strategies such as visualising, predicting, connecting, summarising, monitoring and questioning to build literal and inferred meaning to evaluate information and ideas
 
@@ -206,9 +206,9 @@ use comprehension strategies such as visualising, predicting, connecting, summar
 *  using research skills including identifying research purpose, locating texts, gathering and organising information, evaluating relative value, evaluating the accuracy and currency of print and digital sources, and summarising information from several sources
 *  comparing texts on the same topic to identify similarities and differences in the ideas or information that are included
 
-#### Creating texts
+#### Creating texts {#creating-texts}
 
-##### AC9E5LY06
+##### AC9E5LY06 {#ac9e5ly06}
 
 plan, create, edit and publish written and multimodal texts whose purposes may be imaginative, informative and persuasive, developing ideas using visual features, text structure appropriate to the topic and purpose, text connectives, expanded noun groups, specialist and technical vocabulary, and punctuation including dialogue punctuation
 
@@ -220,7 +220,7 @@ plan, create, edit and publish written and multimodal texts whose purposes may b
 *  writing letters in print and by email demonstrating understanding of audience
 *  re-reading and editing their own and others’ work, which may involve using digital tools, for precision using negotiated criteria for text structure and meaning, and accuracy of grammar, spelling and punctuation
 
-##### AC9E5LY07
+##### AC9E5LY07 {#ac9e5ly07}
 
 plan, create, rehearse and deliver spoken and multimodal presentations that include relevant, elaborated ideas, sequencing ideas and using complex sentences, specialist and technical vocabulary, pitch, tone, pace, volume, and visual and digital features
 
@@ -229,16 +229,16 @@ plan, create, rehearse and deliver spoken and multimodal presentations that incl
 *  experimenting with features of voice such as tone, volume, pitch and pace in formal presentations and recognising the effects these have on audience understanding
 *  reflecting on how new learning can be incorporated into a presentation
 
-#### Phonic and word knowledge
+#### Phonic and word knowledge {#phonic-and-word-knowledge}
 
-##### AC9E5LY08
+##### AC9E5LY08 {#ac9e5ly08}
 
 use phonic, morphemic and vocabulary knowledge to read and spell words that share common letter patterns but have different pronunciations
 
 **Elaborations**
 *  recognising and writing less familiar words that share common letter patterns but have different pronunciations; for example, “journey”, “your”, “tour” and “sour”
 
-##### AC9E5LY09
+##### AC9E5LY09 {#ac9e5ly09}
 
 build and spell new words from knowledge of known words, base words, prefixes and suffixes, word origins, letter patterns and spelling generalisations
 
@@ -246,7 +246,7 @@ build and spell new words from knowledge of known words, base words, prefixes an
 *  using knowledge of known words and base words to spell new words; for example, the spelling and meaning connections between “vision”, “television” and “revision”
 *  applying knowledge of spelling generalisations to spell new words; for example, “suitable”, “likeable” and “collapsible”
 
-##### AC9E5LY10
+##### AC9E5LY10 {#ac9e5ly10}
 
 explore less common plurals, and understand how a suffix changes the meaning or grammatical form of a word
 
@@ -254,7 +254,7 @@ explore less common plurals, and understand how a suffix changes the meaning or 
 *  using knowledge of word origins and roots, and related words, to interpret and spell unfamiliar words, and learning about how these roots affect plurals; for example, “cactus” and “cacti”, “louse” and “lice”
 *  understanding how some suffixes change the grammatical form of words; for example, “-tion” and “-ment” can change verbs into nouns: “protect” to “protection” and “develop” to “development”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 5, students interact with others, and listen to and create spoken and/or multimodal texts including literary texts. For particular purposes and audiences, they share, develop and expand on ideas and opinions, using supporting details from topics or texts. They use different text structures to organise, develop and link ideas. They use language features including topic-specific vocabulary and literary devices, and/or multimodal features and features of voice.
 

--- a/curriculum/english/year-6.md
+++ b/curriculum/english/year-6.md
@@ -1,6 +1,6 @@
-# English - Year 6
+# English - Year 6 {#english-year-6}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -14,13 +14,13 @@ Literary texts that support and extend students in Year 6 as independent readers
 
 Year 6 students create a range of imaginative, informative and persuasive types of texts that may include narratives, procedures, performances, reports, reviews, poetry, expositions, explanations and discussions for particular purposes and audiences.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9E6LA01
+##### AC9E6LA01 {#ac9e6la01}
 
 understand that language varies as levels of formality and social distance increase
 
@@ -29,7 +29,7 @@ understand that language varies as levels of formality and social distance incre
 *  discussing levels of language such as slang, colloquial, conversational and formal, and how their appropriateness changes with the situation and audience
 *  presenting ideas and opinions at levels of formality appropriate to the context and audience
 
-##### AC9E6LA02
+##### AC9E6LA02 {#ac9e6la02}
 
 understand the uses of objective and subjective language, and identify bias
 
@@ -38,9 +38,9 @@ understand the uses of objective and subjective language, and identify bias
 *  understanding when to share feelings and opinions; for example, in a personal recount, and when to remain more objective; for example, in a factual recount
 *  differentiating between reporting the facts; for example, in a factual recount or unedited photograph, and providing a commentary; for example, in an editorial
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9E6LA03
+##### AC9E6LA03 {#ac9e6la03}
 
 explain how texts across the curriculum are typically organised into characteristic stages and phases depending on purposes, recognising how authors often adapt text structures and language features
 
@@ -50,7 +50,7 @@ explain how texts across the curriculum are typically organised into characteris
 *  recognising that texts are organised into stages such as an introduction and that introductions may be divided into phases; for example, the introduction stage of a narrative may begin with a phase that is a “hook” or a flashback
 *  explaining the characteristic stages and phases in reviews, discussions of alternative positions or historical recounts and identifying any adaptations of typical structures or language features
 
-##### AC9E6LA04
+##### AC9E6LA04 {#ac9e6la04}
 
 understand that cohesion can be created by the intentional use of repetition, and the use of word associations
 
@@ -58,9 +58,9 @@ understand that cohesion can be created by the intentional use of repetition, an
 *  noting how a general word is often used for a more specific word already mentioned (word association); for example, “Look at those apples. Granny Smiths are my favourite.”
 *  recognising how cohesion can be developed through repeating key words or by using synonyms or antonyms
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9E6LA05
+##### AC9E6LA05 {#ac9e6la05}
 
 understand how embedded clauses can expand the variety of complex sentences to elaborate, extend and explain ideas
 
@@ -68,7 +68,7 @@ understand how embedded clauses can expand the variety of complex sentences to e
 *  investigating how the choice of conjunctions enables the construction of complex sentences to extend, to elaborate on and to explain ideas; for example, “The town that was flooded suffered extensive damage.”
 *  creating complex sentences with embedded clauses to expand noun groups; for example, “Hamish studied the rock samples that he had collected on the excursion.”
 
-##### AC9E6LA06
+##### AC9E6LA06 {#ac9e6la06}
 
 understand how ideas can be expanded and sharpened through careful choice of verbs, elaborated tenses and a range of adverb groups
 
@@ -77,7 +77,7 @@ understand how ideas can be expanded and sharpened through careful choice of ver
 *  knowing that there are various ways in English to refer to future time: using the auxiliary “will”; for example, “She will call you tomorrow.”, using the present tense; for example, “Tomorrow, I leave for Hobart.” and using adverbials of time; for example, “She arrives in the morning.”
 *  using precise verbs; for example, “slice”, “dice”, “fillet” and “segment” rather than general words; for example, “cut”
 
-##### AC9E6LA07
+##### AC9E6LA07 {#ac9e6la07}
 
 identify and explain how images, figures, tables, diagrams, maps and graphs contribute to meaning
 
@@ -86,7 +86,7 @@ identify and explain how images, figures, tables, diagrams, maps and graphs cont
 *  observing how concepts, information and relationships can be represented visually through tables, maps, graphs and diagrams
 *  understanding that images and maps may be sensitive for First Nations Australians and ensuring that a disclaimer is applied or judgement is used about cultural appropriateness and sensitivities
 
-##### AC9E6LA08
+##### AC9E6LA08 {#ac9e6la08}
 
 identify authors’ use of vivid, emotive vocabulary, such as metaphors, similes, personification, idioms, imagery and hyperbole
 
@@ -95,7 +95,7 @@ identify authors’ use of vivid, emotive vocabulary, such as metaphors, similes
 *  identifying authors’ use of vivid and emotive vocabulary in persuasive texts; for example, the vocabulary used in reviews
 *  discussing texts, using vocabulary to name text structure, literary devices and language features; for example, using words that name the literary device used in a poem
 
-##### AC9E6LA09
+##### AC9E6LA09 {#ac9e6la09}
 
 understand how to use the comma for lists, to separate a dependent clause from an independent clause, and in dialogue
 
@@ -103,11 +103,11 @@ understand how to use the comma for lists, to separate a dependent clause from a
 *  identifying different uses of commas such as commas and conjunctions between independent clauses in compound sentences
 *  using commas in dialogue; for example, Ben said, "I want pie, peas, carrots and chips for dinner, followed by ice cream for dessert, please."
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9E6LE01
+##### AC9E6LE01 {#ac9e6le01}
 
 identify responses to characters and events in literary texts, drawn from historical, social or cultural contexts, by First Nations Australian, and wide-ranging Australian and world authors
 
@@ -116,9 +116,9 @@ identify responses to characters and events in literary texts, drawn from histor
 *  sharing responses about how heroes are portrayed in science fiction or fantasy and more realistic settings
 *  exploring reviews of Australian films
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9E6LE02
+##### AC9E6LE02 {#ac9e6le02}
 
 identify similarities and differences in literary texts on similar topics, themes or plots
 
@@ -126,9 +126,9 @@ identify similarities and differences in literary texts on similar topics, theme
 *  exploring texts on a similar topic by authors with very different styles; for example, comparing fantasy quest novels or realistic novels on a specific theme
 *  identifying differences in the use of narrator, narrative structure and voice, and language and visual features, between texts and determining how these influence readers or viewers
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9E6LE03
+##### AC9E6LE03 {#ac9e6le03}
 
 identify and explain characteristics that define an author's individual style
 
@@ -137,7 +137,7 @@ identify and explain characteristics that define an author's individual style
 *  focusing on a First Nations Australian author and identifying characteristic elements of their writing; for example, images, theme and language
 *  comparing similarities and differences between texts, including those by the same author or illustrator, and identifying the characteristics that define an author’s style; for example, comparing illustrations in picture books by the same illustrator, noting characteristic features
 
-##### AC9E6LE04
+##### AC9E6LE04 {#ac9e6le04}
 
 explain the way authors use sound and imagery to create meaning and effect in poetry
 
@@ -147,9 +147,9 @@ explain the way authors use sound and imagery to create meaning and effect in po
 *  describing the effects of assonance, alliteration and onomatopoeia in a poem
 *  explaining the effect of rhythm in ballads
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9E6LE05
+##### AC9E6LE05 {#ac9e6le05}
 
 create and edit literary texts that adapt plot structure, characters, settings and/or ideas from texts students have experienced, and experiment with literary devices
 
@@ -158,11 +158,11 @@ create and edit literary texts that adapt plot structure, characters, settings a
 *  creating an autobiography of a character from a text explored
 *  discussing the setting in a literary text with a peer during the editing process, and experimenting with literary devices that may enhance the setting
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9E6LY01
+##### AC9E6LY01 {#ac9e6ly01}
 
 examine texts including media texts that represent ideas and events, and identify how they reflect the context in which they were created
 
@@ -171,9 +171,9 @@ examine texts including media texts that represent ideas and events, and identif
 *  comparing advertising posters for animated children's films in different countries and explaining the impact of these choices on audience expectations of the film
 *  identifying how advertisements for the same products reflect the context in which they were created
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9E6LY02
+##### AC9E6LY02 {#ac9e6ly02}
 
 use interaction skills and awareness of formality when paraphrasing, questioning, clarifying and interrogating ideas, developing and supporting arguments, and sharing and evaluating information, experiences and opinions
 
@@ -182,7 +182,7 @@ use interaction skills and awareness of formality when paraphrasing, questioning
 *  using strategies; for example, pausing, questioning, rephrasing, repeating, summarising, reviewing and asking clarifying questions when discussing topics
 *  recognising that closed questions ask for precise responses while open questions prompt a speaker to provide more information
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 6, students interact with others, and listen to and create spoken and/or multimodal texts including literary texts. For particular purposes and audiences, they share, develop, explain and elaborate on ideas from topics or texts. They use and vary text structures to organise, develop and link ideas. They use and vary language features including topic-specific vocabulary and literary devices, and/or multimodal features and features of voice.
 

--- a/curriculum/english/year-7.md
+++ b/curriculum/english/year-7.md
@@ -1,6 +1,6 @@
-# English - Year 7
+# English - Year 7 {#english-year-7}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -14,13 +14,13 @@ Literary texts that support and extend students in Year 7 as independent readers
 
 Year 7 students create a range of texts whose purposes may be aesthetic, imaginative, reflective, informative, persuasive and/or analytical; for example, narratives, performances, reports, reviews and arguments for different audiences.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9E7LA01
+##### AC9E7LA01 {#ac9e7la01}
 
 understand how language expresses and creates personal and social identities
 
@@ -28,7 +28,7 @@ understand how language expresses and creates personal and social identities
 *  understanding local idioms and discussing their connection with personal and social identities
 *  developing dialogue that reveals character in comics, cartoons and animations
 
-##### AC9E7LA02
+##### AC9E7LA02 {#ac9e7la02}
 
 recognise language used to evaluate texts including visual and multimodal texts, and how evaluations of a text can be substantiated by reference to the text and other sources
 
@@ -37,9 +37,9 @@ recognise language used to evaluate texts including visual and multimodal texts,
 *  analysing how evaluative language can be used to assess the qualities of a narrative or persuasive text; for example, its impact on the reader or the author’s skill in the use of language
 *  recognising how evaluative language is used to critically assess the validity of evidence and the reliability of sources
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9E7LA03
+##### AC9E7LA03 {#ac9e7la03}
 
 identify and describe how texts are structured differently depending on their purpose and how language features vary in texts
 
@@ -48,7 +48,7 @@ identify and describe how texts are structured differently depending on their pu
 *  recognising the social purpose of a persuasive text and how the purpose is reflected in the text structure and by the language features; for example, analysing the structure and language features of advertising posters
 *  describing the structure and language features of literary texts, arguments, discussions, creative and analytical responses to literary texts, films or popular media, and discussing how the structure and language serves the purpose of the text
 
-##### AC9E7LA04
+##### AC9E7LA04 {#ac9e7la04}
 
 understand that the cohesion of texts relies on devices that signal structure and guide readers, such as overviews and initial and concluding paragraphs
 
@@ -56,9 +56,9 @@ understand that the cohesion of texts relies on devices that signal structure an
 *  comparing and analysing the structure of media texts such as digital news sites or print media, identifying strategies used to create cohesion
 *  identifying how authors foreshadow how a text will unfold; for example, identifying the topic sentence, sentence openers and text connectives
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9E7LA05
+##### AC9E7LA05 {#ac9e7la05}
 
 understand how complex and compound-complex sentences can be used to elaborate, extend and explain ideas
 
@@ -67,7 +67,7 @@ understand how complex and compound-complex sentences can be used to elaborate, 
 *  consolidating knowledge of simple, compound and complex sentences, recognising that a simple sentence can express sophisticated ideas and a complex sentence need not express “complex” ideas
 *  examining the addition of ideas using a complex-compound sentence; for example, “When dinosaurs roamed the earth, weather patterns shifted significantly and as a result vegetation depleted.”
 
-##### AC9E7LA06
+##### AC9E7LA06 {#ac9e7la06}
 
 understand how consistency of tense through verbs and verb groups achieves clarity in sentences
 
@@ -75,7 +75,7 @@ understand how consistency of tense through verbs and verb groups achieves clari
 *  identifying and discussing how verb tense is maintained in compound, complex and compound-complex sentences
 *  identifying and discussing different forms of verb tenses and their use to maintain consistency of tense in different sentences; for example, “I organise the cake stall every week, and I am running the meeting this weekend, as well.”
 
-##### AC9E7LA07
+##### AC9E7LA07 {#ac9e7la07}
 
 analyse how techniques such as vectors, angle and/or social distance in visual texts can be used to create a perspective
 
@@ -84,7 +84,7 @@ analyse how techniques such as vectors, angle and/or social distance in visual t
 *  comparing how different advertisements advertise the same product, using techniques to create different perspectives for effect
 *  analysing how the illustrations in picture books, graphic novels and advertisements use size, colour, angle, proximity, vector and salience to influence the reader
 
-##### AC9E7LA08
+##### AC9E7LA08 {#ac9e7la08}
 
 investigate the role of vocabulary in building specialist and technical knowledge, including terms that have both everyday and technical meanings
 
@@ -92,18 +92,18 @@ investigate the role of vocabulary in building specialist and technical knowledg
 *  recognising vocabulary used to represent high utility, abstract academic concepts; for example, “factor”, “hypothesise”, “issue” and “critique”
 *  identifying vocabulary used to write about a topic; for example, using terms for poetic devices and words to explain the effects of the devices in poems
 
-##### AC9E7LA09
+##### AC9E7LA09 {#ac9e7la09}
 
 understand the use of punctuation including colons and brackets to support meaning
 
 **Elaborations**
 *  examining the impact of information added to sentences when colons and brackets are used
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9E7LE01
+##### AC9E7LE01 {#ac9e7le01}
 
 identify and explore ideas, points of view, characters, events and/or issues in literary texts, drawn from historical, social and/or cultural contexts, by First Nations Australian, and wide-ranging Australian and world authors
 
@@ -113,9 +113,9 @@ identify and explore ideas, points of view, characters, events and/or issues in 
 *  exploring representations of characters and events in literary texts by First Nations Australians
 *  exploring depictions of the city or the bush in Australian poems and short stories from different eras
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9E7LE02
+##### AC9E7LE02 {#ac9e7le02}
 
 form an opinion about characters, settings and events in texts, identifying areas of agreement and difference with others’ opinions and justifying a response
 
@@ -123,7 +123,7 @@ form an opinion about characters, settings and events in texts, identifying area
 *  establishing forums and criteria for discussing the relative merits of characters, settings and events in literary texts
 *  comparing personal opinions on texts and justifying responses in discussions which may include referencing behaviours such as integrity and loyalty
 
-##### AC9E7LE03
+##### AC9E7LE03 {#ac9e7le03}
 
 explain the ways that literary devices and language features such as dialogue, and images are used to create character, and to influence emotions and opinions in different types of texts
 
@@ -131,7 +131,7 @@ explain the ways that literary devices and language features such as dialogue, a
 *  comparing the representation of a character’s appearance in a novel and film version of the same text
 *  explaining the impact and significance of language features in a text
 
-##### AC9E7LE04
+##### AC9E7LE04 {#ac9e7le04}
 
 discuss the aesthetic and social value of literary texts using relevant and appropriate metalanguage
 
@@ -139,9 +139,9 @@ discuss the aesthetic and social value of literary texts using relevant and appr
 *  determining criteria for evaluating the aesthetic value of a literary text and share opinions
 *  comparing a film adaptation of a literary text using specific language for naming the text structure, literary devices and language features of film and novels, and sharing opinions about the aesthetic and social value of each
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9E7LE05
+##### AC9E7LE05 {#ac9e7le05}
 
 identify and explain the ways that characters, settings and events combine to create meaning in narratives
 
@@ -149,7 +149,7 @@ identify and explain the ways that characters, settings and events combine to cr
 *  analysing and explaining the structure and features of short stories, discussing the purposes and appeal of different authorial choices for structure
 *  exploring traditional stories from Asia and discussing their features; for example, use of the oral mode, visual elements and verse to convey the narrative
 
-##### AC9E7LE06
+##### AC9E7LE06 {#ac9e7le06}
 
 identify and explain how literary devices create layers of meaning in texts including poetry
 
@@ -157,9 +157,9 @@ identify and explain how literary devices create layers of meaning in texts incl
 *  explaining the sound and rhythm of poetry using metalanguage; for example, “end and internal rhyme”, “meter” and “alliteration”, and discussing how layers of meaning are created
 *  viewing or reading First Nations Australian films, plays and poetry, and explaining the layers of meaning created by imagery
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9E7LE07
+##### AC9E7LE07 {#ac9e7le07}
 
 create and edit literary texts that experiment with language features and literary devices encountered in texts
 
@@ -171,11 +171,11 @@ create and edit literary texts that experiment with language features and litera
 *  experimenting with imagery, sentence variation, metaphor and word choice when creating a literary text
 *  transforming familiar print narratives into short video or film narratives, drawing on knowledge of the type of text and possible adaptations to setting for a new mode
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9E7LY01
+##### AC9E7LY01 {#ac9e7ly01}
 
 explain the effect of current technology on reading, creating and responding to texts including media texts
 
@@ -184,9 +184,9 @@ explain the effect of current technology on reading, creating and responding to 
 *  analysing the impact of interactive elements of digital texts on texts such as magazines read in a digital form
 *  identifying changes in topics considered to be newsworthy as a result of technological change
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9E7LY02
+##### AC9E7LY02 {#ac9e7ly02}
 
 use interaction skills when discussing and presenting ideas and information including evaluations of the features of spoken texts
 
@@ -197,9 +197,9 @@ use interaction skills when discussing and presenting ideas and information incl
 *  choosing vocabulary and sentence structures for purposes and audiences, adapting language choices to meet the perceived audience needs
 *  ensuring that ways of communicating for particular audiences are acknowledged
 
-#### Analysing, interpreting and evaluating 
+#### Analysing, interpreting and evaluating  {#analysing-interpreting-and-evaluating}
 
-##### AC9E7LY03
+##### AC9E7LY03 {#ac9e7ly03}
 
 analyse the ways in which language features shape meaning and vary according to audience and purpose
 
@@ -207,14 +207,14 @@ analyse the ways in which language features shape meaning and vary according to 
 *  explaining the relationship between language features, and audience and purpose, such as identifying which group would be the most likely target audience for the information in an advertisement and justifying why
 *  examining depictions of the histories and cultures of First Nations Australians, discussing language features that shape meaning
 
-##### AC9E7LY04
+##### AC9E7LY04 {#ac9e7ly04}
 
 explain the structure of ideas such as the use of taxonomies, cause and effect, extended metaphors and chronology
 
 **Elaborations**
 *  identifying cause and effect in explanations and how these are used to convince an audience of a course of action
 
-##### AC9E7LY05
+##### AC9E7LY05 {#ac9e7ly05}
 
 use comprehension strategies such as visualising, predicting, connecting, summarising, monitoring, questioning and inferring to analyse and summarise information and ideas
 
@@ -223,9 +223,9 @@ use comprehension strategies such as visualising, predicting, connecting, summar
 *  analysing visual features including choice of image, colour, composition and font in covers of different editions of books when predicting the tone of a text
 *  determining and summarising the key idea(s) of paragraphs and chapters in an extended text
 
-#### Creating texts
+#### Creating texts {#creating-texts}
 
-##### AC9E7LY06
+##### AC9E7LY06 {#ac9e7ly06}
 
 plan, create, edit and publish written and multimodal texts, selecting subject matter, and using text structures, language features, literary devices and visual features as appropriate to convey information, ideas and opinions in ways that may be imaginative, reflective, informative, persuasive and/or analytical
 
@@ -235,7 +235,7 @@ plan, create, edit and publish written and multimodal texts, selecting subject m
 *  editing for meaning by removing unnecessary repetition, reordering sentences and varying sentence structures to refine ideas, adding or substituting words for impact, and reviewing accuracy of grammar, spelling and punctuation
 *  tracking a word-processed document to jointly edit texts
 
-##### AC9E7LY07
+##### AC9E7LY07 {#ac9e7ly07}
 
 plan, create, rehearse and deliver presentations for purposes and audiences in ways that may be imaginative, reflective, informative, persuasive and/or analytical, by selecting text structures, language features, literary devices and visual features, and using features of voice including volume, tone, pitch and pace
 
@@ -245,15 +245,15 @@ plan, create, rehearse and deliver presentations for purposes and audiences in w
 *  monitoring ideas developed at each stage of creating a presentation in a blog or journal
 *  sharing feedback with a peer while planning, creating and rehearsing a presentation
 
-#### Word knowledge
+#### Word knowledge {#word-knowledge}
 
-##### AC9E7LY08
+##### AC9E7LY08 {#ac9e7ly08}
 
 understand how to use spelling rules and word origins; for example, Greek and Latin roots, base words, suffixes, prefixes and spelling patterns to learn new words and how to spell them
 
 **Elaborations**
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 7, students interact with others, and listen to and create spoken and/or multimodal texts including literary texts. With different purposes and for audiences, they discuss, express and expand ideas with evidence. They adopt text structures to organise, develop and link ideas. They adopt language features including literary devices, and/or multimodal features and features of voice.
 

--- a/curriculum/english/year-8.md
+++ b/curriculum/english/year-8.md
@@ -1,6 +1,6 @@
-# English - Year 8
+# English - Year 8 {#english-year-8}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -14,13 +14,13 @@ Literary texts that support and extend students in Year 8 as independent readers
 
 Year 8 students create a range of texts whose purposes may be aesthetic, imaginative, reflective, informative, persuasive and/or analytical; for example, narratives, performances, reports and discussions, literary analyses and reviews for different audiences.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9E8LA01
+##### AC9E8LA01 {#ac9e8la01}
 
 recognise how language shapes relationships and roles
 
@@ -28,16 +28,16 @@ recognise how language shapes relationships and roles
 *  understanding that group identities are formed through language that reflects shared values, beliefs and behaviours, and through language choices that engender solidarity such as specialist terminology, acronyms and terms of address; for example, teenage groups and sportspeople have adopted particular words and ways of communicating
 *  exploring the Australian Institute of Aboriginal and Torres Strait Islander Studies Map of Indigenous Australia and identifying language names that inform relationships to Country/Place
 
-##### AC9E8LA02
+##### AC9E8LA02 {#ac9e8la02}
 
 understand how layers of meaning can be created when evaluating by using literary devices such as simile and metaphor
 
 **Elaborations**
 *  identifying how authors use rhetorical devices that reveal the dark or serious aspects of a topic in humorous or amusing ways; for example, by making a statement but implying or meaning the opposite (irony), exaggerating or overstating something (hyperbole), imitating or mocking something (parody), and making something appear less serious than it really is (understatement)
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9E8LA03
+##### AC9E8LA03 {#ac9e8la03}
 
 explain how texts are structured depending on their purpose and how language features vary, recognising that some texts are hybrids that combine different genres or elements of different genres
 
@@ -46,16 +46,16 @@ explain how texts are structured depending on their purpose and how language fea
 *  discussing how the placement of images and written text in a linear or non-linear way, such as online texts, is used differently in a variety of texts for a purpose
 *  explaining the structure and language features of texts such as narratives, literary recounts, memoirs, drama scripts, types of poems, formal speeches, comparisons and creative responses, discussions and debates, and explaining how these structures and language features support their purpose
 
-##### AC9E8LA04
+##### AC9E8LA04 {#ac9e8la04}
 
 understand how cohesion in texts is improved by strengthening the internal structure of paragraphs with examples, quotations and substantiation of claims
 
 **Elaborations**
 *  writing paragraphs of extended length that explain, substantiate and exemplify a particular viewpoint
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9E8LA05
+##### AC9E8LA05 {#ac9e8la05}
 
 examine a variety of clause structures including embedded clauses that add information and expand ideas in sentences
 
@@ -63,7 +63,7 @@ examine a variety of clause structures including embedded clauses that add infor
 *  evaluating how speechmakers influence audiences though embedded clauses to add information
 *  exploring how clauses and embedded clauses can be used to express ideas more succinctly
 
-##### AC9E8LA06
+##### AC9E8LA06 {#ac9e8la06}
 
 understand the effect of nominalisation in texts
 
@@ -71,14 +71,14 @@ understand the effect of nominalisation in texts
 *  highlighting examples of nominalisation in a range of texts including informative texts and explaining the impact on content and tone
 *  nominalising relevant verbs in a series of sentences and discussing the impact of the change in tone on potential audiences
 
-##### AC9E8LA07
+##### AC9E8LA07 {#ac9e8la07}
 
 investigate how visual texts use intertextual references to enhance and layer meaning
 
 **Elaborations**
 *  identifying intertextual references in advertisements and discussing their impact on layering meaning; for example, the interrelationship of words and images
 
-##### AC9E8LA08
+##### AC9E8LA08 {#ac9e8la08}
 
 identify and use vocabulary typical of academic texts
 
@@ -86,18 +86,18 @@ identify and use vocabulary typical of academic texts
 *  identifying the vocabulary of academic report writing on a topic; for example, the use of words such as “evidence”, “consequence”, “contradiction” and “acknowledge” for the topic “sustainability”
 *  comparing and contrasting vocabulary choices in academic texts, considering how they are used to create precise information or convey abstract ideas
 
-##### AC9E8LA09
+##### AC9E8LA09 {#ac9e8la09}
 
 understand and use punctuation conventions including semicolons and dashes to extend ideas and support meaning
 
 **Elaborations**
 *  creating dialogue in drama showing interruptions, asides and pauses for effect
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9E8LE01
+##### AC9E8LE01 {#ac9e8le01}
 
 explain the ways that ideas and points of view may represent the values of individuals and groups in literary texts, drawn from historical, social and cultural contexts, by First Nations Australian, and wide-ranging Australian and world authors
 
@@ -106,9 +106,9 @@ explain the ways that ideas and points of view may represent the values of indiv
 *  explaining attitudes and ideas about the natural world in literary texts drawn from contexts different to their own
 *  explaining the ways texts by First Nations Australian authors represent unique ways of being, knowing, thinking and doing
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9E8LE02
+##### AC9E8LE02 {#ac9e8le02}
 
 share opinions about the language features, literary devices and text structures that contribute to the styles of literary texts
 
@@ -116,7 +116,7 @@ share opinions about the language features, literary devices and text structures
 *  comparing reviews of a literary text and evaluating opinions that challenge or support personal opinions
 *  reflecting on and evaluating opinions and arguments about aspects of literary texts including characterisation, setting and plot
 
-##### AC9E8LE03
+##### AC9E8LE03 {#ac9e8le03}
 
 explain how language and/or images in texts position readers to respond and form viewpoints
 
@@ -124,16 +124,16 @@ explain how language and/or images in texts position readers to respond and form
 *  discussing how a complex picture book combines words and images to position readers to respond
 *  sharing opinions about how a film positions the viewer to respond to a character
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9E8LE04
+##### AC9E8LE04 {#ac9e8le04}
 
 identify intertextual references in literary texts and explain how the references enable new understanding of the aesthetic quality of the text
 
 **Elaborations**
 *  identifying intertextual references through allusion or quotation in written texts and discussing how knowledge of other texts influences the reader’s understanding and appreciation
 
-##### AC9E8LE05
+##### AC9E8LE05 {#ac9e8le05}
 
 analyse how language features such as sentence patterns create tone, and literary devices such as imagery create meaning and effect
 
@@ -142,9 +142,9 @@ analyse how language features such as sentence patterns create tone, and literar
 *  examining how writers use terse and relatively simple language choices or more elaborate and complex syntax, and how these influence meaning
 *  recognising that First Nations Australian authors use words and language to set tone when writing or speaking about specific themes; for example, words used to set the tone when writing or speaking about Country/Place
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9E8LE06
+##### AC9E8LE06 {#ac9e8le06}
 
 create and edit literary texts that experiment with language features and literary devices for particular purposes and effects
 
@@ -154,11 +154,11 @@ create and edit literary texts that experiment with language features and litera
 *  collaborating with a peer, which may include using online spaces, to write a short script with 2 characters, focusing on dialogue choices for each character
 *  editing the imagery and word choices when creating a literary text and reflecting on the effect of those changes
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9E8LY01
+##### AC9E8LY01 {#ac9e8ly01}
 
 identify how texts reflect contexts
 
@@ -166,9 +166,9 @@ identify how texts reflect contexts
 *  identifying and explaining how social media texts reflect the context in which they are created
 *  identifying how speeches for reconciliation reflect the context in which they are created
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9E8LY02
+##### AC9E8LY02 {#ac9e8ly02}
 
 use interaction skills for identified purposes and situations, including when supporting or challenging the stated or implied meanings of spoken texts in presentations or discussion
 
@@ -177,9 +177,9 @@ use interaction skills for identified purposes and situations, including when su
 *  listening to a conversation or speech, identifying the point being made, and explaining the tone and manner of presentation
 *  using effective strategies for dialogue and discussion in range of formal and informal contexts, including speaking clearly and coherently and at appropriate length, asking questions about stated and implied ideas, and restating and summarising main ideas
 
-#### Analysing, interpreting and evaluating 
+#### Analysing, interpreting and evaluating  {#analysing-interpreting-and-evaluating}
 
-##### AC9E8LY03
+##### AC9E8LY03 {#ac9e8ly03}
 
 analyse and evaluate the ways that language features vary according to the purpose and audience of the text, and the ways that sources and quotations are used in a text
 
@@ -187,7 +187,7 @@ analyse and evaluate the ways that language features vary according to the purpo
 *  evaluating an author's use of language features to present an opinion about those features
 *  evaluating the use of sources and quotations and presenting an opinion about how an author has supported an idea
 
-##### AC9E8LY04
+##### AC9E8LY04 {#ac9e8ly04}
 
 analyse how authors organise ideas to develop and shape meaning
 
@@ -197,7 +197,7 @@ analyse how authors organise ideas to develop and shape meaning
 *  exploring texts that attempt to solve problems in a particular way; for example, organising information by considering strengths as well as problems that arise from an approach
 *  analysing how the organisation of a webpage shapes its meaning
 
-##### AC9E8LY05
+##### AC9E8LY05 {#ac9e8ly05}
 
 use comprehension strategies such as visualising, predicting, connecting, summarising, monitoring, questioning and inferring to interpret and evaluate ideas in texts
 
@@ -206,9 +206,9 @@ use comprehension strategies such as visualising, predicting, connecting, summar
 *  determining and applying criteria for evaluating the content of a website; for example, criteria for content and website purpose and its effectiveness
 *  analysing the selection and composition of an image in a text and evaluating its effect on the credibility of the story
 
-#### Creating texts
+#### Creating texts {#creating-texts}
 
-##### AC9E8LY06
+##### AC9E8LY06 {#ac9e8ly06}
 
 plan, create, edit and publish written and multimodal texts, organising and expanding ideas, and selecting text structures, language features, literary devices and visual features for purposes and audiences in ways that may be imaginative, reflective, informative, persuasive and/or analytical
 
@@ -218,7 +218,7 @@ plan, create, edit and publish written and multimodal texts, organising and expa
 *  editing for accuracy of grammar, spelling and punctuation, and for meaning by experimenting with different order of ideas, a range of sentence structures, literary devices and vocabulary to clarify meaning for academic texts where appropriate
 *  using conceptual maps or journals to plan and reflect on each stage of creating a written or multimodal text
 
-##### AC9E8LY07
+##### AC9E8LY07 {#ac9e8ly07}
 
 plan, create, rehearse and deliver spoken and multimodal presentations for audiences and purposes, selecting language features, literary devices, visual features and features of voice to suit formal or informal situations, and organising and developing ideas in texts in ways that may be imaginative, reflective, informative, persuasive and/or analytical
 
@@ -228,9 +228,9 @@ plan, create, rehearse and deliver spoken and multimodal presentations for audie
 *  selecting features of voice, such as tone, volume, pitch and pace, with particular attention to the effects these may have on audience reaction and acceptance of the ideas presented
 *  collaborating with peers to develop a persuasive advertising campaign about a contemporary issue
 
-#### Word knowledge
+#### Word knowledge {#word-knowledge}
 
-##### AC9E8LY08
+##### AC9E8LY08 {#ac9e8ly08}
 
 apply learnt knowledge to spell accurately and to learn new words
 
@@ -238,7 +238,7 @@ apply learnt knowledge to spell accurately and to learn new words
 *  understanding the different ways complex words are constructed, and drawing on morphemic knowledge and knowledge of unusual letter combinations when spelling these words
 *  understanding where to obtain the spelling of Aboriginal language words and Torres Strait Islander language words; for example, the Australian Institute of Aboriginal and Torres Strait Islander Studies Map of Indigenous Australia, and the local First Nations Australian community
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8, students interact with others, and listen to and create spoken and/or multimodal texts including literary texts. With different purposes and for audiences, they discuss, express and elaborate on ideas with supporting evidence. They select and vary text structures to organise, develop and link ideas. They select and vary language features including literary devices, and/or multimodal features and features of voice.
 

--- a/curriculum/english/year-9.md
+++ b/curriculum/english/year-9.md
@@ -1,6 +1,6 @@
-# English - Year 9
+# English - Year 9 {#english-year-9}
 
-## Level Description
+## Level Description {#level-description}
 
 The English curriculum is built around the 3 interrelated strands of _Language, Literature_ and _Literacy_. Together, the 3 strands focus on developing students’ knowledge, understanding and skills in listening, reading, viewing, speaking, writing and creating. Learning in English is recursive and cumulative, building on concepts, skills and processes developed in earlier years.
 
@@ -14,13 +14,13 @@ Literary texts that support and extend students in Year 9 as independent readers
 
 Year 9 students create a range of texts whose purposes may be aesthetic, imaginative, reflective, informative, persuasive, analytical and/or critical; for example, narratives, performances, reports, discussions, literary analyses, arguments, transformations of texts and reviews for a range of audiences.
 
-## Strands
+## Strands {#strands}
 
-### Language
+### Language {#language}
 
-#### Language for interacting with others
+#### Language for interacting with others {#language-for-interacting-with-others}
 
-##### AC9E9LA01
+##### AC9E9LA01 {#ac9e9la01}
 
 recognise how language empowers relationships and roles
 
@@ -28,16 +28,16 @@ recognise how language empowers relationships and roles
 *  identifying the various communities to which students belong and how language reinforces membership of these communities; for example, the intimate language of family members, the jargon of teenage groups, the technicality of some online communities, the language specific to recreational groups and the interaction patterns of the classroom
 *  exploring language used by First Nations Australian authors to reinforce relationships to Country/Place and with others; for example, “Hello” in Turrabul language is “Galang nguruindhau”
 
-##### AC9E9LA02
+##### AC9E9LA02 {#ac9e9la02}
 
 understand how evaluation can be expressed directly and indirectly using devices such as allusion, evocative vocabulary and metaphor
 
 **Elaborations**
 *  comparing texts that use evaluative language in different ways; for example, print advertisements, editorials, talkback radio, podcasts and poetry, and identifying wording that appraises indirectly through evocative language, similes and metaphors that direct readers’ views in particular ways
 
-#### Text structure and organisation
+#### Text structure and organisation {#text-structure-and-organisation}
 
-##### AC9E9LA03
+##### AC9E9LA03 {#ac9e9la03}
 
 examine how authors adapt and subvert text structures and language features by experimenting with spoken, written, visual and multimodal elements, and their combination
 
@@ -45,30 +45,30 @@ examine how authors adapt and subvert text structures and language features by e
 *  comparing the use of linear and non-linear narratives in a range of short stories, and determining the purpose and effect of the different structures
 *  comparing the opening paragraphs of different public texts such as feature articles, and determining the purpose and effect of the different structures and language features
 
-##### AC9E9LA04
+##### AC9E9LA04 {#ac9e9la04}
 
 investigate a range of cohesive devices that condense information in texts, including nominalisation, and devices that link, expand and develop ideas, including text connectives
 
 **Elaborations**
 *  sequencing and developing an argument using language structures that suggest conclusions (“therefore”, “moreover” and “so”) or give reasons (“since”, “because”) or suggest conditionals (“if … then”)
 
-#### Language for expressing and developing ideas
+#### Language for expressing and developing ideas {#language-for-expressing-and-developing-ideas}
 
-##### AC9E9LA05
+##### AC9E9LA05 {#ac9e9la05}
 
 identify how authors vary sentence structures creatively for effects, such as intentionally using a dependent clause on its own or a sentence fragment
 
 **Elaborations**
 *  identifying the effects of using an interrupting clause inside another clause; for example, “His friend, who had left home the previous year, suddenly returned.”, intentionally using a dependent clause on its own; for example, “If you see what I mean.” or using a sentence fragment; for example, “Breathtaking!”
 
-##### AC9E9LA06
+##### AC9E9LA06 {#ac9e9la06}
 
 understand how abstract nouns and nominalisation can be used to summarise ideas in text
 
 **Elaborations**
 *  exploring sections of academic and technical texts, and analysing the use of abstract nouns; for example, “the previous argument”, “the prologue”, to summarise and distil information, structure the argument and summarise preceding explanations
 
-##### AC9E9LA07
+##### AC9E9LA07 {#ac9e9la07}
 
 analyse how symbols in still and moving images augment meaning
 
@@ -76,7 +76,7 @@ analyse how symbols in still and moving images augment meaning
 *  investigating the use of symbols; for example, specific seasons, weather and colours in images, films and picture books, and evaluating their contribution to viewers’ understanding, recognising that visual and verbal symbols have different meanings for different groups and cultures
 *  understanding the use of symbols by First Nations Australians, where a symbol may have many meanings or have different meanings across First Nations Australian groups; for example, artwork enables First Nations Australians from a particular Country/Place to identify symbols and interpret the artwork
 
-##### AC9E9LA08
+##### AC9E9LA08 {#ac9e9la08}
 
 analyse how vocabulary choices contribute to style, mood and tone
 
@@ -84,18 +84,18 @@ analyse how vocabulary choices contribute to style, mood and tone
 *  identifying the words used to create nuanced meaning; for example, identifying the words that create a sarcastic tone in a text
 *  identifying how the vocabulary used in a text contributes to its stylistic effectiveness
 
-##### AC9E9LA09
+##### AC9E9LA09 {#ac9e9la09}
 
 understand punctuation conventions for referencing and citing others for formal and informal purposes
 
 **Elaborations**
 *  understanding who to and how to cite in essays, reviews and academic assignments, and when it is appropriate to use direct quotations or to report sources more generally
 
-### Literature
+### Literature {#literature}
 
-#### Literature and contexts
+#### Literature and contexts {#literature-and-contexts}
 
-##### AC9E9LE01
+##### AC9E9LE01 {#ac9e9le01}
 
 analyse the representations of people and places in literary texts, drawn from historical, social and cultural contexts, by First Nations Australian, and wide-ranging Australian and world authors
 
@@ -104,32 +104,32 @@ analyse the representations of people and places in literary texts, drawn from h
 *  exploring how texts by First Nations Australian authors reflect unique ways of being, knowing, thinking and doing
 *  exploring the way wide-ranging Australian novels, poems and films represent water and characters’ relationships with water
 
-#### Engaging with and responding to literature
+#### Engaging with and responding to literature {#engaging-with-and-responding-to-literature}
 
-##### AC9E9LE02
+##### AC9E9LE02 {#ac9e9le02}
 
 present a personal response to a literary text comparing initial impressions and subsequent analysis of the whole text
 
 **Elaborations**
 *  interrogating and making judgements about a text, comparing others’ ideas against the student’s own and reaching an independent decision or consensus about the interpretations and ideas expressed
 
-##### AC9E9LE03
+##### AC9E9LE03 {#ac9e9le03}
 
 analyse how features of literary texts influence readers’ preference for texts
 
 **Elaborations**
 *  reflecting on and discussing responses to literature including characterisation, setting details, plot events, themes and literary devices used to achieve particular effects, and collaboratively formulating a list of factors that distinguish value
 
-#### Examining literature
+#### Examining literature {#examining-literature}
 
-##### AC9E9LE04
+##### AC9E9LE04 {#ac9e9le04}
 
 analyse texts and evaluate the aesthetic qualities and appeal of an author’s literary style
 
 **Elaborations**
 *  comparing texts created by the same author to determine literary style, assessing their appeal and presenting comparisons to others
 
-##### AC9E9LE05
+##### AC9E9LE05 {#ac9e9le05}
 
 analyse the effect of text structures, language features and literary devices such as extended metaphor, metonymy, allegory, symbolism and intertextual references
 
@@ -137,9 +137,9 @@ analyse the effect of text structures, language features and literary devices su
 *  examining how different authors make use of devices such as imagery, and explaining the effect of these choices on audiences
 *  identifying examples of literary devices in a range of poems and considering how they contribute to meaning and influence the emotional responses of the audience
 
-#### Creating literature
+#### Creating literature {#creating-literature}
 
-##### AC9E9LE06
+##### AC9E9LE06 {#ac9e9le06}
 
 create and edit literary texts, that may be a hybrid, that experiment with text structures, language features and literary devices for purposes and audiences
 
@@ -148,11 +148,11 @@ create and edit literary texts, that may be a hybrid, that experiment with text 
 *  adapting traditional and contemporary literature through textual intervention, prequel or sequel
 *  editing by checking for run-on sentences, ensuring that detail or repetition is used for effect, and ensuring paragraphs are linked in ways that develop the narrative
 
-### Literacy
+### Literacy {#literacy}
 
-#### Texts in context
+#### Texts in context {#texts-in-context}
 
-##### AC9E9LY01
+##### AC9E9LY01 {#ac9e9ly01}
 
 analyse how representations of people, places, events and concepts reflect contexts
 
@@ -161,9 +161,9 @@ analyse how representations of people, places, events and concepts reflect conte
 *  identifying and analysing how news is conveyed in texts; for example, analysing representations of an event at a particular time reported in the media
 *  comparing texts from different time periods and analysing the language features used to represent individuals or groups
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9E9LY02
+##### AC9E9LY02 {#ac9e9ly02}
 
 listen to spoken texts that have different purposes and audiences, analysing how language features position listeners to respond in particular ways, and use interacting skills to present and discuss opinions regarding these texts
 
@@ -171,9 +171,9 @@ listen to spoken texts that have different purposes and audiences, analysing how
 *  discussing how stereotypes are created through language and how they position listeners to respond
 *  using effective strategies for dialogue and discussion in a range of formal and informal contexts, including speaking clearly and coherently and for an appropriate length of time, presenting an opinion and listening to the opinions of others
 
-#### Analysing, interpreting and evaluating 
+#### Analysing, interpreting and evaluating  {#analysing-interpreting-and-evaluating}
 
-##### AC9E9LY03
+##### AC9E9LY03 {#ac9e9ly03}
 
 analyse and evaluate how language features are used to represent a perspective of an issue, event, situation, individual or group
 
@@ -182,7 +182,7 @@ analyse and evaluate how language features are used to represent a perspective o
 *  explaining how authors use language features to represent ideas and convey opinions
 *  comparing a range of advocacy, campaign or inspirational speeches from films or media and identifying language features that influence the listener
 
-##### AC9E9LY04
+##### AC9E9LY04 {#ac9e9ly04}
 
 analyse the organisation of ideas in paragraphs and extended texts, and evaluate its impact on meaning
 
@@ -190,7 +190,7 @@ analyse the organisation of ideas in paragraphs and extended texts, and evaluate
 *  evaluating techniques used in texts to organise ideas and evoke emotional responses, such as comparison, contrast, exaggeration, juxtaposition, the changing of chronological order, and the expansion and compression of time
 *  explaining whether the author conveys meaning effectively, through the sequence of information and evidence
 
-##### AC9E9LY05
+##### AC9E9LY05 {#ac9e9ly05}
 
 use comprehension strategies such as visualising, predicting, connecting, summarising, monitoring, questioning and inferring to compare and contrast ideas and opinions in and between texts
 
@@ -199,9 +199,9 @@ use comprehension strategies such as visualising, predicting, connecting, summar
 *  comparing the representation of an event in print and digital sources, summarising their qualities, identifying opinions and analysing evidence
 *  summarising articles representing a current event comparing and contrasting ideas and opinions in and between texts
 
-#### Creating texts
+#### Creating texts {#creating-texts}
 
-##### AC9E9LY06
+##### AC9E9LY06 {#ac9e9ly06}
 
 plan, create, edit and publish written and multimodal texts, organising, expanding and developing ideas, and selecting text structures, language features, literary devices and multimodal features for purposes and audiences in ways that may be imaginative, reflective, informative, persuasive, analytical and/or critical
 
@@ -211,7 +211,7 @@ plan, create, edit and publish written and multimodal texts, organising, expandi
 *  reviewing and editing their own and others’ texts, which may involve using online applications, for accuracy of grammar, spelling and punctuation, and to achieve particular purposes and address specific audiences by improving clarity and control of content through organising, developing, extending and linking ideas
 *  discussing choices of literary devices used in a literary text with a peer, and evaluating the potential effect of each choice on an audience
 
-##### AC9E9LY07
+##### AC9E9LY07 {#ac9e9ly07}
 
 plan, create, rehearse and deliver spoken and multimodal presentations for purpose and audience, using language features, literary devices and features of voice such as volume, tone, pitch and pace, and organising, expanding and developing ideas in ways that may be imaginative, reflective, informative, persuasive, analytical and/or critical
 
@@ -221,9 +221,9 @@ plan, create, rehearse and deliver spoken and multimodal presentations for purpo
 *  choosing text structures and adapting literary devices such as similes, metaphors and personification to meet the perceived needs of an audience when debating a topic, creating a voiceover for a media presentation or presenting a seminar
 *  collaborating with peers to develop imaginative recreations of part of a text or to represent a key idea in a text
 
-#### Word knowledge
+#### Word knowledge {#word-knowledge}
 
-##### AC9E9LY08
+##### AC9E9LY08 {#ac9e9ly08}
 
 understand how spelling is used in texts for particular effects; for example, characterisation, humour and to represent accents and distinctive speech
 
@@ -231,7 +231,7 @@ understand how spelling is used in texts for particular effects; for example, ch
 *  exploring the spelling of neologisms and their effect in media texts such as online posts; for example, “selfie” and “Paralympics”
 *  analysing how spelling is used to represent the distinctive speech of a character by noting where authors have dropped letters from words to emulate the sound of spoken words
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 9, students interact with others, and listen to and create spoken and multimodal texts including literary texts. With a range of purposes and for audiences, they discuss and expand on ideas, shaping meaning and providing substantiation. They select and experiment with text structures to organise and develop ideas. They select and experiment with language features including literary devices, and experiment with multimodal features and features of voice.
 

--- a/curriculum/hass-civics-and-citizenship/year-10.md
+++ b/curriculum/hass-civics-and-citizenship/year-10.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Civics and Citizenship 7-10 - Year 10
+# Civics and Citizenship - Year 10 {#civics-and-citizenship-year-10}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 10, students compare Australia’s federal system of government with another system of government in a country in Asia. Students examine Australia’s roles and responsibilities within the international context, such as its involvement with the United Nations and responses to global issues. Students also study the purpose and work of the High Court. They examine how rights are protected in Australia, and investigate the values and practices that enable a democratic society to be sustained. Students reflect on their rights, privileges and responsibilities as active and informed citizens.
 
@@ -12,13 +12,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   What are the features of a resilient democracy?
 *   How does Australia respond to emerging global issues?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Government and democracy
+#### Government and democracy {#government-and-democracy}
 
-##### AC9HC10K01
+##### AC9HC10K01 {#ac9hc10k01}
 
 the key features and values of Australia’s system of government compared with at least one other democratic or non-democratic system of government in the Asia-Pacific region
 
@@ -27,7 +27,7 @@ the key features and values of Australia’s system of government compared with 
 *  researching and comparing the experiences of First Nations Australians in engaging with the political system with those of the Indigenous peoples in an Asian nation
 *  exploring and reflecting on the cultural influences shaping the Australian political system and that of a comparison country
 
-##### AC9HC10K02
+##### AC9HC10K02 {#ac9hc10k02}
 
 the Australian Government’s role and responsibilities at a regional and global level
 
@@ -39,9 +39,9 @@ the Australian Government’s role and responsibilities at a regional and global
 *  identifying ways that the forces of global interconnectedness could both exacerbate and enhance the ability to solve the key issues of our time
 *  evaluating the impacts of these issues on Australia’s identity; First Nations Australians’ reconciliation, truth-telling and sovereignty; Australian government policies and citizens’ choices to act in the global interest
 
-#### Laws and citizens
+#### Laws and citizens {#laws-and-citizens}
 
-##### AC9HC10K03
+##### AC9HC10K03 {#ac9hc10k03}
 
 the role of the parliament and the High Court of Australia in protecting rights under the Constitution, common law, and through federal and state statute law
 
@@ -51,7 +51,7 @@ the role of the parliament and the High Court of Australia in protecting rights 
 *  <p>investigating understanding of terra nullius and how the <em>Native Title Act 1993</em> property rights were developed through High Court interpretation of common law and enshrined in statutory law</p>
 *  comparing the effectiveness of a constitutional bill of rights, such as in the USA, with a statutory bill of rights, such as in New Zealand
 
-##### AC9HC10K04
+##### AC9HC10K04 {#ac9hc10k04}
 
 how Australia’s international legal obligations shape Australian law and government policies, including those relating to First Nations Australians, and the issues related to the application of these obligations
 
@@ -60,9 +60,9 @@ how Australia’s international legal obligations shape Australian law and gover
 *  explaining how international conventions and declarations, such as the Declaration on the Rights of Indigenous Peoples, have shaped Australian government law and policies with regards to First Nations Australians
 *  analysing Australia’s legal obligations to the environment under the Paris Agreement (2016) and the World Heritage Convention (1972), and/or to refugees under the Convention Relating to the Status of Refugees (1951) and its optional protocol (1967)
 
-#### Citizenship, diversity and identity
+#### Citizenship, diversity and identity {#citizenship-diversity-and-identity}
 
-##### AC9HC10K05
+##### AC9HC10K05 {#ac9hc10k05}
 
 the challenges to and ways of sustaining a resilient democracy and a cohesive society in Australia and/or in our region or globally
 
@@ -72,11 +72,11 @@ the challenges to and ways of sustaining a resilient democracy and a cohesive so
 *  locating and discussing a range of possible threats to the resilience of democratic societies globally, such as extreme polarisation of views and a breakdown in social consensus, and the reasons for the rise of non-democratic forces such as extremist groups with no commitment to democratic values
 *  examining how our Western democratic heritage and values such as freedom of speech support participation in public debate about controversial issues; for example, the date of Australia Day, the Uluru Statement, reconciliation and truth-telling, or the call for a treaty between First Nations Australians and the Australian Government
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HC10S01
+##### AC9HC10S01 {#ac9hc10s01}
 
 develop and modify questions to investigate Australia’s political and legal systems, and contemporary civic issues
 
@@ -84,7 +84,7 @@ develop and modify questions to investigate Australia’s political and legal sy
 *  developing a range of sub-questions connected to the over-arching question and using these to modify the question; for example, “How does the system of government provide equality?”, “How representative is the government?”, “What processes ensure accountability?” and “How accessible is the government to citizens?”
 *  revisiting the questions based on further collection of information; for example, “Do different groups in society have particular views on representativeness, equality and accountability?”
 
-##### AC9HC10S02
+##### AC9HC10S02 {#ac9hc10s02}
 
 locate, select and compare information, data and ideas from a range of sources
 
@@ -94,9 +94,9 @@ locate, select and compare information, data and ideas from a range of sources
 *  exploring traditional and social media texts for stereotypes, over-generalisation and misrepresentation, such as those related to how cultural groups such as recent immigrants are represented in the media
 *  comparing the varying policies of different political groups on an issue such as mining, climate change, services for rural communities, or refugees
 
-#### Analysis, evaluation and interpretation
+#### Analysis, evaluation and interpretation {#analysis-evaluation-and-interpretation}
 
-##### AC9HC10S03
+##### AC9HC10S03 {#ac9hc10s03}
 
 analyse information, data and ideas about political, legal or civic issues to identify and evaluate differences in perspectives and interpretations
 
@@ -105,18 +105,18 @@ analyse information, data and ideas about political, legal or civic issues to id
 *  examining the role of institutions of global governance, such as the United Nations or the International Criminal Court, and evaluating their effectiveness in upholding democratic norms and human rights
 *  investigating a contemporary international event or situation, such as armed conflict, development of an international agreement, or natural or humanitarian disaster, to assess the effectiveness and values positions of global actors such as NGOs, and the response of the Australian Government to the event or situation
 
-#### Civic participation and decision-making
+#### Civic participation and decision-making {#civic-participation-and-decision-making}
 
-##### AC9HC10S04
+##### AC9HC10S04 {#ac9hc10s04}
 
 evaluate the methods or strategies and outcomes related to making decisions about civic participation
 
 **Elaborations**
 *  examining the methods or strategies used by the Australian government, a non-government organisation, or a campaigning or pressure group, to address an issue at a regional or global level, or to ensure accountability to Australia's international obligations
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HC10S05
+##### AC9HC10S05 {#ac9hc10s05}
 
 create descriptions, explanations and arguments using civics and citizenship knowledge, concepts and terms that incorporate evidence
 
@@ -124,7 +124,7 @@ create descriptions, explanations and arguments using civics and citizenship kno
 *  developing an evidence-based argument about a civics and citizenship issue, such as the role of Australia in the security of the Asia-Pacific region or the role of Australia’s trading relationships with nations that have human rights issues, and drawing conclusions about the future impacts of this issue on Australia’s values
 *  using terms and concepts such as “conventions”, “international law”, “cohesive society” and “global citizen”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 10, students compare the key features and values of Australia’s system of government to those of another system of government. They describe the Australian Government’s role and responsibilities at a regional and global level. They explain the role of the High Court of Australia. They explain how Australia’s international legal obligations influence the law and government policy. They identify and explain challenges to a resilient democracy and a cohesive society in Australia.
 

--- a/curriculum/hass-civics-and-citizenship/year-6.md
+++ b/curriculum/hass-civics-and-citizenship/year-6.md
@@ -1,4 +1,0 @@
-
-## Achievement Standards
-
-

--- a/curriculum/hass-civics-and-citizenship/year-7.md
+++ b/curriculum/hass-civics-and-citizenship/year-7.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Civics and Citizenship 7-10 - Year 7
+# Civics and Citizenship - Year 7 {#civics-and-citizenship-year-7}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 7, students study the key features of democracy and Australia’s federal system of government, and explore how values shape our democracy. Students learn about the key features and principles of Australia’s legal system. They look at how the rights of individuals are protected through the legal system, which aims to provide justice. Students also explore how Australia’s secular system of government supports a diverse society with shared values that promote community cohesion.
 
@@ -11,13 +11,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How do features of Australian democracy and the legal system uphold and enact democratic values?
 *   How is Australia a diverse society and what factors contribute to a cohesive society?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Government and democracy
+#### Government and democracy {#government-and-democracy}
 
-##### AC9HC7K01
+##### AC9HC7K01 {#ac9hc7k01}
 
 the key features of Australia's system of government, including democracy, the Australian Constitution, responsible government and federalism
 
@@ -27,7 +27,7 @@ the key features of Australia's system of government, including democracy, the A
 *  exploring key democratic concepts, including popular sovereignty, representation, accountability and a partial separation of powers through the election of members of a legislative branch who answer to the people and from whom the executive branch is drawn
 *  investigating Australia as a federation with a division of powers and responsibilities between Commonwealth and state/territory governments
 
-##### AC9HC7K02
+##### AC9HC7K02 {#ac9hc7k02}
 
 the characteristics of Australia's democracy, including freedom of speech, association, assembly, religion and movement
 
@@ -38,9 +38,9 @@ the characteristics of Australia's democracy, including freedom of speech, assoc
 *  identifying characteristics of formal citizenship and the attributes of active citizenship, and identifying who has been included and excluded from the rights and freedoms of citizenship in Australia, particularly in relation to First Nations Australians
 *  examining the active citizenship of First Nations Australians such as Neville Bonner, Adam Goodes, Noel Pearson, Murundoo Yanner, Charles Mene, Ellie Gaffney, Evelyn Scott and Pat O'Shane, and their contributions to the rights and freedoms of Australian First Nations Peoples
 
-#### Laws and citizens
+#### Laws and citizens {#laws-and-citizens}
 
-##### AC9HC7K03
+##### AC9HC7K03 {#ac9hc7k03}
 
 the key principles and features of the Australian legal system, including the Australian Constitution, the rule of law and the court system
 
@@ -52,9 +52,9 @@ the key principles and features of the Australian legal system, including the Au
 *  discussing the elements of a “fair trial”, including citizens’ roles as witnesses and jurors, legal representation and due process
 *  exploring how Australians can receive access to justice and can apply for legal representation, such as through legal aid
 
-#### Citizenship, diversity and identity
+#### Citizenship, diversity and identity {#citizenship-diversity-and-identity}
 
-##### AC9HC7K04
+##### AC9HC7K04 {#ac9hc7k04}
 
 how Australia’s secular democracy and pluralist, multi-faith society draws upon diverse cultural origins, including Christian and Western heritage, distinct First Nations Australian histories and cultures, and migrant communities
 
@@ -65,7 +65,7 @@ how Australia’s secular democracy and pluralist, multi-faith society draws upo
 *  exploring the diversity of spiritualities among First Nations Australian communities, from traditional spirituality to the adoption of other religions such as Christianity and Islam
 *  appreciating the cultural and historical foundations of Australia's Christian heritage and their impact on Australia’s political and legal systems
 
-##### AC9HC7K05
+##### AC9HC7K05 {#ac9hc7k05}
 
 how values based on freedom, respect, fairness and equality of opportunity can support social cohesion and democracy within Australian society
 
@@ -77,11 +77,11 @@ how values based on freedom, respect, fairness and equality of opportunity can s
 *  identifying Christian traditions and values that have influenced the development of Australian society, democracy and law, including the impacts upon First Nations Australian communities and other groups within Australian society
 *  identifying the values and beliefs of religions practised in contemporary Australia, such as Judaism, Buddhism, Islam and Hinduism
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HC7S01
+##### AC9HC7S01 {#ac9hc7s01}
 
 develop questions to investigate Australia’s political and legal systems, and contemporary civic issues
 
@@ -89,7 +89,7 @@ develop questions to investigate Australia’s political and legal systems, and 
 *  developing a key question related to a specific investigation; for example, “What is the ‘rule of law’ and how does it apply to Australia’s legal system?” or “How does Australia’s federal system of government divide powers between states and territories?”
 *  using current events to generate questions that apply to the wider investigation; for example, “How is Australians’ freedom of expression protected and limited in cases of incorrect information being published or distributed?”
 
-##### AC9HC7S02
+##### AC9HC7S02 {#ac9hc7s02}
 
 locate, select and organise information, data and ideas from different sources
 
@@ -99,9 +99,9 @@ locate, select and organise information, data and ideas from different sources
 *  identifying key findings from specialist sources, such as reports into Australia’s legal system by the Australian Law Reform Commission or state/territory commissions and committees
 *  selecting and organising information from different sources, such as media reports, online publications and government websites, on the basis of similarity and relevance to the topic
 
-#### Analysis, evaluation and interpretation
+#### Analysis, evaluation and interpretation {#analysis-evaluation-and-interpretation}
 
-##### AC9HC7S03
+##### AC9HC7S03 {#ac9hc7s03}
 
 analyse information, data and ideas about political, legal or civic issues to identify and explain differences in perspectives and potential challenges
 
@@ -109,9 +109,9 @@ analyse information, data and ideas about political, legal or civic issues to 
 *  examining online publications to find examples of how the system of government protects respect for human rights and the rule of law, and compare these examples with other publications that have different perspectives or challenge these views
 *  evaluating data from surveys or reports to draw conclusions about a current issue of challenge; for example, a Lowy Institute poll on important issues facing Australia or media reports on the effectiveness of the court system
 
-#### Civic participation and decision-making
+#### Civic participation and decision-making {#civic-participation-and-decision-making}
 
-##### AC9HC7S04
+##### AC9HC7S04 {#ac9hc7s04}
 
 explain the methods or strategies related to making decisions about civic participation
 
@@ -120,9 +120,9 @@ explain the methods or strategies related to making decisions about civic partic
 *  identifying the core responsibilities of active citizenship and evaluating how the contributions of Australian citizens enacting democratic values demonstrate active citizenship and contribute to creating a cohesive society; for example, disability advocacy services or Landcare Australia groups
 *  identifying and explaining the features of methods or strategies used by citizens and groups to achieve democratic and just outcomes, such as social media campaigns, letters, petitions, participating in mediation or tribunals, or taking direct action
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HC7S05
+##### AC9HC7S05 {#ac9hc7s05}
 
 create descriptions, explanations and arguments using civics and citizenship knowledge, concepts and terms that reference evidence
 
@@ -131,7 +131,7 @@ create descriptions, explanations and arguments using civics and citizenship kno
 *  presenting ideas and information appropriate to purpose and audience; for example, to develop digital material promoting participation in Australia’s democracy or written material presenting a case for a constitutional change
 *  presenting an argument using appropriate terms and concepts such as “rule of law”, “separation of powers” or “secular nation”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 7, students describe the key features of Australia's system of government, and the principles and features of the Australian legal system. They explain the characteristics of Australian democracy. Students describe the nature of Australian society, its cultural and religious diversity, and identify the values that support cohesion in Australian society.
 

--- a/curriculum/hass-civics-and-citizenship/year-8.md
+++ b/curriculum/hass-civics-and-citizenship/year-8.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Civics and Citizenship 7-10 - Year 8
+# Civics and Citizenship - Year 8 {#civics-and-citizenship-year-8}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 8, students understand how citizens can actively participate in Australia’s political system, the role and impact of elections, and the ways political parties, interest groups, media and individuals influence government and decision-making processes. Students consider how laws are made and the types of laws used in Australia. Students also examine what it means to be Australian by identifying the reasons for and influences that shape national identity, and how this contributes to active citizenship.
 
@@ -11,13 +11,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How are laws made and applied in Australia?
 *   What different perspectives are there about national identity?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Government and democracy
+#### Government and democracy {#government-and-democracy}
 
-##### AC9HC8K01
+##### AC9HC8K01 {#ac9hc8k01}
 
 how Australians are informed about and participate in democracy
 
@@ -29,7 +29,7 @@ how Australians are informed about and participate in democracy
 *  explaining how citizens’ understanding of issues, policies and political choices are shaped and can contribute to active and informed citizenship, including the influence of the media and social media, political parties, interest groups and election campaigns
 *  examining a range of strategies used to influence citizens’ electoral choices, such as public debate, media and social media, opinion polls and political consulting firms, advertising, interest groups and political party campaigns
 
-##### AC9HC8K02
+##### AC9HC8K02 {#ac9hc8k02}
 
 the role of political parties and independent representatives in Australian democracy, including elections and the formation of governments
 
@@ -39,9 +39,9 @@ the role of political parties and independent representatives in Australian demo
 *  understanding how government is formed and may be lost, through discussing concepts such as parliamentary majority, the opposition, hung parliament, minority government, party discipline and balance of power
 *  investigating the roles of political parties and elected representatives, including independents
 
-#### Laws and citizens
+#### Laws and citizens {#laws-and-citizens}
 
-##### AC9HC8K03
+##### AC9HC8K03 {#ac9hc8k03}
 
 the characteristics of laws and how laws are made in Australia through parliaments (statutory law) and through the courts (common law)
 
@@ -52,7 +52,7 @@ the characteristics of laws and how laws are made in Australia through parliamen
 *  identifying the 2 chief sources of law (parliament and the courts) and analysing a case study of statute and common law
 *  examining the relationship between parliament and the courts
 
-##### AC9HC8K04
+##### AC9HC8K04 {#ac9hc8k04}
 
 the types of law in Australia, including criminal law and civil law, and the place of First Nations Australian customary law
 
@@ -62,9 +62,9 @@ the types of law in Australia, including criminal law and civil law, and the pla
 *  examining the significance of customary law for First Nations Australians through selected case studies
 *  evaluating the opportunities and limitations of Native Title law for First Nations Australians
 
-#### Citizenship, diversity and identity
+#### Citizenship, diversity and identity {#citizenship-diversity-and-identity}
 
-##### AC9HC8K05
+##### AC9HC8K05 {#ac9hc8k05}
 
 how culture and religion may influence individuals' and groups' perceptions and expressions of citizenship and their actions as citizens
 
@@ -73,7 +73,7 @@ how culture and religion may influence individuals' and groups' perceptions and 
 *  exploring the collective identities of several different groups in Australia’s multicultural society, and how these identities might be represented and perceived
 *  discussing the differences between legal citizenship, active citizenship and global citizenship
 
-##### AC9HC8K06
+##### AC9HC8K06 {#ac9hc8k06}
 
 different experiences of, perspectives on and debates about Australia’s national identity and citizenship, including the perspectives of First Nations Australians as owners of their respective nations, and of different migrant groups
 
@@ -85,11 +85,11 @@ different experiences of, perspectives on and debates about Australia’s nation
 *  examining the types of questions asked in the citizenship test and exploring how these questions reflect our national identity
 *  discussing how the national anthem contributes to our national identity
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HC8S01
+##### AC9HC8S01 {#ac9hc8s01}
 
 develop questions to investigate Australia’s political and legal systems, and contemporary civic issues
 
@@ -98,7 +98,7 @@ develop questions to investigate Australia’s political and legal systems, and 
 *  developing a range of closed and open-ended questions about a particular topic or issue; for example, “What are the main features of a democracy?”, “How are laws made?” and “What is the relationship between democracy and active citizenship?"
 *  considering current events to generate ideas for research; for example, how Australian governments have developed media and communications campaigns on public health issues to reach the culturally and linguistically diverse groups in Australia, why media coverage of the National Agreement on Closing the Gap reflects changing perspectives on Australia's national identity
 
-##### AC9HC8S02
+##### AC9HC8S02 {#ac9hc8s02}
 
 locate, select and organise information, data and ideas from different sources
 
@@ -107,9 +107,9 @@ locate, select and organise information, data and ideas from different source
 *  selecting information from a range of sources by applying understandings of accuracy and reliability to the selection of information
 *  organising the ideas in different sources, such as opinion pieces, information from political parties, government reports and reports from independent organisations, by identifying bias, language choices and selective use of information
 
-#### Analysis, evaluation and interpretation
+#### Analysis, evaluation and interpretation {#analysis-evaluation-and-interpretation}
 
-##### AC9HC8S03
+##### AC9HC8S03 {#ac9hc8s03}
 
 analyse information, data and ideas about political, legal or civic issues to identify and explain differences in perspectives and potential challenges
 
@@ -119,9 +119,9 @@ analyse information, data and ideas about political, legal or civic issues to id
 *  examining letters to the editor about current issues, and identifying and explaining the differences of opinion
 *  identifying and explaining possible reasons for the difference in perspectives about a civics and citizenship issue, such as marriage equality
 
-#### Civic participation and decision-making
+#### Civic participation and decision-making {#civic-participation-and-decision-making}
 
-##### AC9HC8S04
+##### AC9HC8S04 {#ac9hc8s04}
 
 explain the methods or strategies related to making decisions about civic participation
 
@@ -129,9 +129,9 @@ explain the methods or strategies related to making decisions about civic partic
 *  describing how active citizenship strategies may contribute to an informed and positive change, and to building a democratically cohesive society; for example, stopping whaling, reducing carbon emissions
 *  explaining the links between democratic societies, active citizenship and global citizenship at national, regional and global levels, and methods used to take civic action; for example, citizens who protest against militaristic and authoritarian regimes and/or abuses of human rights in other societies
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HC8S05
+##### AC9HC8S05 {#ac9hc8s05}
 
 create descriptions, explanations and arguments using civics and citizenship knowledge, concepts and terms that reference evidence
 
@@ -139,7 +139,7 @@ create descriptions, explanations and arguments using civics and citizenship kno
 *  persuading the public on a contemporary issue or about a need for action, using evidence; for example, to argue the case for a constitutional change or an advertisement promoting participation in Australia’s democracy
 *  using appropriate terms and concepts such as “freedoms”, “responsibilities”, “common law”, “statutory law” and “customary law”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8, students explain how Australians are informed about and participate in their democracy. They describe the roles of political parties and elected representatives in Australian government. They explain the characteristics of laws, how laws are made and the types of law in Australia. Students identify ways in which Australians express different aspects of their identity and explain perspectives on Australia’s national identity.
 

--- a/curriculum/hass-civics-and-citizenship/year-9.md
+++ b/curriculum/hass-civics-and-citizenship/year-9.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Civics and Citizenship 7-10 - Year 9
+# Civics and Citizenship - Year 9 {#civics-and-citizenship-year-9}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 9, students further develop their understanding of Australia’s federal system of government and how it enables change. Students investigate the features and jurisdictions of Australia’s court system, including its role in applying and interpreting Australian law. They also examine global connectedness and how this is shaping contemporary Australian society and global citizenship.
 
@@ -10,13 +10,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How does Australia's court system work in support of a democratic and just society?
 *   How do citizens participate in an interconnected world?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Government and democracy
+#### Government and democracy {#government-and-democracy}
 
-##### AC9HC9K01
+##### AC9HC9K01 {#ac9hc9k01}
 
 the role of the Australian Constitution in providing the basis for Australia’s federal system of government and democratic processes, including institutions, and the process for constitutional change through a referendum
 
@@ -26,7 +26,7 @@ the role of the Australian Constitution in providing the basis for Australia’s
 *  investigating the extent to which the Constitution upholds and enables democratic institutions and processes, including a constitutional monarchy, a federal parliamentary system with elected legislatures, protection of states’ rights and individual rights, and representation of the interests of all Australians
 *  <p>assessing the effectiveness of the process of constitutional change and the degree to which it supports popular sovereignty through examining selected referendum proposals; for example, the successful vote on the <em>Constitution Alteration (Aboriginals) 1967</em> or the unsuccessful vote on the <em>Constitution Alteration (Establishment of Republic) 1999</em></p>
 
-##### AC9HC9K02
+##### AC9HC9K02 {#ac9hc9k02}
 
 the legislative processes through which federal government policy is shaped, developed and implemented
 
@@ -35,9 +35,9 @@ the legislative processes through which federal government policy is shaped, dev
 *  charting the process of development of a policy from initial idea to enacted legislation
 *  using a specific federal policy to understand and analyse the influences on policy formulation and implementation, such as political parties, interest groups, citizens, international influences and the public service
 
-#### Laws and citizens
+#### Laws and citizens {#laws-and-citizens}
 
-##### AC9HC9K03
+##### AC9HC9K03 {#ac9hc9k03}
 
 the key features and jurisdictions of Australia’s court system, and the operations of courts and tribunals
 
@@ -47,7 +47,7 @@ the key features and jurisdictions of Australia’s court system, and the operat
 *  using sample cases to investigate the differences between civil and criminal law, and how the courts apply and interpret criminal laws and resolve civil disputes
 *  exploring how court judgements impact on the development of law; such as the role of statutory interpretation and the creation of precedent; for example, the decision in the Mabo Case (1992) overturned the legal concept of terra nullius and established the concept of native title
 
-##### AC9HC9K04
+##### AC9HC9K04 {#ac9hc9k04}
 
 the role of courts, judges, lawyers and juries in trials, and the rights of the accused and the rights of victims
 
@@ -59,9 +59,9 @@ the role of courts, judges, lawyers and juries in trials, and the rights of the 
 *  investigating potential barriers to equality of access to justice, such as education and literacy, location and proximity to legal avenues, financial constraints, race or ethnicity, especially for First Nations Australians
 *  exploring how legal aid operates and how it contributes to rights of the accused or victims
 
-#### Citizenship, diversity and identity
+#### Citizenship, diversity and identity {#citizenship-diversity-and-identity}
 
-##### AC9HC9K05
+##### AC9HC9K05 {#ac9hc9k05}
 
 how and why individuals and groups, including community, religious and cultural groups, participate in and contribute to civic life in Australia and to global citizenship
 
@@ -70,7 +70,7 @@ how and why individuals and groups, including community, religious and cultural 
 *  researching examples of young people who are acting as global citizens, such as Malala Yousafzai and Greta Thunberg, and Australia’s Amelia Telford, Mackinley Butson and Bassam Maaliki, or UNICEF Australia’s Young Ambassadors
 *  collaborating with peers to plan a citizenship campaign on an issue related to sustainability or climate change
 
-##### AC9HC9K06
+##### AC9HC9K06 {#ac9hc9k06}
 
 the influence of a range of media, including social media, in shaping identity and attitudes to diversity
 
@@ -78,11 +78,11 @@ the influence of a range of media, including social media, in shaping identity a
 *  analysing how media represent different groups in Australian society, such as First Nations Australians, immigrant groups, and male and female sporting figures, and people with disability, and assessing the impact those representations have on community cohesiveness
 *  investigating a human rights campaign that uses social media and how members of the public have engaged with the issue
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HC9S01
+##### AC9HC9S01 {#ac9hc9s01}
 
 develop and modify questions to investigate Australia’s political and legal systems, and contemporary civic issues
 
@@ -90,7 +90,7 @@ develop and modify questions to investigate Australia’s political and legal sy
 *  developing questions about Australia’s political and legal systems; for example, “How democratic is Australia’s system of government?” or “Does Australia’s legal system deliver justice?”
 *  revisiting the questions based on further collection of information; for example, modifying “How democratic is Australia’s system of government” to “How representative is Australia’s system of government?”
 
-##### AC9HC9S02
+##### AC9HC9S02 {#ac9hc9s02}
 
 locate, select and compare information, data and ideas from a range of sources
 
@@ -98,9 +98,9 @@ locate, select and compare information, data and ideas from a range of sources
 *  locating from a range of print and online sources, information, such as statistics, graphs, tables, maps, articles, blogs and advertisements to select relevant information or data about an issue; for example, the development of water policy in the Murray–Darling Basin, an aspect of the COVID-19 pandemic or First Nations Australians’ rights
 *  identifying why some sources and information have greater accuracy and reliability than others
 
-#### Analysis, evaluation and interpretation
+#### Analysis, evaluation and interpretation {#analysis-evaluation-and-interpretation}
 
-##### AC9HC9S03
+##### AC9HC9S03 {#ac9hc9s03}
 
 analyse information, data and ideas about political, legal or civic issues to identify and evaluate differences in perspectives and interpretations
 
@@ -109,9 +109,9 @@ analyse information, data and ideas about political, legal or civic issues to id
 *  examining information that includes a diversity of perspectives about the effectiveness of a political or legal institution; for example, “Is Australia’s parliament representative of the Australian community?” or “Does the court system deliver justice for the victims of crime?”
 *  investigating how the Australian Government responds to an issue and examining the process of policy development and implementation, such as the development of welfare changes and financial support in response to natural disasters or emergencies
 
-#### Civic participation and decision-making
+#### Civic participation and decision-making {#civic-participation-and-decision-making}
 
-##### AC9HC9S04
+##### AC9HC9S04 {#ac9hc9s04}
 
 evaluate the methods or strategies related to making decisions about civic participation
 
@@ -120,9 +120,9 @@ evaluate the methods or strategies related to making decisions about civic parti
 *  developing a plan of action to address a contemporary issue that incorporates a consultation process to ensure a range of views are heard and recorded, and participants are provided with opportunities to contribute; for example, planning a campaign to raise awareness about a personal or road safety issue at a local level; developing a strategy to aid a group in another region or country (a developing nation) with educational resources and opportunities
 *  evaluating the government media campaigns and community supported activities that have been used over time to promote reduction in littering and disposal of waste, and determine if they have been effective
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HC9S05
+##### AC9HC9S05 {#ac9hc9s05}
 
 create descriptions, explanations and arguments using civics and citizenship knowledge, concepts and terms that incorporate evidence
 
@@ -130,7 +130,7 @@ create descriptions, explanations and arguments using civics and citizenship kno
 *  developing an evidence-based argument about a civics and citizenship issue, such as a need to reform youth justice arrangements in a particular jurisdiction
 *  using terms and concepts such as “representative”, “jurisdictions”, “parliamentary majority” and “mandate”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 9, students analyse the role of the Australian Constitution, the federal system of government, and the process and reasons for constitutional change. They explain policy development and legislative processes in Australia’s democracy. Students identify the key features and jurisdictions of Australia’s court system and explain the role and processes of courts and tribunals. Students identify the reasons individuals and groups participate in and contribute to civic life nationally and globally.  They explain the influence of the media on reflections of identity and diversity. 
 

--- a/curriculum/hass-economics-and-business/year-10.md
+++ b/curriculum/hass-economics-and-business/year-10.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Economics and Business 7-10 - Year 10
+# Economics and Business - Year 10 {#economics-and-business-year-10}
 
-## Level Description
+## Level Description {#level-description}
 
 The focus of learning in Year 10 is the topic **"productivity, growth and living standards"** within a national context.
 
@@ -16,11 +16,11 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How does Australia’s superannuation system support human wellbeing, a prosperous economy and the common good?
 *   What factors influence decision-making within consumer and financial contexts, and how are participants impacted?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-##### AC9HE10K01
+##### AC9HE10K01 {#ac9he10k01}
 
 how and why the economic indicators influence economic decision-making
 
@@ -30,7 +30,7 @@ how and why the economic indicators influence economic decision-making
 *  explaining economic objectives of the Australian Government (for example, economic growth, full employment and price stability) and how these have been framed in response to economic indicators (for example, gross domestic product, business sales or earnings, inflation)
 *  identifying an example of an economic indicator, such as employment statistics, and explaining how it influences government economic decision-making; for example, by providing support for new apprenticeships and training places
 
-##### AC9HE10K02
+##### AC9HE10K02 {#ac9he10k02}
 
 the ways that government intervenes in the economy to improve economic performance and living standards within Australian society
 
@@ -40,7 +40,7 @@ the ways that government intervenes in the economy to improve economic performan
 *  explaining how the government may redistribute income to achieve a more equal distribution of income and wealth; for example, income transfers such as pensions, youth allowance and job search, or the provision of services for all such as healthcare and education
 *  investigating the role and function of the Reserve Bank of Australia within the Australian economy
 
-##### AC9HE10K03
+##### AC9HE10K03 {#ac9he10k03}
 
 factors that influence major consumer and financial decisions, and the short- and long-term consequences of these decisions
 
@@ -49,7 +49,7 @@ factors that influence major consumer and financial decisions, and the short- an
 *  analysing factors that influence major consumer and financial decisions, such as price, availability and cost of finance, marketing of products, age and gender of consumer, convenience, and ethical and environmental considerations
 *  identifying the costs of consumer and financial transactions over time, such as the ability to make loan repayments, available savings, depreciation, and maintenance costs and insurance, as well as the benefits such as independence and convenience when purchasing a car or home
 
-##### AC9HE10K04
+##### AC9HE10K04 {#ac9he10k04}
 
 the importance of Australia’s superannuation system and how this system affects consumer and financial decision-making
 
@@ -58,7 +58,7 @@ the importance of Australia’s superannuation system and how this system affect
 *  identifying why individuals make decisions about superannuation investment options and how their circumstances, such as age, employment status, dependents and anticipated retirement age, affect these decisions
 *  explaining how individuals manage a personal superannuation fund; for example, who contributes, taxation, consolidating superannuation funds, finding lost superannuation and tracking the performance of a superannuation account
 
-##### AC9HE10K05
+##### AC9HE10K05 {#ac9he10k05}
 
 processes that businesses use to manage the workforce and improve productivity, including the role of entrepreneurs
 
@@ -69,11 +69,11 @@ processes that businesses use to manage the workforce and improve productivity, 
 *  identifying and explaining strategies that improve productivity; for example, training or upskilling, capital investment, increasing research and development, investment in applications of technologies, use of just-in-time inventory systems or collection, and analysis of data to inform product development or service delivery
 *  explaining how entrepreneurs lead responses to changes in global and domestic economic conditions and use technologies to drive innovation; for example, influencing approaches to waste management or sustainable use of energy
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HE10S01
+##### AC9HE10S01 {#ac9he10s01}
 
 develop and modify questions to investigate a contemporary economic and business issue
 
@@ -81,7 +81,7 @@ develop and modify questions to investigate a contemporary economic and business
 *  developing a range of questions to investigate a complex issue (for example, “Why does the government intervene in the economy to improve living standards?”) or formulating a hypothesis such as “Responding to an upswing in the economy with expansionary measures will improve business productivity”
 *  developing and modifying a range of questions to improve the focus of an investigation; for example, modifying “What factors influence decision-making within consumer and financial contexts?” to “What factors influence choosing a mobile phone plan?”
 
-##### AC9HE10S02
+##### AC9HE10S02 {#ac9he10s02}
 
 locate, select and analyse information and data from a range of sources
 
@@ -92,9 +92,9 @@ locate, select and analyse information and data from a range of sources
 *  explaining assumptions or missing information in sources that may affect the reliability of an opinion about an economic or business issue
 *  selecting and representing information and data about an economic or business issue, using specialised digital tools and processes to support interpretation and analysis; for example, a graphic organiser connecting objectives of the Australian economy with examples of government intervention in the economy
 
-#### Interpreting and analysing
+#### Interpreting and analysing {#interpreting-and-analysing}
 
-##### AC9HE10S03
+##### AC9HE10S03 {#ac9he10s03}
 
 interpret information and data, explaining economic and business issues, trends and economic cause-and-effect relationships, and make predictions about consumer and financial impacts
 
@@ -104,9 +104,9 @@ interpret information and data, explaining economic and business issues, trends 
 *  analysing the causes and effects of an economic issue on individuals or businesses; for example, the reasons for and implications of government intervention in the economy to improve living standards
 *  analysing trends to make predictions about who will be affected and how; for example, trends in productivity and implications for businesses
 
-#### Evaluating, concluding and decision-making
+#### Evaluating, concluding and decision-making {#evaluating-concluding-and-decision-making}
 
-##### AC9HE10S04
+##### AC9HE10S04 {#ac9he10s04}
 
 develop and evaluate a response to an economic and business issue, using cost-benefit analysis or criteria to decide on a course of action
 
@@ -116,9 +116,9 @@ develop and evaluate a response to an economic and business issue, using cost-be
 *  evaluating a response, using criteria such as efficiency, profitability or equity to explain the reasons for a course of action; for example, use of indicators of economic performance to identify variations within the Australian economy
 *  examining the opportunity cost consumers and businesses may have to consider when deciding on a course of action; for example, employing more staff instead of upskilling existing staff to improve productivity
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HE10S05
+##### AC9HE10S05 {#ac9he10s05}
 
 create descriptions, explanations and arguments, using economic and business knowledge, concepts and terms that incorporate and acknowledge and research findings
 
@@ -127,7 +127,7 @@ create descriptions, explanations and arguments, using economic and business kno
 *  explaining decisions and conclusions about a business issue, supported by reasons and representations of data in a range of formats; for example, financial statements or information sheet and research in appropriate formats, such as reports and webpages
 *  presenting an argument for a proposal for action in response to an economic or business issue, applying tone appropriate to purpose; for example, using an authoritative tone when presenting an argument and making predictions about impacts, and audience; for example, a business manager or entrepreneur
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 10, students analyse how economic indicators influence Australian Government decision-making. They explain ways that government intervenes to improve economic performance and living standards. They explain processes that businesses use to manage the workforce and improve productivity. They explain the importance of Australia’s superannuation system and its effect on consumer and financial decision-making.  Students analyse factors that influence major consumer and financial decisions, and explain the short- and long-term effects of these decisions.
 

--- a/curriculum/hass-economics-and-business/year-7.md
+++ b/curriculum/hass-economics-and-business/year-7.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Economics and Business 7-10 - Year 7
+# Economics and Business - Year 7 {#economics-and-business-year-7}
 
-## Level Description
+## Level Description {#level-description}
 
 The focus of learning in Year 7 is the topic **"individuals, businesses and entrepreneurs"** within a personal, community and national context.
 
@@ -14,11 +14,11 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   Why do individuals contribute to their community and how do they derive an income?
 *   Why do consumers and businesses have both rights and responsibilities?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-##### AC9HE7K01
+##### AC9HE7K01 {#ac9he7k01}
 
 why opportunity cost exists as decisions are made to allocate limited resources to meet unlimited needs and wants
 
@@ -29,7 +29,7 @@ why opportunity cost exists as decisions are made to allocate limited resources 
 *  investigating how First Nations communities use exchange systems (barter) or networks (partnerships) to decide about the use of limited resources in sustainable ways
 *  explaining the concept of “opportunity cost” in relation to a choice; for example, if a student chooses to spend their time (resource) riding their bike after school, they cannot go for a swim (trade-off)
 
-##### AC9HE7K02
+##### AC9HE7K02 {#ac9he7k02}
 
 the reasons businesses exist and how different types of businesses provide goods and services
 
@@ -39,7 +39,7 @@ the reasons businesses exist and how different types of businesses provide goods
 *  investigating a business owned by First Nations Australians, exploring the types of goods and services offered and why this business was started
 *  identifying examples of different types of businesses that sell goods and/or services in the local community; for example, a sole proprietor operating a car yard, a partnership providing legal services or a corporation selling groceries through a chain of supermarkets
 
-##### AC9HE7K03
+##### AC9HE7K03 {#ac9he7k03}
 
 characteristics of entrepreneurs and how these influence the success of a business
 
@@ -49,7 +49,7 @@ characteristics of entrepreneurs and how these influence the success of a busine
 *  analysing the influence of values on entrepreneurial decision-making; for example, identifying and taking advantage of an opportunity, negotiating with stakeholders, and complying with the law and regulations
 *  combining knowledge, skills and attitudes demonstrated by entrepreneurs with observations of successful local businesses to explain factors that contribute to success, such as seeing and taking advantage of an opportunity or demonstrating initiative and innovation
 
-##### AC9HE7K04
+##### AC9HE7K04 {#ac9he7k04}
 
 the reasons individuals work, the types of work they are involved in, and how they may derive an income
 
@@ -59,7 +59,7 @@ the reasons individuals work, the types of work they are involved in, and how th
 *  describing examples of how continuity of cultural practices and management of Country/Place contributes to and sustains First Nations communities; for example, regional tourism ventures, coaching and mentoring initiatives, and fostering entrepreneurial and start-up cultures in regional and remote communities
 *  analysing the contribution that work can make to an individual’s identity and role within a community; for example, earning an income, contributing to self-esteem and happiness, supporting the community through volunteering, enhancing material and non-material living standards
 
-##### AC9HE7K05
+##### AC9HE7K05 {#ac9he7k05}
 
 the rights and responsibilities of individuals and businesses in relation to consumer and financial products and services
 
@@ -69,11 +69,11 @@ the rights and responsibilities of individuals and businesses in relation to con
 *  discussing the responsibilities of businesses in relation to consumer and financial products and services, such as the role of mandatory and voluntary standards, and product safety recalls
 *  explaining the importance of developing personal or business budgets or savings plans before making decisions in relation to consumer and financial products and services
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HE7S01
+##### AC9HE7S01 {#ac9he7s01}
 
 develop questions to investigate a contemporary economic and business issue
 
@@ -81,7 +81,7 @@ develop questions to investigate a contemporary economic and business issue
 *  developing questions to form the basis of an investigation; for example, “How does an understanding of consumer rights and responsibilities impact on decision-making?” and “What are the attributes of an entrepreneur?”
 *  developing questions, using economic and business concepts and terms; for example, “How do businesses decide what to produce?”, “What is economic scarcity?” and “Why can individuals not have all the items they want, meaning they must choose?”
 
-##### AC9HE7S02
+##### AC9HE7S02 {#ac9he7s02}
 
 locate, select and organise information and data from a range of sources
 
@@ -91,9 +91,9 @@ locate, select and organise information and data from a range of sources
 *  collaborating and safely exchanging information online with an entrepreneur to identify attributes that built success
 *  organising data into appropriate formats using specialised digital tools, such as tables and graphs, visual displays
 
-#### Interpreting and analysing
+#### Interpreting and analysing {#interpreting-and-analysing}
 
-##### AC9HE7S03
+##### AC9HE7S03 {#ac9he7s03}
 
 interpret information and data to identify economic and business issues, trends and economic cause-and-effect relationships
 
@@ -102,9 +102,9 @@ interpret information and data to identify economic and business issues, trends 
 *  interpreting multi-variable data by using interactive digital tools to identify trends and to answer questions such as “For a 10-year period, to what extent has the number of people in casual work changed?”
 *  interpreting visual displays of multi-variable data to identify a cause-and-effect relationship within an economic and business issue, such as the relationship between income earned by an individual and levels of saving and spending
 
-#### Evaluating, concluding and decision-making
+#### Evaluating, concluding and decision-making {#evaluating-concluding-and-decision-making}
 
-##### AC9HE7S04
+##### AC9HE7S04 {#ac9he7s04}
 
 develop a response to an economic and business issue, identifying potential costs and benefits
 
@@ -114,9 +114,9 @@ develop a response to an economic and business issue, identifying potential cost
 *  identifying the potential costs and benefits of a decision; for example, deciding whether to work part-time involves identifying benefits such as earning money and recognising costs such as time on the weekend devoted to travelling to and from work
 *  explaining how making an economic and business decision involves selecting one alternative over another; for example, to satisfy a particular want, a selection of goods or services is preferred or purchased over another
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HE7S05
+##### AC9HE7S05 {#ac9he7s05}
 
 create descriptions and explanations, using economic and business knowledge, concepts and terms, and referencing information and data from sources
 
@@ -124,7 +124,7 @@ create descriptions and explanations, using economic and business knowledge, con
 *  developing a response to an issue that orients the audience (for example, peers or community members) to the issue, using relevant economic and business concepts and terms such as “market”, “income”, “business”, “goods and services” and “costs and benefits”
 *  explaining ideas and decisions with details and examples, using data and information presented in appropriate formats; for example, visual displays, tables and graphs, or budget and savings plans, and research findings presented in appropriate formats, such as a graphic organiser or summary
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 7, students describe how decisions are made to allocate limited resources to individuals and communities in an economy. They describe the reasons businesses exist and types of businesses, and identify how entrepreneurial characteristics contribute to the success of a business. They describe the reasons individuals choose to work, how they may derive an income and the types of work that exist. Students identify the rights and responsibilities of individuals and businesses in terms of products and services.
 

--- a/curriculum/hass-economics-and-business/year-8.md
+++ b/curriculum/hass-economics-and-business/year-8.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Economics and Business 7-10 - Year 8
+# Economics and Business - Year 8 {#economics-and-business-year-8}
 
-## Level Description
+## Level Description {#level-description}
 
 The focus of learning in Year 8 is the topic **"Australian markets"** within a national context.
 
@@ -15,11 +15,11 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   What is the role of Australia’s taxation system and how does it support individuals and business?
 *   Why are financial planning and budgeting important processes for individuals and businesses?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-##### AC9HE8K01
+##### AC9HE8K01 {#ac9he8k01}
 
 how markets influence decisions about the allocation of resources to the production of goods and services, and the effect of prices on these decisions
 
@@ -29,7 +29,7 @@ how markets influence decisions about the allocation of resources to the product
 *  discussing examples of products or services that sell for high prices and low prices, and identifying the factors that influence the setting of price; for example, factors influencing the cost of petrol include available supply, consumer demand, manufacturing costs and competition
 *  explaining how price is the means by which the decisions of consumers and businesses interact to determine the allocation of resources; for example, when the price of a good or service rises, resources are redirected to produce additional goods and services
 
-##### AC9HE8K02
+##### AC9HE8K02 {#ac9he8k02}
 
 different ways that businesses adapt to opportunities in the market and respond to the changing nature of work
 
@@ -39,7 +39,7 @@ different ways that businesses adapt to opportunities in the market and respond 
 *  explaining current influences on the ways people work; for example, technological change, outsourced labour in the global economy, rapid communication changes, casualisation of the workforce
 *  identifying and explaining changes to the workforce over time; for example, the jobs available, the way individuals or businesses value particular work, career length and human resource development, changing demography, corporate social responsibility, sustainability practices, changes to workplace laws
 
-##### AC9HE8K03
+##### AC9HE8K03 {#ac9he8k03}
 
 how First Nations Australian businesses and entrepreneurs develop opportunities in the market
 
@@ -48,7 +48,7 @@ how First Nations Australian businesses and entrepreneurs develop opportunities 
 *  investigating how First Nations Australian communities participate in contemporary markets; for example, producing, buying and selling goods and services; approaches to marketing, employment and social contribution; and strategies to overcome difficulties in accessing markets
 *  investigating how First Nations Australian businesses and entrepreneurs use connection to, and responsibility for, Country/Place to make innovations in the production and distribution of goods and services; for example, medicines and food derived from the environment or cultural tourism
 
-##### AC9HE8K04
+##### AC9HE8K04 {#ac9he8k04}
 
 the importance of Australia’s system of taxation and how this system affects decision-making by individuals and businesses
 
@@ -59,7 +59,7 @@ the importance of Australia’s system of taxation and how this system affects d
 *  identifying examples of taxes paid by individuals and businesses, and explaining how they may influence decision-making about spending; for example, the effect of income tax, import duties or excise duties on price of goods and services
 *  explaining how the collection of taxes and the provision of services supports individual human and financial wellbeing, communities and Australian society
 
-##### AC9HE8K05
+##### AC9HE8K05 {#ac9he8k05}
 
 processes that individuals and/or businesses use to plan and budget to achieve short-term and long-term financial objectives
 
@@ -68,11 +68,11 @@ processes that individuals and/or businesses use to plan and budget to achieve s
 *  explaining how financial records, such as income statements, balance sheets, budgets and cash flow statements, inform business decision-making
 *  identifying and explaining business processes that are used to manage finances and plan in the short- and long-term; for example, devising a business plan, borrowing from a financial institution, building savings by earning interest
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HE8S01
+##### AC9HE8S01 {#ac9he8s01}
 
 develop questions to investigate a contemporary economic and business issue
 
@@ -80,7 +80,7 @@ develop questions to investigate a contemporary economic and business issue
 *  developing a range of questions to form the basis of an investigation; for example, “Why does an individual or group establish a business?” and “How are consumers’ rights protected?”
 *  developing targeted or key questions using economics and business concepts and terms, such as, “How is the price of goods and services determined?” and “Why do changes in market price act as a signal about how scarce resources should be allocated?”
 
-##### AC9HE8S02
+##### AC9HE8S02 {#ac9he8s02}
 
 locate, select and organise information and data from a range of sources
 
@@ -89,9 +89,9 @@ locate, select and organise information and data from a range of sources
 *  selecting relevant information and data from sources about websites of government departments or non-government organisations by asking questions such as “How will the data or information help answer the question?”
 *  organising data into appropriate formats using specialised digital tools; for example, constructing a diagram modelling the relationship between consumers, producers and workers in a market or a table showing the features of different ways businesses adapt to opportunities in the market
 
-#### Interpreting and analysing
+#### Interpreting and analysing {#interpreting-and-analysing}
 
-##### AC9HE8S03
+##### AC9HE8S03 {#ac9he8s03}
 
 interpret information and data to identify economic and business issues, trends and economic cause-and-effect relationships
 
@@ -100,9 +100,9 @@ interpret information and data to identify economic and business issues, trends 
 *  interpreting data displayed in tables and graphs to identify trends and answer questions such as, “For a 10-year period, what is the trend in the percentage of people over 60 paying income tax?”
 *  interpreting multi-variable data to identify a cause-and-effect relationship within an economic and business issue; for example, an increase in income earned by an individual and taxation paid, or when the supply of a good and service increases, the price adjusts
 
-#### Evaluating, concluding and decision-making
+#### Evaluating, concluding and decision-making {#evaluating-concluding-and-decision-making}
 
-##### AC9HE8S04
+##### AC9HE8S04 {#ac9he8s04}
 
 develop a response to an economic and business issue, identifying potential costs and benefits
 
@@ -112,9 +112,9 @@ develop a response to an economic and business issue, identifying potential cost
 *  identifying the potential costs and benefits of a decision; for example, doing casual work involves identifying benefits such as money earned, and costs such as less certainty about work hours each week
 *  explaining that making an economic and business decision involves choice and foregoing an alternative want; for example, the goods and/or services they must forgo or give up in order to satisfy a particular want
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HE8S05
+##### AC9HE8S05 {#ac9he8s05}
 
 create descriptions and explanations, using economic and business knowledge, concepts and terms, and referencing information and data from sources
 
@@ -122,7 +122,7 @@ create descriptions and explanations, using economic and business knowledge, con
 *  developing a response to an issue that orients the audience (for example, peers or community groups) to the issue, using relevant economic and business concepts and terms such as “markets”, “business”, “consumer and financial decision-making” and “taxation”
 *  creating a description or explanation using data or information presented in appropriate formats to support decisions and conclusions about an economic and business issue
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8, students explain how markets influence the allocation of resources to the production of goods and services. They explain ways that businesses adapt to opportunities in markets and respond to the work environment. They describe the importance of Australia’s taxation system and its effect on decision-making by individuals and businesses. Students explain why individuals and/or businesses budget and plan.
 

--- a/curriculum/hass-economics-and-business/year-9.md
+++ b/curriculum/hass-economics-and-business/year-9.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Economics and Business 7-10 - Year 9
+# Economics and Business - Year 9 {#economics-and-business-year-9}
 
-## Level Description
+## Level Description {#level-description}
 
 The focus of learning in Year 9 is the topic **"international trade and interdependence"** within a global context, including trade with the countries of Asia.
 
@@ -16,11 +16,11 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How does creating and maintaining a competitive advantage benefit businesses?
 *   What processes can be used to manage financial risks and rewards?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-##### AC9HE9K01
+##### AC9HE9K01 {#ac9he9k01}
 
 the role of Australia’s financial sector and its effect on economic decision-making by individuals, businesses and global markets
 
@@ -31,7 +31,7 @@ the role of Australia’s financial sector and its effect on economic decision-m
 *  explaining the forces that shape and affect Australia’s financial landscape, such as financial deregulations, technological changes, economic and business activities, and consumer and business sentiment about the future
 *  identifying examples and explaining how Australia’s financial sector supports businesses in global markets; for example, the nature of global financial services, payment systems – clearing and settlement, access to currencies, insurance and capital
 
-##### AC9HE9K02
+##### AC9HE9K02 {#ac9he9k02}
 
 how economic decision-making involves the interdependence of consumers, businesses, the financial sector and government
 
@@ -41,7 +41,7 @@ how economic decision-making involves the interdependence of consumers, business
 *  analysing the implications of interdependence within the global economy for Australian consumers, workers and businesses; for example, costs of the product or service and impacts of disruption or changes to regulations in another country
 *  identifying examples and explaining how changes to a nation’s economic conditions affects other nations; for example, rising unemployment affects consumer demand in one country and impacts the exports of goods and services in another country
 
-##### AC9HE9K03
+##### AC9HE9K03 {#ac9he9k03}
 
 the reasons Australia trades with other nations, and the patterns of trade between Australia and Asia
 
@@ -52,7 +52,7 @@ the reasons Australia trades with other nations, and the patterns of trade betwe
 *  identifying similarities and differences or trends in the composition and direction of trade between Australia and Asia now and 50 years ago
 *  explaining the interdependent nature of trade between Australia and the countries of Asia
 
-##### AC9HE9K04
+##### AC9HE9K04 {#ac9he9k04}
 
 processes that businesses use to create and maintain competitive advantage, including the role of entrepreneurs
 
@@ -64,7 +64,7 @@ processes that businesses use to create and maintain competitive advantage, incl
 *  explaining processes that businesses use to produce goods and services at a lower cost, such as research and development; improving efficiency in development, production or delivery processes; utilising local resources, and outsourced labour in the global economy
 *  explaining processes that businesses use to innovate and differentiate products and services from competitors; for example, identifiable marketable attributes, and use of advertising and social media
 
-##### AC9HE9K05
+##### AC9HE9K05 {#ac9he9k05}
 
 how individuals and businesses manage consumer and financial risks and rewards
 
@@ -75,11 +75,11 @@ how individuals and businesses manage consumer and financial risks and rewards
 *  identifying and explaining practices used by businesses to protect the safety of consumers; for example, mandatory and voluntary standards, product safety recalls or cooling-off periods
 *  reflecting on the importance of ethical decision-making and corporate social responsibility when making consumer and financial decisions; for example, considering consequences for themselves, their families, the broader community and/or the environment
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HE9S01
+##### AC9HE9S01 {#ac9he9s01}
 
 develop and modify questions to investigate a contemporary economic and business issue
 
@@ -87,7 +87,7 @@ develop and modify questions to investigate a contemporary economic and business
 *  developing questions to investigate a complex issue, such as “How do participants in the global economy interact?” and “Why does international trade benefit Australian society?”
 *  developing and modifying questions to improve the focus of an investigation, using economic and business concepts and terms such as, “How can consumers protect themselves from risk?” and “How do businesses create and maintain a competitive advantage?”
 
-##### AC9HE9S02
+##### AC9HE9S02 {#ac9he9s02}
 
 locate, select and analyse information and data from a range of sources
 
@@ -97,9 +97,9 @@ locate, select and analyse information and data from a range of sources
 *  selecting and analysing information and data for reliability by asking questions such as “How and when was it collected?”, “Who collected the data?” and “For what purpose was the data collected?”
 *  selecting and presenting data in appropriate formats using specialised digital tools and processes; for example, a table and graph showing the composition and direction of trade between Australia and Asia
 
-#### Interpreting and analysing
+#### Interpreting and analysing {#interpreting-and-analysing}
 
-##### AC9HE9S03
+##### AC9HE9S03 {#ac9he9s03}
 
 interpret information and data, explaining economic and business issues, trends and economic cause-and-effect relationships, and make predictions about consumer and financial impacts
 
@@ -109,9 +109,9 @@ interpret information and data, explaining economic and business issues, trends 
 *  explaining relationships between the actions of individuals and businesses; for example, the way businesses operate in the global economy and implications for the Australian market
 *  explaining trends to make predictions about who will be affected and how; for example, the trend for money lost in scams and age groups most affected, and predictions about how it will affect the behaviour of individuals and businesses
 
-#### Evaluating, concluding and decision-making
+#### Evaluating, concluding and decision-making {#evaluating-concluding-and-decision-making}
 
-##### AC9HE9S04
+##### AC9HE9S04 {#ac9he9s04}
 
 develop and evaluate a response to an economic and business issue, using cost-benefit analysis or criteria to decide on a course of action
 
@@ -121,9 +121,9 @@ develop and evaluate a response to an economic and business issue, using cost-be
 *  developing processes that consider the results of a cost-benefit analysis; for example, processes used by businesses to remain competitive in the global market
 *  selecting and justifying a preferred response using criteria such as consideration of consumer and financial risk
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HE9S05
+##### AC9HE9S05 {#ac9he9s05}
 
 create descriptions, explanations and arguments, using economic and business knowledge, concepts and terms that incorporate and acknowledge research findings
 
@@ -132,7 +132,7 @@ create descriptions, explanations and arguments, using economic and business kno
 *  explaining decisions and conclusions related to an economic or business issue supported by representations of relevant data; for example, visual displays, a graphic organiser or tables and graphs, and research in a range of formats such as explanations, procedures or reports
 *  presenting a reasoned argument in relation to an economic or business issue, applying tone appropriate to the purpose; for example, using an authoritative tone when explaining trends in data to an audience such as peers or representatives of a business
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 9, students explain the role of Australia’s financial sector and its effect on economic decision-making by individuals and businesses. They explain the interdependence of participants in the global market and the effect on economic decision-making. They explain the reasons for trade and Australia’s pattern of trade with Asia. They explain why businesses seek to create and maintain a competitive advantage. Students explain how individuals and businesses manage consumer and financial risks and rewards.
 

--- a/curriculum/hass-geography/year-10.md
+++ b/curriculum/hass-geography/year-10.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Geography 7-10 - Year 10
+# Geography - Year 10 {#geography-year-10}
 
-## Level Description
+## Level Description {#level-description}
 
 The Year 10 curriculum involves the study of 2 sub-strands.
 
@@ -18,13 +18,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   What management options exist for sustaining human and natural systems into the future?
 *   How do world views influence decisions on how to manage environmental and social change?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Environmental change and management
+#### Environmental change and management {#environmental-change-and-management}
 
-##### AC9HG10K01
+##### AC9HG10K01 {#ac9hg10k01}
 
 the human-induced changes that challenge the sustainability of places and environments
 
@@ -33,7 +33,7 @@ the human-induced changes that challenge the sustainability of places and en
 *  explaining the nature of human-induced environmental changes (for example, water and atmospheric pollution; loss of biodiversity; degradation of land and aquatic environments) and the challenge they pose for sustainability
 *  discussing the concept of sustainability in relation to environmental functions and identifying tensions between the conflicting perspectives of communities, businesses and government
 
-##### AC9HG10K02
+##### AC9HG10K02 {#ac9hg10k02}
 
 the environmental world views of people and their implications for environmental management
 
@@ -42,7 +42,7 @@ the environmental world views of people and their implications for environm
 *  comparing differences in peoples’ views about the causes of an environmental issue of personal, national and global importance
 *  discussing whether environmental change is necessarily a problem that should be managed and explaining people’s choices of methods for managing or responding to environmental changes
 
-##### AC9HG10K03
+##### AC9HG10K03 {#ac9hg10k03}
 
 First Nations Australians’ approaches to custodial responsibility and environmental management in different regions of Australia
 
@@ -51,7 +51,7 @@ First Nations Australians’ approaches to custodial responsibility and environm
 *  discussing the role of First Nations Australian Park Rangers and their cultural knowledge and practices in the management of their Country/Place and environments
 *  explaining First Nations Australians’ models of sustainability, which contribute to broader conservation practices; for example, obligations to Country/Place, land management and care practices such as cleaning up the land and fire management, removal of weeds and rubbish, protection of threatened species, and capacity building within their communities
 
-##### AC9HG10K04
+##### AC9HG10K04 {#ac9hg10k04}
 
 causes and effects of a change in an identified environment at a local, national or global scale, and strategies to manage sustainability
 
@@ -62,9 +62,9 @@ causes and effects of a change in an identified environment at a local, nationa
 *  comparing management strategies in Australia with strategies in another country for human-induced environmental change, using criteria; for example, managing waste in Australia compared with India’s rubbish pickers or managing floods in Australia compared to floods in China
 *  explaining how Traditional Owners, communities, developers, governments and non-government organisations use environmental, economic and social criteria, and consider trade-offs when making decisions
 
-#### Geographies of human wellbeing
+#### Geographies of human wellbeing {#geographies-of-human-wellbeing}
 
-##### AC9HG10K05
+##### AC9HG10K05 {#ac9hg10k05}
 
 the methods used to measure spatial variations in human wellbeing and development, and how these can be applied to determine differences between places at the global scale
 
@@ -73,7 +73,7 @@ the methods used to measure spatial variations in human wellbeing and developmen
 *  comparing different measurements of human wellbeing (for example, comparing rankings of selected indicators such as Gross Domestic Product [GDP], Human Development Index [HDI] and Physical Quality of Life Index [PQLI] for Australia, India and a country in the Pacific) and explaining trends in the different measurements
 *  interpreting and explaining trends in human wellbeing in a developed country and a developing country over time; for example, Australia compared with a country in Asia or the Pacific
 
-##### AC9HG10K06
+##### AC9HG10K06 {#ac9hg10k06}
 
 reasons for, and consequences of, spatial variations in human wellbeing at a regional and national scale, drawing on studies such as from within India or another country in Asia
 
@@ -83,7 +83,7 @@ reasons for, and consequences of, spatial variations in human wellbeing at a reg
 *  interpreting and analysing spatial data on human wellbeing in India or another country in Asia to identify the regions with high and low levels of human wellbeing, explaining similarities and differences; for example, rural Rajasthan compared to urban Mumbai
 *  interpreting and analysing measures of human wellbeing, such as the Multidimensional Poverty Index (MPI), Press Freedom Index (PFI) and Fragile States Index (FSI), and making inferences about the level of wellbeing at different scales; for example, for child labour and child slaves at the local scale or for Syria or Afghanistan at the national scale
 
-##### AC9HG10K07
+##### AC9HG10K07 {#ac9hg10k07}
 
 reasons for, and consequences of, spatial variations in human wellbeing in Australia, including for First Nations Australians
 
@@ -92,7 +92,7 @@ reasons for, and consequences of, spatial variations in human wellbeing in Austr
 *  interpreting and analysing similarities, differences, patterns and trends in human wellbeing data for communities of First Nations Australians compared to non-Indigenous Australians, and explaining the links between human wellbeing and Closing the Gap initiatives
 *  explaining how a person’s wellbeing is influenced by where they live, with reference to interconnections of environmental, economic, social and technological factors in at least 2 different places in Australia, such as urban and remote places
 
-##### AC9HG10K08
+##### AC9HG10K08 {#ac9hg10k08}
 
 responses of international and national government and non-government organisations to improve human wellbeing in Australia, within India and another country in the Pacific
 
@@ -101,11 +101,11 @@ responses of international and national government and non-government organisati
 *  explaining the objectives and outcomes of an overseas economic and social development program by the Australian Government (for example, AusAID) or a non-government overseas aid program (for example, World Vision) in India or a country in the Pacific
 *  identifying and explaining ways to improve the wellbeing of remote communities of First Nations Australians, including ways proposed by the communities
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching using geographical methods
+#### Questioning and researching using geographical methods {#questioning-and-researching-using-geographical-methods}
 
-##### AC9HG10S01
+##### AC9HG10S01 {#ac9hg10s01}
 
 develop a range of questions for a geographical inquiry related to a phenomenon or challenge
 
@@ -114,7 +114,7 @@ develop a range of questions for a geographical inquiry related to a phenom
 *  developing and modifying questions to sharpen the focus of an investigation using concepts or scale of study; for example, “How are variations in the spatial distribution of human wellbeing measured at the global scale?”, “Why does human wellbeing vary between and within countries?” (national scale), “How would you measure human wellbeing in the local area?” (local scale)
 *  planning an investigation of a phenomenon or challenge being studied at a range of scales, using digital tools; for example, investigating the causes of human-induced climate change at the global scale and its impacts on Australia, Bangladesh and/or a Pacific Island country at the national scale
 
-##### AC9HG10S02
+##### AC9HG10S02 {#ac9hg10s02}
 
 collect, represent and compare data and information from primary research methods, including fieldwork and secondary research materials, using geospatial technologies and digital tools as appropriate
 
@@ -127,9 +127,9 @@ collect, represent and compare data and information from primary research meth
 *  representing multi-variable data using geospatial technologies; for example, using scatterplots to visually represent data for countries to demonstrate the correlation between 2 variables, such as comparing adult literacy with GDP per capita in United Arab Emirates or Bhutan
 *  representing multi-variable data using digital tools; for example, generating pie graphs showing threats to biodiversity; using digital photographs to indicate differences in material goods between people and places, and the influence of environment, culture and income; using tables to measure and compare wellbeing using different indexes and the world gender equality gap
 
-#### Interpreting and analysing geographical data and information
+#### Interpreting and analysing geographical data and information {#interpreting-and-analysing-geographical-data-and-information}
 
-##### AC9HG10S03
+##### AC9HG10S03 {#ac9hg10s03}
 
 evaluate geographical data and information to make generalisations and predictions, explain patterns and trends and infer relationships
 
@@ -138,9 +138,9 @@ evaluate geographical data and information to make generalisations and predictio
 *  explaining patterns and trends; for example, explaining why a vegetation corridor for movement of koalas assists them to traverse through the bush and reduce death rates, or whether there has been an increased use of technology such as satellite images, drones and robots during and after a natural disaster to identify the need for aid
 *  inferring relationships between key environmental indicators and sustainability of places at the national scale; for example, using a geospatial technologies application to create a map of Australia and another country to show measures of environmental change such as air quality, freshwater quality, fish resources, energy use, biodiversity or waste generation
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HG10S04
+##### AC9HG10S04 {#ac9hg10s04}
 
 evaluate data and information to justify conclusions
 
@@ -148,7 +148,7 @@ evaluate data and information to justify conclusions
 *  drawing conclusions using at least 2 concepts, such as place, space, environment, interconnection, sustainability, scale and change as organisers for example discussing the concept of sustainability in relation to human-induced change affecting environments or considering implications of spatial variations in human wellbeing
 *  examining the reasons given for making a specific decision and explain how these reasons have or have not justified the conclusion reached, such as considering the interconnection of environmental, economic, social, political or technological factors when developing strategies to address sustainable management of environments, or unequal access of people to resources essential for human wellbeing
 
-##### AC9HG10S05
+##### AC9HG10S05 {#ac9hg10s05}
 
 develop and evaluate strategies using environmental, economic or social criteria; recommend a strategy and explain the predicted impacts
 
@@ -159,9 +159,9 @@ develop and evaluate strategies using environmental, economic or social criteria
 *  explaining reasons for decisions and choices, such as the traditional use of firestick farming by First Nations Australians to control fires, or grassroots decisions on implementation and effectiveness of aid projects
 *  reflecting on personal values and attitudes and how these influence strategies; for example, applying sustainable design principles to urban redevelopment projects that provide green, open spaces for citizens, or supporting non-government organisations that reflect personal values
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HG10S06
+##### AC9HG10S06 {#ac9hg10s06}
 
 create descriptions, explanations and responses, using geographical knowledge and geographical tools as appropriate, and concepts and terms that incorporate and acknowledge research findings
 
@@ -170,7 +170,7 @@ create descriptions, explanations and responses, using geographical knowledge an
 *  presenting conclusions using geospatial technologies and digital tools to create representations of data (for example, the trends in Human Development Index [HDI] over time in a selected country or region) and research findings (for example, how a person’s wellbeing is influenced by where they live) to explain causes and effects of a geographical phenomenon or challenge, and reinforcing understanding of the interconnections between people, places and the environment
 *  developing an explanation, applying tone appropriate to purpose and audience; for example, using an authoritative tone, and referring to representations of data and information when explaining a strategy to improve the sustainability of an identified environment or action to improve human wellbeing
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 10, students explain how the interactions of people and environmental processes at different scales change the characteristics of places. They explain the effects of human activity on environments, and the effect of environments on human activity, over time. They evaluate the implications of a distribution. They evaluate the extent of interconnections occurring between people and places and environments. They analyse changes that result from these interconnections and their consequences. Students evaluate strategies to address a geographical phenomenon or challenge using environmental, social and economic criteria.
 

--- a/curriculum/hass-geography/year-7.md
+++ b/curriculum/hass-geography/year-7.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Geography 7-10 - Year 7
+# Geography - Year 7 {#geography-year-7}
 
-## Level Description
+## Level Description {#level-description}
 
 The Year 7 curriculum involves the study of 2 sub-strands.
 
@@ -18,13 +18,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How does people’s reliance on places and environments influence their perception of them?
 *   What effect does the uneven distribution of resources and services have on the lives of people?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Water in the world
+#### Water in the world {#water-in-the-world}
 
-##### AC9HG7K01
+##### AC9HG7K01 {#ac9hg7k01}
 
 classification of environmental resources and the way that water connects and changes places as it moves through environments
 
@@ -34,7 +34,7 @@ classification of environmental resources and the way that water connects an
 *  explaining the environmental, economic or social effects of water as it connects places; for example, the environmental effects of water diversion in the Snowy Mountains, the economic effects of irrigation in the Ord River or the social effects of the Mutitjulu Waterhole connecting Australian First Nations Peoples in Central Australia
 *  explaining how moving water changes places; for example, moving water causes soil and rock erosion or cuts valleys into mountains
 
-##### AC9HG7K02
+##### AC9HG7K02 {#ac9hg7k02}
 
 the location and distribution of water resources in Australia, their implications, and strategies to manage the sustainability of water
 
@@ -46,7 +46,7 @@ the location and distribution of water resources in Australia, their implication
 *  examining why water is a difficult resource for communities to manage and sustain; for example, because of its shared and competing uses, and variability of supply over time
 *  examining how a strategy may manage the sustainability of water resources; for example, recycling (“grey water”), stormwater harvesting and re-use, desalination, inter-regional transfer of water and trade in virtual water, and reducing water consumption
 
-##### AC9HG7K03
+##### AC9HG7K03 {#ac9hg7k03}
 
 the economic, cultural, spiritual and aesthetic value of water for people, including First Nations Australians
 
@@ -56,7 +56,7 @@ the economic, cultural, spiritual and aesthetic value of water for people, inclu
 *  examining bays, rivers, waterfalls or lakes in Australia and in countries of Asia that have been listed as either World Heritage sites or national parks for their aesthetic and cultural value
 *  investigating the spiritual significance of water in an Asian culture
 
-##### AC9HG7K04
+##### AC9HG7K04 {#ac9hg7k04}
 
 the causes and impacts of an atmospheric or hydrological hazard, and responses from communities and governments
 
@@ -66,9 +66,9 @@ the causes and impacts of an atmospheric or hydrological hazard, and responses f
 *  identifying examples of responses to a hazard from the community and the government at the local scale, and identifying practices that increased effectiveness
 *  reflecting on the principles of prevention, mitigation and preparedness in responses from the community and the government to explain how the impact of a hazard can be reduced
 
-#### Place and liveability
+#### Place and liveability {#place-and-liveability}
 
-##### AC9HG7K05
+##### AC9HG7K05 {#ac9hg7k05}
 
 factors that influence the decisions people make about where to live, including perceptions of the liveability of places and the influence of environmental quality
 
@@ -78,7 +78,7 @@ factors that influence the decisions people make about where to live, including�
 *  comparing students’ access to and use of places and spaces in their local area, and evaluating how this affects perceptions of liveability
 *  examining the influence of environmental quality on decisions people make about where to live; for example, clean land, air and water, views, recreation facilities and favourable climate
 
-##### AC9HG7K06
+##### AC9HG7K06 {#ac9hg7k06}
 
 the location and distribution of services and facilities, and implications for liveability of places
 
@@ -87,7 +87,7 @@ the location and distribution of services and facilities, and implications for l
 *  explaining the role transport and technologies play in people’s ability to access services and participate in activities in their local area
 *  analysing the distribution of services and facilities in different types of settlements (for example, using aerial images of contrasting places in Australia such as inner and outer suburbs, or rural and remote) to identify implications for people, such as access to services and availability of facilities
 
-##### AC9HG7K07
+##### AC9HG7K07 {#ac9hg7k07}
 
 the cultural connectedness of people to places and how this influences their identity, sense of belonging and perceptions of a place, in particular the cultural connectedness of First Nations Australians to Country/Place
 
@@ -96,7 +96,7 @@ the cultural connectedness of people to places and how this influences their ide
 *  explaining the importance of people being socially connected and the effect on perceptions of liveability
 *  discussing the cultural connectedness and belonging that First Nations Australians have to a number of places through family, Country/Place, dispossession, relocation and employment
 
-##### AC9HG7K08
+##### AC9HG7K08 {#ac9hg7k08}
 
 strategies used to enhance the liveability of a place, including for young people, the aged or those with disability, drawing on studies such as those from Australia or Europe
 
@@ -105,11 +105,11 @@ strategies used to enhance the liveability of a place, including for youn
 *  developing a strategy to improve an aspect of liveability at the local scale, taking into account the needs of diverse groups in the community, including young people (for example, through fieldwork in the local recreation area) or Traditional Owners (for example, developing bilingual signage or garden projects in the local area with First Nations Australians)
 *  evaluating a strategy to improve the liveability of a place using criteria, and deciding on its applicability to their own locality
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching using geographical methods
+#### Questioning and researching using geographical methods {#questioning-and-researching-using-geographical-methods}
 
-##### AC9HG7S01
+##### AC9HG7S01 {#ac9hg7s01}
 
 develop questions for a geographical inquiry related to a phenomenon or challenge
 
@@ -117,7 +117,7 @@ develop questions for a geographical inquiry related to a phenomenon or challeng
 *  developing questions to investigate why a geographical phenomenon has changed or a challenge may arise; for example, the causes of water scarcity in different places, or measuring the liveability of a place and the factors affecting the liveability of a place
 *  planning an investigation of a geographical phenomenon or challenge being studied, using digital planning tools; for example, analysing statistics on variation in water quantity and quality over time in Central Australia, or using fieldwork to survey perceptions of the liveability of a local place
 
-##### AC9HG7S02
+##### AC9HG7S02 {#ac9hg7s02}
 
 collect, organise and represent data and information from primary research methods, including fieldwork and secondary research materials, using geospatial technologies and digital tools as appropriate
 
@@ -127,9 +127,9 @@ collect, organise and represent data and information from primary research m
 *  representing relevant data and information in appropriate formats to combine ideas; for example, applying primary research to the design of a questionnaire or survey on what is meant by liveability, with results presented in a table or graph
 *  representing spatial distribution of different types of geographical phenomena by constructing appropriate maps at different scales that conform to cartographic conventions, for example using computer mapping to show the spatial distribution of impacts of hydrological hazards on environments
 
-#### Interpreting and analysing geographical data and information
+#### Interpreting and analysing geographical data and information {#interpreting-and-analysing-geographical-data-and-information}
 
-##### AC9HG7S03
+##### AC9HG7S03 {#ac9hg7s03}
 
 interpret and analyse geographical data and information to identify similarities and differences, explain patterns and trends and infer relationships
 
@@ -138,9 +138,9 @@ interpret and analyse geographical data and information to identify similarities
 *  explaining patterns and trends; for example, using graphs, weather maps and satellite images to examine the temporal and spatial patterns of a selected hydrological hazard
 *  inferring relationships in data and information collected; for example, using surveys and interviews to identify community attitudes or perceptions about the extent of services and facilities in Australia’s cities compared with remote communities
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HG7S04
+##### AC9HG7S04 {#ac9hg7s04}
 
 draw conclusions based on the analysis of the data and information
 
@@ -148,7 +148,7 @@ draw conclusions based on the analysis of the data and information
 *  drawing on the results of an analysis and using at least one of the concepts of place, space, environment, interconnections, sustainability, scale or change as an organiser to respond to a question; for example, using an analysis of the distribution of water resources to form conclusions about the sustainability of farming, or an analysis of the location of services to form conclusions about interconnections between people, place, environment and liveability
 *  explaining the impacts of a geographical phenomenon or challenge on people, places and environments; for example, impacts of water scarcity on individuals, communities and government, or the impacts of declining water quality on people and the liveability of places
 
-##### AC9HG7S05
+##### AC9HG7S05 {#ac9hg7s05}
 
 identify a strategy for action in relation to environmental, economic, social or other factors, and explain potential impacts
 
@@ -157,9 +157,9 @@ identify a strategy for action in relation to environmental, economic, social 
 *  proposing collective action in response to a geographical phenomenon or challenge and supporting the proposal with reasons; for example, developing guidelines for conserving water at school to promote awareness of levels of water usage for a community over time, especially during droughts; planning sustainable and liveable cities such as the ecopolis
 *  reflecting on the influence of personal values and attitudes on explanations of potential impacts; for example, the effects of personal factors such as availability of technology and infrastructure on what is perceived as a liveable place; conflicting cultural and economic uses of water by people
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HG7S06
+##### AC9HG7S06 {#ac9hg7s06}
 
 create descriptions, explanations and responses, using geographical knowledge and methods, concepts, terms and reference sources
 
@@ -168,7 +168,7 @@ create descriptions, explanations and responses, using geographical knowledge an
 *  constructing an explanation, using research findings to support ideas; for example, data on water usage over time and at different places; information about liveability indexes for different places in Australia and Europe
 *  developing conclusions, using geographical methods to represent data and information; for example, a map showing water usage and a map indicating water scarcity in Australia; a map representing places where liveability is difficult and dangerous due to environmental factors
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 7, students describe how the characteristics of places are perceived and valued differently by people. They describe the importance of environments to people. They describe the features of a distribution. They explain the interconnections between people and places and environments, and describe how these interconnections change places or environments. Students describe a response or strategy to address a geographical challenge or phenomenon. Students develop questions about a geographical phenomenon or challenge.
 

--- a/curriculum/hass-geography/year-8.md
+++ b/curriculum/hass-geography/year-8.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Geography 7-10 - Year 8
+# Geography - Year 8 {#geography-year-8}
 
-## Level Description
+## Level Description {#level-description}
 
 The Year 8 curriculum involves the study of 2 sub-strands.
 
@@ -18,13 +18,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How do the interconnections between places, people and environments affect the lives of people?
 *   What are the consequences of changes to places and environments, and how can these changes be managed?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Landscapes and landforms
+#### Landscapes and landforms {#landscapes-and-landforms}
 
-##### AC9HG8K01
+##### AC9HG8K01 {#ac9hg8k01}
 
 geomorphological processes that produce different landscapes and significant landforms
 
@@ -34,7 +34,7 @@ geomorphological processes that produce different landscapes and significant lan
 *  explaining the effects of rock type on a selected landform at the local scale; such as Fraser Island, Queensland or Twelve Apostles, Victoria; for example, sedimentary – igneous and metamorphic; chemical weathering – oxidation and solution; physical weathering – exfoliation and frost wedging
 *  explaining the effects of erosion, transportation and deposition of water and wind on a selected landform at the local scale; for example, Fraser Island, Queensland, formed by wind, waves and ocean currents; the Twelve Apostles, Victoria, formed by erosion, tides and ocean currents
 
-##### AC9HG8K02
+##### AC9HG8K02 {#ac9hg8k02}
 
 the location and distribution of Australia’s distinctive landscapes and significant landforms
 
@@ -44,7 +44,7 @@ the location and distribution of Australia’s distinctive landscapes and sig
 *  comparing the distribution of Australia’s distinctive landscapes with distinctive landscapes in another country; for example, grasslands in Arnhem Land in northern Australia compared to grasslands in Mongolia; tropical rainforests in northern Australia compared to forests in Laos and Cambodia
 *  explaining the significance of a landform important to First Nations Australians; for example, the names, meanings and significance of the Three Sisters in the Blue Mountains, New South Wales; Budj Bim cultural landscape within Gunditjmara Country; Uluru-Kata Tjuta National Park in Northern Territory
 
-##### AC9HG8K03
+##### AC9HG8K03 {#ac9hg8k03}
 
 the spiritual, aesthetic and cultural value of landscapes and landforms for people, including Country/Place of First Nations Australians
 
@@ -56,7 +56,7 @@ the spiritual, aesthetic and cultural value of landscapes and landforms for peop
 *  discussing the multilayered meanings (material, cultural and spiritual wellbeing) associated with landscapes and significant landforms for First Nations Australians
 *  explaining the formation of a landform with reference to the special connections First Nations Australians have to Country/Place
 
-##### AC9HG8K04
+##### AC9HG8K04 {#ac9hg8k04}
 
 the interconnections between human activity and geomorphological processes, and ways of managing distinctive landscapes
 
@@ -66,7 +66,7 @@ the interconnections between human activity and geomorphological processes, and 
 *  explaining the effects of river regulation, including dams, locks, channel straightening and drains, on the quality of riverine and wetland environments; for example, the Three Gorges Dam on the Yangtze River in China, or dams and weirs on the Murray–Darling River system
 *  identifying the contribution of the knowledges of First Nations Australians to the use and management of distinctive landscapes; for example, Indigenous Peoples’ Knowledge (IPK) incorporated into modern management of diverse landscapes and landforms such as Kakadu National Park, Uluru, the Great Barrier Reef and the Snowy Mountains
 
-##### AC9HG8K05
+##### AC9HG8K05 {#ac9hg8k05}
 
 the causes and impacts of a geomorphological hazard on people, places and environments, and the effects of responses
 
@@ -76,9 +76,9 @@ the causes and impacts of a geomorphological hazard on people, places and env
 *  reflecting on observations of a location where the environment has been altered by human activities to explain how the change has heightened the impact of a hazard
 *  reflecting on the principles of prevention, mitigation and preparedness to explain how the harmful effects of a hazard can be reduced by the implementation of a management strategy
 
-#### Changing nations
+#### Changing nations {#changing-nations}
 
-##### AC9HG8K06
+##### AC9HG8K06 {#ac9hg8k06}
 
 causes of urbanisation and its impacts on places and environments, drawing on a study from a country such as the United States of America, and its implications
 
@@ -89,7 +89,7 @@ causes of urbanisation and its impacts on places and environments, drawing on a 
 *  explaining the connections between urbanisation and economic and social opportunities; for example, the location of universities, sporting stadiums or parliaments in capital cities
 *  explaining how urbanisation can positively or negatively affect the quality of the environment; for example, increases in carbon emissions or increases in water consumption
 
-##### AC9HG8K07
+##### AC9HG8K07 {#ac9hg8k07}
 
 differences in the distribution of urban settlements and urban concentration in Australia compared with another country such as the United States of America, and their implications
 
@@ -99,7 +99,7 @@ differences in the distribution of urban settlements and urban concentration in 
 *  examining the effects of urban concentration in a country other than Australia; for example, the decline in biodiversity and increase in waste, the increase in carbon emissions leading to a large carbon footprint, or the decline in access to adequate clean water and the development of slums
 *  interpreting and explaining the relationship between population density and proximity to urban centres at the national scale; for example, higher population density towards the urban central business district (CBD) as a centre of employment, education, culture and government, such as in Brisbane, and declining towards the rural-urban fringe (core and periphery)
 
-##### AC9HG8K08
+##### AC9HG8K08 {#ac9hg8k08}
 
 reasons for, and effects of, internal migration and international migration in Australia, China or other countries
 
@@ -111,7 +111,7 @@ reasons for, and effects of, internal migration and international migration in
 *  interpreting population data and describing the relationship between international migration and urban concentration within Australia, and internal migration and urban concentration within China
 *  exploring the connections between the cultural diversity of places and how they are affected by internal and international migration; for example, in Australia or China
 
-##### AC9HG8K09
+##### AC9HG8K09 {#ac9hg8k09}
 
 strategies to manage the sustainability of Australia’s changing urban places
 
@@ -119,11 +119,11 @@ strategies to manage the sustainability of Australia’s changing urban places
 *  examining a strategy used by local, state or national governments to manage projected population growth in one of Australia’s cities or regional urban centres, and identifying implications for sustainability (environmental, economic and social factors) and liveability
 *  generating ideas for a strategy for a more balanced distribution of urban population, such as decentralisation, using Canberra as an example
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching using geographical methods
+#### Questioning and researching using geographical methods {#questioning-and-researching-using-geographical-methods}
 
-##### AC9HG8S01
+##### AC9HG8S01 {#ac9hg8s01}
 
 develop questions for a geographical inquiry related to a phenomenon or challenge
 
@@ -131,7 +131,7 @@ develop questions for a geographical inquiry related to a phenomenon or challeng
 *  developing questions to investigate why a geographical phenomenon has changed or why a challenge may arise; for example, “How does urban development affect the sustainability of wetlands?”, “Why is biodiversity declining in urban places?”
 *  planning an investigation of a geographical phenomenon or challenge being studied, at a range of scales using digital planning tools; for example, how geomorphological processes produce significant landforms at the local scale, or the causes and consequences of urbanisation at the national scale
 
-##### AC9HG8S02
+##### AC9HG8S02 {#ac9hg8s02}
 
 collect, organise and represent data and information from primary research methods, including fieldwork and secondary research materials, using geospatial technologies and digital tools as appropriate
 
@@ -144,9 +144,9 @@ collect, organise and represent data and information from primary research m
 *  representing relevant and reliable data and information in appropriate formats to combine ideas, using digital tools; for example, creating annotated diagrams to show the changes to a landform over time or using digital mapping tools to show the cultural and demographic diversity of First Nations Australians
 *  representing spatial distributions of different types of geographical phenomena by constructing appropriate maps at different scales that conform to cartographic conventions; for example, constructing a map to show the relationship between landforms such as mountains and landscapes such as deserts, or contrasting the spatial distribution of population in Australia and/or China
 
-#### Interpreting and analysing geographical data and information
+#### Interpreting and analysing geographical data and information {#interpreting-and-analysing-geographical-data-and-information}
 
-##### AC9HG8S03
+##### AC9HG8S03 {#ac9hg8s03}
 
 interpret and analyse geographical data and information to identify similarities and differences, explain patterns and trends and infer relationships
 
@@ -155,9 +155,9 @@ interpret and analyse geographical data and information to identify similarities
 *  explaining patterns and trends; for example, comparing compound graphs or census data for different time periods to identify patterns in urban concentration in Australia and the United States of America, or trends in international migration
 *  inferring relationships from data and information collected during primary research; for example, using observations, field sketches, field measurements, questionnaires or interviews to explain the distribution of population in your local area and suggesting possible causes, effects and trends
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HG8S04
+##### AC9HG8S04 {#ac9hg8s04}
 
 draw conclusions based on the analysis of the data and information
 
@@ -165,7 +165,7 @@ draw conclusions based on the analysis of the data and information
 *  drawing on the results of an analysis and using at least one of the concepts of place, space, environment, interconnections, sustainability, scale or change as an organiser to respond to a question; for example, using research about the value of distinctive landscapes to form conclusions about the influence they have on peoples’ lives or an analysis of the distribution of urban settlements to form conclusions about how space is used
 *  explaining reasons for decisions and choices; for example, reflecting on research findings or data analysis of the impacts of geomorphological hazards or urbanisation to identify and explain significant impacts on people, places and environments
 
-##### AC9HG8S05
+##### AC9HG8S05 {#ac9hg8s05}
 
 identify a strategy for action in relation to environmental, economic, social or other factors, and explain potential impacts
 
@@ -175,9 +175,9 @@ identify a strategy for action in relation to environmental, economic, social 
 *  evaluating the effectiveness of a strategy in relation to environmental, economic and social factors
 *  reflecting on personal values and attitudes and how these influence explanations of potential outcomes; for example, applying sustainable design principles to urban redevelopment projects that provide green, open spaces for citizens
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HG8S06
+##### AC9HG8S06 {#ac9hg8s06}
 
 create descriptions, explanations and responses, using geographical knowledge and methods, concepts, terms and reference sources
 
@@ -186,7 +186,7 @@ create descriptions, explanations and responses, using geographical knowledge a
 *  constructing an explanation, using research findings to support ideas, such as the causes and effects of a geographical phenomenon or challenge, and reinforcing knowledge and understanding of the interconnections between people, places and the environment
 *  developing a response, using representations of data and information to support actions and conclusions, such as a map showing the location of iconic landforms or a flow map showing the international movement of refugees
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8, students explain how the interactions of people and environmental processes impact on the characteristics of places. They explain how the characteristics of places are perceived and valued differently by people. They describe the effects of human activity or hazards on environments. They explain the features of a distribution and identify implications. They explain the interconnections between people and places and environments. They explain how these interconnections change places or environments. Students explain responses or strategies to address a geographical phenomenon or challenge, referring to environmental, economic or social factors.
 

--- a/curriculum/hass-geography/year-9.md
+++ b/curriculum/hass-geography/year-9.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - Geography 7-10 - Year 9
+# Geography - Year 9 {#geography-year-9}
 
-## Level Description
+## Level Description {#level-description}
 
 The Year 9 curriculum involves the study of 2 sub-strands.
 
@@ -18,13 +18,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   What are the future implications of changes to places and environments?
 *   Why are interconnections and interdependencies important for the future of places and environments?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Biomes and food security
+#### Biomes and food security {#biomes-and-food-security}
 
-##### AC9HG9K01
+##### AC9HG9K01 {#ac9hg9k01}
 
 the distribution and characteristics of biomes as regions with distinctive climates, soils, vegetation and productivity
 
@@ -33,7 +33,7 @@ the distribution and characteristics of biomes as regions with distinctive clima
 *  interpreting and explaining patterns and trends in the productivity of the major aquatic and terrestrial biomes in Australia compared with a country in Asia
 *  explaining the effects of interconnections between environmental processes (atmosphere, hydrosphere, lithosphere and biosphere) and human activities, such as deforestation, mining and agriculture on the characteristics of biomes
 
-##### AC9HG9K02
+##### AC9HG9K02 {#ac9hg9k02}
 
 the effects on environments of human alteration of biomes to produce food, industrial materials and fibres
 
@@ -42,7 +42,7 @@ the effects on environments of human alteration of biomes to produce food, indu
 *  explaining the differences between natural and agricultural ecosystems in flows of nutrients and water, and in biodiversity; for example, the tropical rainforest biome in Indonesia produces food such as fruit, grains, nuts, vegetables and spices, and non-food products such as wood, rubber, coffee, chocolate and palm oil
 *  explaining how human alteration of biomes (for example, drip irrigation, fertilisers, pesticides, genetically modified seeds, agrobiotics, terracing, and controlling erosion and overgrazing) has increased agricultural productivity in Australia and a country in Asia
 
-##### AC9HG9K03
+##### AC9HG9K03 {#ac9hg9k03}
 
 the environmental, economic and technological factors that impact agricultural productivity, in Australia and a country in Asia
 
@@ -52,7 +52,7 @@ the environmental, economic and technological factors that impact agricultural p
 *  examining how agricultural innovations have reduced environmental limitations on food production in Australia and a country in Asia; for example, increased food production due to research into and development of high-yielding and genetically engineered pest resistant varieties, construction of drip irrigation systems, and the use of stubble mulching, intercropping, agroforestry and crop rotation
 *  explaining the impact of the interconnections between environmental, economic and technological factors on the yield of a particular crop, such as wheat, rice or maize, in Australia
 
-##### AC9HG9K04
+##### AC9HG9K04 {#ac9hg9k04}
 
 challenges to sustainable food production and food security in Australia and appropriate management strategies
 
@@ -64,9 +64,9 @@ challenges to sustainable food production and food security in Australia and
 *  explaining management strategies that restore the quality or diversity of agriculture in Australia; for example, improving the function of natural biomes and anthropogenic biomes, monitoring land management practices, improving the condition of the soil or building the capability of farmers
 *  generating ideas for a strategy to expand agricultural production in Australia; for example, market bush food such as herbs and wattle seed, invest in research, support farm innovations or develop the expertise of farmers
 
-#### Geographies of interconnections
+#### Geographies of interconnections {#geographies-of-interconnections}
 
-##### AC9HG9K05
+##### AC9HG9K05 {#ac9hg9k05}
 
 the ways changing transportation and technologies are used to connect people to services, information and people in other places
 
@@ -77,7 +77,7 @@ the ways changing transportation and technologies are used to connect peopl
 *  interpreting differences in people’s access to the internet between and within countries, such as in rural areas across Australia and across the world, including a country of Asia, and explaining how technologies are used to connect people to information, services and other people
 *  examining how technologies have made it possible for places to provide a range of global business services, such as businesses operating call centres in India and the Philippines
 
-##### AC9HG9K06
+##### AC9HG9K06 {#ac9hg9k06}
 
 the effects on places of people’s travel, recreational, cultural or leisure choices, and the strategies for managing the impacts on these places
 
@@ -86,7 +86,7 @@ the effects on places of people’s travel, recreational, cultural or leisure ch
 *  explaining the impacts of people’s cultural and leisure choices on the sustainability of places popular with tourists (for example, visiting Mecca, Vatican City or Varanasi as religious pilgrimages) and predicting how space tourism or the impacts of COVID-19 may affect places
 *  examining how management plans for national parks, such as Uluru-Kata Tjuta National Park, bring together cultural and scientific knowledge and experience, and examining governance and past experience to manage the effects of people’s cultural and leisure choices
 
-##### AC9HG9K07
+##### AC9HG9K07 {#ac9hg9k07}
 
 the ways that places and people are interconnected with other places through trade in goods and services, at all scales
 
@@ -95,7 +95,7 @@ the ways that places and people are interconnected with other places through tra
 *  examining how and why places are interconnected nationally, regionally and globally through trade in goods and services
 *  identifying examples of change in interconnections between places and people through trade in goods and/or services over time at the local, national and global scale
 
-##### AC9HG9K08
+##### AC9HG9K08 {#ac9hg9k08}
 
 the impacts of the production and consumption of goods on places throughout the world, and strategies to manage sustainability in these places
 
@@ -105,11 +105,11 @@ the impacts of the production and consumption of goods on places throughout the 
 *  evaluating the environmental, economic and social impacts of the global oil supply chain, from where the resource is extracted, processed and sold, and how impacts could be sustainably managed in Australia and in West Asia
 *  examining a strategy used by local, state or national governments to manage waste in one of Australia’s cities or regional urban centres, and identifying implications for sustainability (environmental, economic and social factors)
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching using geographical methods
+#### Questioning and researching using geographical methods {#questioning-and-researching-using-geographical-methods}
 
-##### AC9HG9S01
+##### AC9HG9S01 {#ac9hg9s01}
 
 develop a range of questions for a geographical inquiry related to a phenomenon or challenge
 
@@ -118,7 +118,7 @@ develop a range of questions for a geographical inquiry related to a phenomenon 
 *  developing and modifying questions to sharpen the focus of an investigation using concepts or scale of study; for example, “Why is the security and sustainability of food production important at the national scale?”, “How can bush food become a sustainable nutritional source of food in Australia?”, “How can connections between people, environments and places affect the sustainability of places at the global scale?”
 *  planning an investigation of a geographical phenomenon or challenge being studied at a range of scales, using digital tools; for example, the diverse types of biomes modified by humans for food and non-food products at a national and global scale, or the different types of connections between people and places at local, national and global scales
 
-##### AC9HG9S02
+##### AC9HG9S02 {#ac9hg9s02}
 
 collect, represent and compare data and information from primary research methods, including fieldwork and secondary research materials, using geospatial technologies and digital tools as appropriate
 
@@ -130,9 +130,9 @@ collect, represent and compare data and information from primary research met
 *  creating visual representations of multi-variable geographical data using digital tools; for example, a table to compare the daily consumption of meat per person in developed and developing countries; a complex graph to illustrate the relationship between temperature, precipitation and biomes; or a cross-section identifying horizons in a soil profile, and the impacts of mining and fracking on agricultural land
 *  representing spatial distribution of geographical phenomena by constructing special purpose maps that conform to cartographic conventions, for example creating a map to show the relationship between biomes and world food production
 
-#### Interpreting and analysing geographical data and information
+#### Interpreting and analysing geographical data and information {#interpreting-and-analysing-geographical-data-and-information}
 
-##### AC9HG9S03
+##### AC9HG9S03 {#ac9hg9s03}
 
 evaluate geographical data and information to make generalisations and predictions, explain patterns and trends and infer relationships
 
@@ -141,9 +141,9 @@ evaluate geographical data and information to make generalisations and predictio
 *  explaining a pattern; for example, using the current Global Hunger Index and the updated Food and Agricultural Organization’s Low-Income Food-Deficit Countries (LIFDCs) to identify locations of food scarcity and malnutrition, or comparing maps showing transport networks with survey responses on personal mobility
 *  explaining relationships between causes and impacts of factors represented in data; for example, the impact of the use of Global Positioning System (GPS) and Geographic Information Systems (GIS) on the way farmers control the dispersion of fertilisers and pesticides to produce higher yields and limit run-off, or the effects of the use of GPS to construct maps on how tourists use different transport systems to visits popular places in Australia
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HG9S04
+##### AC9HG9S04 {#ac9hg9s04}
 
 evaluate data and information to justify conclusions
 
@@ -151,7 +151,7 @@ evaluate data and information to justify conclusions
 *  drawing conclusions about the impact of a geographical challenge on people, places and environments; for example, investigating the causes of a decline in food species, its impacts on food security and the establishment of the Svalbard Global Seed Vault, or the effects of cyberattacks on technological interconnections and implementation of international laws related to cyber security
 *  justifying conclusions by reflecting on perspectives identified and reasons for these perspectives; for example, considering environmental, economic and social factors when challenging disappearing arable land converted from food production to non-food crops, or promoting ecotourism that impacts on people and places
 
-##### AC9HG9S05
+##### AC9HG9S05 {#ac9hg9s05}
 
 develop and evaluate strategies using environmental, economic or social criteria; recommend a strategy and explain the predicted impacts
 
@@ -162,9 +162,9 @@ develop and evaluate strategies using environmental, economic or social criteria
 *  explaining the outcomes and impacts of a strategy, such as providing people with adequate and quality food that is acceptable in different cultures, or reducing the global movement of hazardous waste between countries
 *  reflecting on the influence of personal values and attitudes on predicted outcomes and impacts; for example, how preferring to buy locally produced food reduces food miles and greenhouse gases, or how reducing, recycling and reusing goods contributes to a more sustainable environment
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HG9S06
+##### AC9HG9S06 {#ac9hg9s06}
 
 create descriptions, explanations and responses, using geographical knowledge and geographical tools as appropriate, and concepts and terms that incorporate and acknowledge research findings
 
@@ -173,7 +173,7 @@ create descriptions, explanations and responses, using geographical knowledge an
 *  creating a description, using representations of data (for example, using maps to illustrate the major terrestrial biomes of Australia and photographs to show their impacts on people and places) and research findings (for example, using diagrams, graphs, tables and/or satellite images to show how environmental, economic or technological factors affect crop yields)
 *  creating an explanation that applies tone appropriate to the audience; such as reducing food wastage, or developing a management plan for a tourist hot spot, in an authoritative tone and reasoned argument
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 9, students explain how peoples’ activities or environmental processes change the characteristics of places. They explain the effects of human activity on environments, and the effects of environments on human activity. They explain the features of biomes’ distribution and identify implications for environments. They analyse the interconnections between people and places and environments. They identify and explain how these interconnections influence people, and change places and environments. Students analyse strategies to address a geographical phenomenon or challenge using environmental, social or economic criteria.
 

--- a/curriculum/hass-history/year-10.md
+++ b/curriculum/hass-history/year-10.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - History 7-10 - Year 10
+# History - Year 10 {#history-year-10}
 
-## Level Description
+## Level Description {#level-description}
 
 The Year 10 curriculum provides a study of the history of the modern world and Australia from 1918 to the present, with an emphasis on Australia in its global context. The 20th century became a critical period in Australia’s social, political, economic, cultural, environmental and political development. The transformation of the modern world during a time of political turmoil, global conflict and international cooperation provides a necessary context for understanding Australia’s development, its place within the Asia-Pacific region and its global standing, and the demands for rights and recognition by First Nations Australians.
 
@@ -16,13 +16,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   What were the perspectives of people at the time? How did these perspectives change?
 *   What are the contested debates and reasons for different historical interpretations?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Second World War
+#### Second World War {#second-world-war}
 
-##### AC9HH10K01
+##### AC9HH10K01 {#ac9hh10k01}
 
 the causes, outbreak and course of the Second World War and the significance of Australian involvement
 
@@ -32,7 +32,7 @@ the causes, outbreak and course of the Second World War and the significance of 
 *  investigating the causes of the effects of the Treaty of Versailles on Germany, the structural weaknesses of the League of Nations, the rise of fascist and militarist regimes, and the failure of appeasement policies
 *  examining the reasons for Australia’s involvement in the Second World War, and the responses to the conflicts of prime minister Robert Menzies, “Australia is also at war” and prime minister John Curtin, “Australia looks to America”
 
-##### AC9HH10K02
+##### AC9HH10K02 {#ac9hh10k02}
 
 the places where Australians fought, and their perspectives and experiences during the Second World War, such as the fall of Singapore, prisoners of war (POWs), the Battle of Britain and Kokoda
 
@@ -42,7 +42,7 @@ the places where Australians fought, and their perspectives and experiences duri
 *  comparing the experiences of various prisoners of war (POWs), such as the treatment of Australian POWs under German and Japanese control
 *  examining the perspectives of particular groups of POWs, such as those in camps in Ambon or Rabaul, those used as forced labour on the Thai–Burma Railway, or army nurses captured in Singapore
 
-##### AC9HH10K03
+##### AC9HH10K03 {#ac9hh10k03}
 
 the significant events and turning points of the Second World War, including the Holocaust and use of the atomic bomb
 
@@ -55,7 +55,7 @@ the significant events and turning points of the Second World War, including the
 *  identifying the race to build the atomic bomb by Germany, Japan and the USA, and analysing why the atomic bombs were dropped on Hiroshima and Nagasaki
 *  investigating the effects of the atomic bombs on Hiroshima and Nagasaki, including short- and long-term effects on human health, and short- and long-term environmental effects on the cities and surrounding areas
 
-##### AC9HH10K04
+##### AC9HH10K04 {#ac9hh10k04}
 
 the effects of the Second World War, with a particular emphasis on the continuities and changes on the Australian home front, such as the changing roles of women and First Nations Australians, and the use of wartime government controls
 
@@ -68,7 +68,7 @@ the effects of the Second World War, with a particular emphasis on the continuit
 *  examining the reasons for the Australian Government changing its views on including First Nations Australians in the defence forces, such as the critical shortage of soldiers, Torres Strait Light Infantry Battalion established in 1941 and specialised work undertaken by First Nations Australians; for example, the Nackeroos and the Northern Territory Special Reconnaissance Unit
 *  examining the changing roles of First Nations Australian men and women working as civilians for the army during the Second World War, such as increased employment opportunities in domestic work in hospitals, ammunition stacking, timber cutting and cement works, maintaining gardens, slaughtering cattle, and assembling and clearing gearboxes
 
-##### AC9HH10K05
+##### AC9HH10K05 {#ac9hh10k05}
 
 the significance of the Second World War to Australia’s immediate post-war economic, political and social development, and Australia’s international relationships in the 20th century
 
@@ -79,7 +79,7 @@ the significance of the Second World War to Australia’s immediate post-war eco
 *  describing the involvement of Australia in the founding of the United Nations, such as the roles played by HV Evatt and Jessie Street in drafting the charter of the United Nations
 *  investigating the impact of the significant wave of post-war European and Asian migration, including the Colombo Plan, and views about race, including attitudes towards First Nations Australians
 
-##### AC9HH10K06
+##### AC9HH10K06 {#ac9hh10k06}
 
 the commemoration of the Second World War, including different historical interpretations and debates
 
@@ -87,9 +87,9 @@ the commemoration of the Second World War, including different historical interp
 *  analysing the debate over the Battle for Australia 1942 and its commemoration since 2008
 *  discussing the commemoration of Kokoda, including the debate about the appropriateness of hiking the Kokoda trail today as a form of commemoration
 
-#### Building modern Australia
+#### Building modern Australia {#building-modern-australia}
 
-##### AC9HH10K07
+##### AC9HH10K07 {#ac9hh10k07}
 
 the effects of significant post–Second World War world events, ideas and developments on Australian society
 
@@ -98,7 +98,7 @@ the effects of significant post–Second World War world events, ideas and devel
 *  describing the main features of a government policy that affected migration to Australia, such as the government’s “populate or perish” policy and the “White Australia” policy
 *  investigating the nature of the waves of migration (for example, from Europe in the 1950s–1960s, from different parts of Asia in the 1970s–2000s, from the Middle East in the 1980s–1990s, from India in the 1990s–2000s or from Africa in the 2000s), the numbers of migrants from those countries since the Second World War and the reasons for those migrations, including push factors such as the effects of war, economic downturns or social upheaval, and pull factors such as Australia’s peaceful democracy and economic and educational opportunities
 
-##### AC9HH10K08
+##### AC9HH10K08 {#ac9hh10k08}
 
 the causes of changes in perspectives, responses, beliefs and values on migration that have influenced Australian society since 1945
 
@@ -109,7 +109,7 @@ the causes of changes in perspectives, responses, beliefs and values on migratio
 *  discussing the debate over multiculturalism that arose in the 1980s
 *  discussing how debates over different aspects of Australia’s immigration and border protection policies have changed over time in light of international events, including consideration of issues such as mandatory detention of asylum seekers, humanitarian migration, business and skilled migration, and temporary protection visas, from the early 1990s to the present day
 
-##### AC9HH10K09
+##### AC9HH10K09 {#ac9hh10k09}
 
 the causes of First Nations Australians' campaigns for rights and freedoms before 1965, such as discriminatory legislation and policies, the 1938 Day of Mourning and the Stolen Generations
 
@@ -118,7 +118,7 @@ the causes of First Nations Australians' campaigns for rights and freedoms befor
 *  explaining the significance of the 1938 Day of Mourning in the campaigns of First Nations Australians for rights and freedoms, including the significance of 26 January 1938 (150 years since the arrival of the First Fleet) and the national Indigenous rights meeting
 *  exploring accounts of the past experiences of First Nations Australians who were members of the Stolen Generations and how these experiences influenced the civil rights movement in Australia from the 1960s through to the present day
 
-##### AC9HH10K10
+##### AC9HH10K10 {#ac9hh10k10}
 
 the contributions of significant individuals and groups in the campaign for the recognition of the rights of First Nations Australians and the extent to which they brought change to Australian society
 
@@ -128,7 +128,7 @@ the contributions of significant individuals and groups in the campaign for the 
 *  examining the role of Christian, union and labour groups in the movement for First Nations Australians' rights and freedoms, including the foundation of the National Day of Mourning
 *  examining the ways some First Nations Australians’ embracing of Christianity and Islam has interacted with their beliefs, identity and political freedoms
 
-##### AC9HH10K11
+##### AC9HH10K11 {#ac9hh10k11}
 
 the significant events and methods in the movement for the civil rights of First Nations Australians and the extent to which they contributed to change
 
@@ -139,7 +139,7 @@ the significant events and methods in the movement for the civil rights of First
 *  discussing how Reconciliation is not a single significant event or change, but an ongoing process of truth-telling and healing between First Nations Australians and other Australians
 *  investigating the Mabo case and the significance of this event’s contribution to understanding of terra nullius and the land rights movement for First Nations Australians
 
-##### AC9HH10K12
+##### AC9HH10K12 {#ac9hh10k12}
 
 the significant events, individuals and groups in the women’s movement in Australia, and how they have changed the role and status of women
 
@@ -147,7 +147,7 @@ the significant events, individuals and groups in the women’s movement in Aust
 *  <p>investigating events connected to the changing roles and rights of women in the workforce since 1945 such as the repeal of the “marriage bar”, the <em>Sex Discrimination Act 1984</em>, the changing nature of participation in employment and the gender pay gap</p>
 *  examining the contributions of significant female leaders in Australian public life; for example, political leaders and activists, social reformers, sporting identities, artists and entertainers
 
-##### AC9HH10K13
+##### AC9HH10K13 {#ac9hh10k13}
 
 the continuing efforts to create change in the civil rights and freedoms in Australia, for First Nations Australians, migrants and women
 
@@ -157,9 +157,9 @@ the continuing efforts to create change in the civil rights and freedoms in Aust
 *  <p>investigating the changes in government policy in relation to migrants and how these policies have reflected and impacted on Australia’s changing place in the world; for example, the <em>Racial Discrimination Act 1975</em></p>
 *  examining the ideas in and Australia’s responsibilities as a signatory to the United Nations Declaration of the Rights of Indigenous Peoples (UNDRIP) (2007) and discussing how it influences calls for recognising the rights of First Nations Australians and First Peoples in other countries
 
-#### The globalising world
+#### The globalising world {#the-globalising-world}
 
-##### AC9HH10K14
+##### AC9HH10K14 {#ac9hh10k14}
 
 changing historical perspectives over time in relation to the developments in technology, public health, longevity, standard of living in the 20th century, and concern for the environment and sustainability
 
@@ -168,7 +168,7 @@ changing historical perspectives over time in relation to the developments in te
 *  discussing the growth in the world’s population during the 20th century, including life expectancy changes in different parts of the world, and the depletion of natural resources
 *  identifying how the rise of the environmental movement around the world has changed people’s perspectives on things such as developments in renewable energy technology and sustainability measures such as recycling
 
-##### AC9HH10K15
+##### AC9HH10K15 {#ac9hh10k15}
 
 the origins and significance of the Universal Declaration of Human Rights, including Australia’s involvement in the development of the declaration
 
@@ -176,7 +176,7 @@ the origins and significance of the Universal Declaration of Human Rights, inclu
 *  describing the causes of the development of the Universal Declaration of Human Rights, such as the atrocities of the Holocaust, the immense scale of destruction and displacement because of Second World War
 *  investigating the present significance of the Universal Declaration of Human Rights
 
-##### AC9HH10K16
+##### AC9HH10K16 {#ac9hh10k16}
 
 causes and effects of the significant events and developments of the major global influences on Australia in the post-Second World War period
 
@@ -188,7 +188,7 @@ causes and effects of the significant events and developments of the major globa
 *  comparing views on the values and beliefs of rock ‘n’ roll, film and television across time, age and gender, such as issues of conservatism and rebellion, the challenge to established ideas and national identity
 *  analysing the causes and conditions that led to the environment movement and its effects on changing public opinion about protecting the environment, such as rapid population increase, urbanisation, increases in industrial pollution and waste, and species extinction
 
-##### AC9HH10K17
+##### AC9HH10K17 {#ac9hh10k17}
 
 changing social, political, economic, cultural, environmental and technological conditions, and the causes of a major global influence in Australia
 
@@ -202,7 +202,7 @@ changing social, political, economic, cultural, environmental and technological 
 *  identifying American and Asian influences on Australian popular culture since the Second World War, such as through mainstream Hollywood and Bollywood films, and the animation film industry in China and Japan
 *  investigating the changing contribution of the Australian rock ‘n’ roll, film and television industries to Australian culture and identity through the development and export of music, film and television
 
-##### AC9HH10K18
+##### AC9HH10K18 {#ac9hh10k18}
 
 continuities and changes in perspectives, responses, beliefs and values that have influenced the Australian way of life
 
@@ -212,7 +212,7 @@ continuities and changes in perspectives, responses, beliefs and values that hav
 *  comparing and contrasting the policies relating to engagement with the Asia-Pacific region of the governments led by prime minister Paul Keating (1991–1996) and prime minister John Howard (1996–2007) 
 *  examining the nature of religion in Australia; for example, the changing attitudes to religious practice, the increase of non-Christian religions and non-traditional Christian churches
 
-##### AC9HH10K19
+##### AC9HH10K19 {#ac9hh10k19}
 
 the effects of global influences on Australia’s changing identity as a nation and its international relationships
 
@@ -223,7 +223,7 @@ the effects of global influences on Australia’s changing identity as a nation 
 *  discussing the rising economic and political influence of countries such as China and India since the end of the Cold War
 *  examining the role of digital media, including social media, in shaping Australian society and connecting to global relationships
 
-##### AC9HH10K20
+##### AC9HH10K20 {#ac9hh10k20}
 
 different historical interpretations and debates during the second half of the 20th century
 
@@ -234,11 +234,11 @@ different historical interpretations and debates during the second half of the 2
 *  discussing the global debate over the use of nuclear energy from the 1960s to the present and its change over time, including arguments for and against its use as an alternative to fossil fuels, and the effects of nuclear disasters such as Three Mile Island (1979), Chernobyl (1986) and Fukushima Daiichi (2011)
 *  investigating the change in debate about climate change over time from the 1960s to the present
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HH10S01
+##### AC9HH10S01 {#ac9hh10s01}
 
 develop and modify a range of historical questions about the past to inform historical inquiry
 
@@ -248,7 +248,7 @@ develop and modify a range of historical questions about the past to inform hist
 *  modifying a key question or related questions in an inquiry, depending on the suitability of the sources available
 *  determining whether a key question or related questions are too broad or narrow given the requirements of the investigation
 
-##### AC9HH10S02
+##### AC9HH10S02 {#ac9hh10s02}
 
 locate, identify and compare primary and secondary sources to use in a historical inquiry
 
@@ -257,9 +257,9 @@ locate, identify and compare primary and secondary sources to use in a historica
 *  identifying information in a primary or secondary source that matches the historical questions being asked
 *  comparing multiple primary or secondary sources and selecting the source/s most pertinent to the historical research being conducted
 
-#### Using historical sources
+#### Using historical sources {#using-historical-sources}
 
-##### AC9HH10S03
+##### AC9HH10S03 {#ac9hh10s03}
 
 identify the origin and content of sources, and explain the purpose and context of primary and secondary sources
 
@@ -268,7 +268,7 @@ identify the origin and content of sources, and explain the purpose and context 
 *  analysing the intent of the author and the features of the source to determine the purpose of the source
 *  describing stylistic elements of sources, such as artistic or architectural, to inform the meaning of sources
 
-##### AC9HH10S04
+##### AC9HH10S04 {#ac9hh10s04}
 
 explain the usefulness of primary and secondary sources, and the reliability of the information as evidence
 
@@ -280,9 +280,9 @@ explain the usefulness of primary and secondary sources, and the reliability of 
 *  determining whether or not the information in one historical source can be verified by information in another historical source
 *  comparing a range of historical sources and identifying similarities, differences and inconsistencies in interpretations
 
-#### Historical perspectives and interpretations
+#### Historical perspectives and interpretations {#historical-perspectives-and-interpretations}
 
-##### AC9HH10S05
+##### AC9HH10S05 {#ac9hh10s05}
 
 analyse cause and effect, and evaluate patterns of continuity and change
 
@@ -291,7 +291,7 @@ analyse cause and effect, and evaluate patterns of continuity and change
 *  organising a range of primary sources in chronological order to support the development of a historical argument about significant causes
 *  explaining the links between the main ideas, actions and individuals of an event, and drawing links between them by placing them in sequence; for example, sequencing the Freedom Rides campaigns in the USA and Australia, and explaining the links between the 2 campaigns
 
-##### AC9HH10S06
+##### AC9HH10S06 {#ac9hh10s06}
 
 compare perspectives in sources and explain how these are influenced by significant events, ideas, locations, beliefs and values
 
@@ -301,7 +301,7 @@ compare perspectives in sources and explain how these are influenced by signific
 *  analysing the views of men and women at different times regarding gender equality in Australia and explaining how these views might reflect changing values and attitudes
 *  explaining why some perspectives in the past may not have been recorded
 
-##### AC9HH10S07
+##### AC9HH10S07 {#ac9hh10s07}
 
 analyse different and contested historical interpretations
 
@@ -311,9 +311,9 @@ analyse different and contested historical interpretations
 *  analysing how historians have changed the way they interpret the event under investigation over time, such as a change in view with the discovery of more sources
 *  constructing a historical argument that identifies different possibilities in interpretation, organising ideas to build an argument, presents a particular point of view with consistent reference to the evidence available, and uses evaluative language
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HH10S08
+##### AC9HH10S08 {#ac9hh10s08}
 
 create descriptions, explanations and historical arguments, using historical knowledge, concepts and terms that incorporate and acknowledge evidence from sources
 
@@ -323,7 +323,7 @@ create descriptions, explanations and historical arguments, using historical kno
 *  developing a historical explanation or interpretation, using historical concepts and terms to build understanding of context, significance, purpose and the impact of the event or development
 *  presenting a historical argument, such as essay, oral presentation, debate, interactive digital or non-digital display, online conference or forum incorporating evidence
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 10, students explain the historical significance of the period between 1918 and the early 21st century. They explain the causes and effects of events, developments, turning points or movements in 20th century Australia and internationally, leading up to and through the Second World War, and the post-war world. They describe social, cultural, economic and/or political aspects, including international developments, related to the changes and continuities in Australian society over this historical period. Students explain the role of significant ideas, individuals, groups and institutions connected to the developments of this period and their influences on Australian and global history.
 

--- a/curriculum/hass-history/year-7.md
+++ b/curriculum/hass-history/year-7.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - History 7-10 - Year 7
+# History - Year 7 {#history-year-7}
 
-## Level Description
+## Level Description {#level-description}
 
 The Year 7 curriculum provides a study of history from the time of the earliest human communities to the end of the ancient period, approximately 60,000 years ago – c.650 (CE), and a study of early First Nations Peoples of Australia. It was a period defined by the development of cultural practices and organised societies. The study of the ancient world includes the discoveries (the remains of the past and what we know) and the mysteries (what we do not know) about this period of history, in a range of societies from places including Egypt, Greece, Rome, India and China.
 
@@ -22,13 +22,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   What emerged as the defining features and achievements of ancient societies?
 *   What have been the significant legacies of ancient societies?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Deep time history of Australia
+#### Deep time history of Australia {#deep-time-history-of-australia}
 
-##### AC9HH7K01
+##### AC9HH7K01 {#ac9hh7k01}
 
 theories and historical interpretations about early human evolution and migration, such as the theory that people moved out of Africa and the causes of migration to other parts of the world, including Australia
 
@@ -37,7 +37,7 @@ theories and historical interpretations about early human evolution and migratio
 *  describing how environmental changes, such as climate change and desertification, triggered the movement of peoples from Africa
 *  identifying how different approaches, such as the use of excavation and stratigraphy, oral history and the data derived from radiocarbon dating, inform historical interpretations
 
-##### AC9HH7K02
+##### AC9HH7K02 {#ac9hh7k02}
 
 theories about the causes and effects of the arrival of early First Nations Australians on the Australian continent and their migration routes across the continent
 
@@ -47,7 +47,7 @@ theories about the causes and effects of the arrival of early First Nations Aust
 *  examining online maps and information to investigate the relationship between geographical features and the location of known ancient sites on the mega-continent known as Sahul; for example, investigating the vegetation types and water sources in different parts of the continent and how they reflect the location of ancient sites
 *  investigating the techniques used to predict the chronology and the routes taken in the dispersal of early First Nations Australians across the continent; for example, using online information that explains how research into ancient landscapes, waterways, terrain and important early First Nations Australians’ habitation sites can model the movement of people across the continent, or how DNA taken from hair samples can track the genetic connections of First Nations Australians back to specific parts of Australia as far back as tens of thousands of years ago
 
-##### AC9HH7K03
+##### AC9HH7K03 {#ac9hh7k03}
 
 how First Nations Australians are the world’s oldest continuing cultures, displaying evidence of both continuity and change over deep time
 
@@ -58,7 +58,7 @@ how First Nations Australians are the world’s oldest continuing cultures, disp
 *  exploring evidence of continuing culture that was evident in the ancient period, such as the use of ochre
 *  examining First Nations Australians’ views on creation and changes in the landscape that have been passed down through oral tradition, such as the existence of megafauna, changes from wetter to drier climates and changes in vegetation in central Australia
 
-##### AC9HH7K04
+##### AC9HH7K04 {#ac9hh7k04}
 
 how First Nations Australians have responded to environmental processes and changes over time
 
@@ -69,7 +69,7 @@ how First Nations Australians have responded to environmental processes and chan
 *  exploring evidence of how First Nations Australians responded to environmental changes in the Holocene epoch; for example, archaeological evidence that people maintained seasonal presence in the Willandra Lakes region at times when water was available, the maritime specialisation of those on the Torres Strait Islands and Cape York around 2,500 BP, and the de-population of islands such as Rottnest, Kangaroo and Flinders islands when cut off from the mainland
 *  investigating the water management techniques used by early First Nations Australians in environments with scarce supplies of fresh water, such as islands and deserts
 
-##### AC9HH7K05
+##### AC9HH7K05 {#ac9hh7k05}
 
 the technological achievements of early First Nations Australians, and how these developed in different places and contributed to daily life, and land and water source management
 
@@ -79,7 +79,7 @@ the technological achievements of early First Nations Australians, and how these
 *  exploring land and water management practices developed by early First Nations Australians, such as cultural burning practices, and the conservation and use of water through the development of weirs, irrigation and water evaporation reduction systems
 *  exploring aquaculture practices developed by early First Nations Australians, such as eel traps of the Gundtitjmara People at Budj Bim, Victoria, the mollusc harvesting of the Kombumerri People on the Gold Coast, Queensland, and stone fish traps used by the Ngemba People at Brewarrina, New South Wales
 
-##### AC9HH7K06
+##### AC9HH7K06 {#ac9hh7k06}
 
 the social organisation and cultural practices of early First Nations Australians, and their continuity and change over time
 
@@ -89,7 +89,7 @@ the social organisation and cultural practices of early First Nations Australian
 *  investigating important cultural practices of early First Nations Australians and their continuity and change over time; for example, lore, rites of passage, and the antiquity and types of funerary customs and burial practices such as the early example of cremation at the Willandra Lakes in New South Wales, the tombstone openings of the Torres Strait Islands and the log coffins used by the Yolngu Peoples of Arnhem Land
 *  exploring the existence of defined land, sea and sky territories, and the social and political systems that governed early First Nations Australians’ societies, such as land tenure systems, delineation and reciprocal access rights, and the trade and bartering of items such as ochre, medicine and trepang
 
-##### AC9HH7K07
+##### AC9HH7K07 {#ac9hh7k07}
 
 the cultural obligations of First Nations Australians about significant heritage sites, including ancestral remains, material culture and artefacts, and the role of collaboration between First Nations Australians and other individuals and groups to ensure cultural preservation
 
@@ -100,9 +100,9 @@ the cultural obligations of First Nations Australians about significant heritage
 *  investigating world heritage criteria for the listing of significant sites such as the Budj Bim and Willandra Lakes regions, and cultural landscapes such as Uluru-Kata Tjuta and Kakadu
 *  examining the role of national and state/territory galleries, libraries, archives, museums, historical societies and field-sites in curating, conserving and showcasing First Nations Australians’ histories and cultures
 
-#### The ancient world
+#### The ancient world {#the-ancient-world}
 
-##### AC9HH7K08
+##### AC9HH7K08 {#ac9hh7k08}
 
 the different methods and sources of evidence used by historians and archaeologists to investigate early societies, and the importance of archaeology and conserving the remains, material culture and heritage of the past
 
@@ -113,7 +113,7 @@ the different methods and sources of evidence used by historians and archaeologi
 *  examining the roles and responsibilities of governments and other bodies, such as UNESCO, in protecting key archaeological sites; for example, the rescue mission to save the temples of Abu Simbel or the campaign for the return of the Elgin Marbles to Greece
 *  investigating world heritage criteria for the listing of significant sites; for example, the Great Wall of China or the Mausoleum of the First Qin Emperor (Qin Shi Huang) or Mohenjo-dara in India
 
-##### AC9HH7K09
+##### AC9HH7K09 {#ac9hh7k09}
 
 how the physical environment and geographical features influenced the development of the ancient society
 
@@ -126,7 +126,7 @@ how the physical environment and geographical features influenced the developmen
 *  examining the role of climate in enabling the establishment and expansion of agriculture around the Yellow River and how this supported the ancient society
 *  describing the impact of topographic features, such as the Himalayas, rivers and seas, on contact with other societies, including trade and warfare
 
-##### AC9HH7K10
+##### AC9HH7K10 {#ac9hh7k10}
 
 the organisation and roles of key groups in ancient society such as the nobility, bureaucracy, women and slaves, and how they influenced and changed society
 
@@ -142,7 +142,7 @@ the organisation and roles of key groups in ancient society such as the nobility
 *  describing the role of women in shaping ancient society in the areas of marriage, family life, work and education
 *  outlining the rights and responsibilities of the Shi class
 
-##### AC9HH7K11
+##### AC9HH7K11 {#ac9hh7k11}
 
 key beliefs, values and practices of an ancient society, with a particular emphasis on one of the following areas: everyday life, warfare, or death and funerary customs
 
@@ -158,7 +158,7 @@ key beliefs, values and practices of an ancient society, with a particular empha
 *  identifying how the Mandate of Heaven assisted people in understanding and justifying periods of warfare
 *  investigating the significant beliefs, values and practices of Chinese society associated with daily life; for example, irrigation and the practice of agriculture, the teachings of Confucius, the evidence of daily life from the Han tombs
 
-##### AC9HH7K12
+##### AC9HH7K12 {#ac9hh7k12}
 
 causes and effects of contacts and conflicts within ancient societies and/or with other societies, resulting in developments such as the conquest of other lands, the expansion of trade and peace treaties
 
@@ -175,7 +175,7 @@ causes and effects of contacts and conflicts within ancient societies and/or wit
 *  <p>explaining the rise of imperial China; for example, through chariot warfare and the adoption of mass infantry armies, the building of the first phase of the Great Wall of China, military strategies as codified in Sun Tzu’s <em>The Art of War</em></p>
 *  describing indirect contact and interactions between the Roman Empire and the Han Dynasty
 
-##### AC9HH7K13
+##### AC9HH7K13 {#ac9hh7k13}
 
 the role and achievements of a significant individual in an ancient society
 
@@ -191,11 +191,11 @@ the role and achievements of a significant individual in an ancient society
 *  describing the social, political and cultural impact of Confucius on ancient Chinese society
 *  examining the historical context, early life and achievements of a significant historical figure such as Confucius or Qin Shi Huang, and how each was perceived by their contemporaries
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HH7S01
+##### AC9HH7S01 {#ac9hh7s01}
 
 develop historical questions about the past to inform historical inquiry
 
@@ -203,7 +203,7 @@ develop historical questions about the past to inform historical inquiry
 *  developing a key question such as “How were the pyramids at Giza built?” and understanding that there may not be a definitive answer; identifying related questions to inform the inquiry, including “What evidence is there?” and “What theories have been developed?”
 *  developing questions using historical concepts such as cause, effect, change, continuity, perspectives, interpretations and significance; for example, “What were the effects of rising sea levels on the movements of early First Nations Australians?”
 
-##### AC9HH7S02
+##### AC9HH7S02 {#ac9hh7s02}
 
 locate and identify primary and secondary sources to use in historical inquiry
 
@@ -214,9 +214,9 @@ locate and identify primary and secondary sources to use in historical inquiry
 *  examining methods for investigating the ancient past for providing information relevant to inquiry questions; for example, stratigraphy to date discoveries, DNA testing to identify past individuals from their remains (such as Egyptian mummies) and common diseases
 *  explaining the challenges of translation and intercultural understanding when interrogating sources of evidence, such as the inscriptions of Asoka and other edicts carved in stone and contained in religious literature, and the Vedas and epics of the Ramayana and Mahabharata
 
-#### Using historical sources
+#### Using historical sources {#using-historical-sources}
 
-##### AC9HH7S03
+##### AC9HH7S03 {#ac9hh7s03}
 
 identify the origin, content, context and purpose of primary and secondary sources
 
@@ -225,7 +225,7 @@ identify the origin, content, context and purpose of primary and secondary sourc
 *  identifying and explaining the origin, content, features and purposes of different sources in understanding the impact and legacy of a key individual such as Leonidas (King of Sparta), Pericles or Alexander the Great
 *  explaining the difficulties in identifying the origin and purpose of some sources, such as the Kimberley Bradshaw paintings
 
-##### AC9HH7S04
+##### AC9HH7S04 {#ac9hh7s04}
 
 identify and describe the accuracy and usefulness of primary and secondary sources as evidence
 
@@ -235,9 +235,9 @@ identify and describe the accuracy and usefulness of primary and secondary sourc
 *  distinguishing between a fact (for example, “Some gladiators wore helmets”) and an opinion (for example, “All gladiators were brave”)
 *  identifying information within a source that can be useful evidence to support an interpretation of an event, movement, individual, group or society
 
-#### Historical perspectives and interpretations
+#### Historical perspectives and interpretations {#historical-perspectives-and-interpretations}
 
-##### AC9HH7S05
+##### AC9HH7S05 {#ac9hh7s05}
 
 describe causes and effects, and explain continuities and changes
 
@@ -247,7 +247,7 @@ describe causes and effects, and explain continuities and changes
 *  identifying gaps in timelines or narratives and explaining possible reasons for why these gaps occur
 *  sequencing a range of primary sources in chronological order to support the development of an explanation of continuities or changes
 
-##### AC9HH7S06
+##### AC9HH7S06 {#ac9hh7s06}
 
 identify perspectives, attitudes and values of the past in sources
 
@@ -256,7 +256,7 @@ identify perspectives, attitudes and values of the past in sources
 *  identifying that, while evidence may be limited for a particular group of people such as women, slaves, peoples living in newly conquered areas and ethnic groups, such evidence can provide useful insights into the power structures of a society
 *  identifying the possible meanings of, and attitudes and values shown by, images and symbols in primary sources, such as funerary texts or religious manuscripts
 
-##### AC9HH7S07
+##### AC9HH7S07 {#ac9hh7s07}
 
 explain historical interpretations about significant events, individuals and groups
 
@@ -264,9 +264,9 @@ explain historical interpretations about significant events, individuals and gro
 *  examining different interpretations to explain short-term triggers and/or turning points of the decline of an empire or society, such as failing economy, political upheaval, foreign invasion or conflict
 *  developing a historical argument about why an event, individual or group is interpreted in different ways
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HH7S08
+##### AC9HH7S08 {#ac9hh7s08}
 
 create descriptions, explanations and historical arguments, using historical knowledge, concepts and terms that reference evidence from sources
 
@@ -276,7 +276,7 @@ create descriptions, explanations and historical arguments, using historical kno
 *  creating a presentation using different formats; for example, visual displays to recreate and show the specific features of an ancient battle, temple, pyramid complex or burial site supported by a timeline, annotations on a diagram or a summary
 *  developing a historical argument; for example, explaining the significance of a past event, providing reasons for the event with reference to relevant evidence
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 7, students describe the historical significance of the ancient past and the histories of early First Nations Peoples of Australia. They identify the causes and effects of events, developments and achievements connected to groups and individuals in Australia and other societies from the ancient past. Students describe the social, religious, cultural, economic, environmental and/or political aspects related to changes and continuities in these societies. They identify the roles and achievements of significant individuals and groups, and the influences on the development of ancient societies. Students explain the importance of heritage sites connected to Australia and other societies from the ancient past.
 

--- a/curriculum/hass-history/year-8.md
+++ b/curriculum/hass-history/year-8.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - History 7-10 - Year 8
+# History - Year 8 {#history-year-8}
 
-## Level Description
+## Level Description {#level-description}
 
 The Year 8 curriculum provides a study of history from the end of the ancient period to the beginning of the modern period (c.650–1750 CE). This was when major societies around the world came into contact with each other. Social, economic, religious and political beliefs were often challenged and significantly changed. It was the period when the modern world began to take shape.
 
@@ -36,13 +36,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   Which significant people, groups and ideas from this period have influenced and shaped the world today?
 *   How and why have historians interpreted this period differently?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Medieval Europe and the early modern world
+#### Medieval Europe and the early modern world {#medieval-europe-and-the-early-modern-world}
 
-##### AC9HH8K01
+##### AC9HH8K01 {#ac9hh8k01}
 
 the transformation of the ancient world to the early modern world, from the decline of the Roman Empire in western Europe through Medieval, Renaissance or pre-modern Europe
 
@@ -52,7 +52,7 @@ the transformation of the ancient world to the early modern world, from the decl
 *  investigating the emergence of ideas about the world such as those formed during the Renaissance, and the place of significant individuals and people that caused change
 *  explaining the historical significance of selected key events such as the conversion to Christianity of the Emperor Constantine in 312 CE and the invasion of England by William the Conqueror in 1066
 
-##### AC9HH8K02
+##### AC9HH8K02 {#ac9hh8k02}
 
 the roles and relationships of different groups in Medieval, Renaissance or pre-modern Europe
 
@@ -68,7 +68,7 @@ the roles and relationships of different groups in Medieval, Renaissance or pre-
 *  <p>describing the contribution of key theories such as Nicolaus Copernicus’ <em>De revolutionibus orbium coelestium</em>, Galileo’s <em>Dialogue Concerning the Two Chief World Systems</em> and Isaac Newton’s <em>Philosophiae Naturalis Principia Mathematica</em> to the changes brought about by the Scientific Revolution</p>
 *  examining the changes in economic activity created by the discoveries of new commodities, making the costs of basic foodstuffs lower and the quality higher, and the advancements of technologies such as in tools, armaments and shipbuilding
 
-##### AC9HH8K03
+##### AC9HH8K03 {#ac9hh8k03}
 
 a significant event, development, turning point or challenge that contributed to continuity and change in Medieval, Renaissance or pre-modern Europe
 
@@ -88,7 +88,7 @@ a significant event, development, turning point or challenge that contributed to
 *  examining how rulers in different European nations responded differently to new and dissenting ideas that were emerging by comparing the responses of France, England, Spain and Russia
 *  investigating the way of life in key features of the French “Ancien Régime” and how it represented increasing centralisation of administrative power in the monarchy
 
-##### AC9HH8K04
+##### AC9HH8K04 {#ac9hh8k04}
 
 the experiences and perspectives of rulers and of subject peoples, and the interaction between power and/or authority in Medieval, Renaissance or pre-modern Europe
 
@@ -101,7 +101,7 @@ the experiences and perspectives of rulers and of subject peoples, and the inter
 *  examining the change in the role and power of monarchies in the political systems of Western Europe, for example, decline of "absolutism", development of parliaments, and new ideas relating to nationalism
 *  investigating the changes and continuities in the political power of the bourgeoise and peasant classes with the growth of cities and increased urbanisation, and the movement of peoples
 
-##### AC9HH8K05
+##### AC9HH8K05 {#ac9hh8k05}
 
 the role and achievements of a significant individual and/or group in Medieval, Renaissance or pre-modern Europe
 
@@ -114,7 +114,7 @@ the role and achievements of a significant individual and/or group in Medieval, 
 *  investigating the importance of the Scientific Revolution, in particular the scientific theories and discoveries of Copernicus, Galileo, Kepler and Newton, for overturning traditional views of the motion of the planets, and how these contributed to science being seen by many as an alternative to the Church as a source of fundamental truth about reality
 *  investigating the role and significance of Oliver Cromwell and the execution of Charles I in the English Civil War in the development of the Westminster parliamentary system
 
-##### AC9HH8K06
+##### AC9HH8K06 {#ac9hh8k06}
 
 interpretations about an event, individual, group, institution or movement in Medieval, Renaissance or pre-modern Europe
 
@@ -125,9 +125,9 @@ interpretations about an event, individual, group, institution or movement in Me
 *  explaining how the interpretations of the discoveries of science are linked to ideas about the free exercise of human reason and how that could lead to improvements and progress in human life and society generally
 *  examining historical interpretations of key events, developments or achievements during this period, such as the Scientific Revolution or the beginnings of the Age of Reason/Enlightenment, and how these interpretations highlight their importance or significance to contemporary society
 
-#### Empires and expansions
+#### Empires and expansions {#empires-and-expansions}
 
-##### AC9HH8K07
+##### AC9HH8K07 {#ac9hh8k07}
 
 the significant social, religious, cultural, economic, environmental and/or political features of different groups related to the empire and/or expansion
 
@@ -140,7 +140,7 @@ the significant social, religious, cultural, economic, environmental and/or poli
 *  explaining how the environment of Viking lands in Scandinavia influenced the activities of societies
 *  describing pre-Columbian life in the Americas, including the social organisation of the Aztecs (for example, nobility and slaves), their beliefs (for example, worship of a number of gods and the need to make human sacrifices to appease these gods), and life in the capital city of Tenochtitlan
 
-##### AC9HH8K08
+##### AC9HH8K08 {#ac9hh8k08}
 
 a significant event, development, turning point or challenge that contributed to continuity and change related to the empire and/or expansion
 
@@ -162,7 +162,7 @@ a significant event, development, turning point or challenge that contributed to
 *  <p>outlining the effects of Spanish conquest on the Americas, such as the spread of disease, introduction of crops such as maize, beans, tobacco, chocolate and potatoes to Europe, the <em>Encomienda system</em>, mining and deforestation, and the impact of the loss of natural resources</p>
 *  explaining the longer-term effects of conquest and colonisation on the Indigenous populations of the Americas, such as the unequal distribution of land and wealth, slavery, political inequality, and supremacy of Spanish culture and language over conquered territories
 
-##### AC9HH8K09
+##### AC9HH8K09 {#ac9hh8k09}
 
 the experiences and perspectives of rulers and of subject peoples, and how the interaction between power and/or authority relates to the empire and/or expansion
 
@@ -177,7 +177,7 @@ the experiences and perspectives of rulers and of subject peoples, and how the i
 *  describing encounters between Hernán Cortés and the Aztecs, as well as the siege of Tenochtitlan
 *  investigating the impact of conquest on the Indigenous populations of the Americas (for example, the introduction of new diseases, horses and gunpowder, and the loss of natural resources) and the wider world (for example, the introduction of crops such as maize, beans, potatoes, tobacco and chocolate from the Americas to Europe and increased wealth in Europe)
 
-##### AC9HH8K10
+##### AC9HH8K10 {#ac9hh8k10}
 
 the role and achievements of a significant individual and/or group connected to the empire and/or expansion
 
@@ -188,7 +188,7 @@ the role and achievements of a significant individual and/or group connected to 
 *  comparing the artefacts discovered at L’Anse aux Meadows in Newfoundland (Canada) with Viking artefacts as possible evidence that the Vikings had journeyed to North America 500 years before Christopher Columbus
 *  explaining the significance of key chronological events in the lives of individuals such as Columbus, Balboa, Cortés, Montezuma II and/or Pizarro
 
-##### AC9HH8K11
+##### AC9HH8K11 {#ac9hh8k11}
 
 interpretations about the society and events, and/or individuals and/or groups connected to the empire and/or expansion
 
@@ -198,9 +198,9 @@ interpretations about the society and events, and/or individuals and/or groups c
 *  analysing the extent to which historians’ interpretations are corroborated with the oral histories contained in Icelandic sagas, such as about Erik the Red founding Greenland 
 *  analysing the extent to which historians’ interpretations that the Spanish conquest can be attributed to the pursuit of “Gold, God and Glory” differ
 
-#### Asia-Pacific world
+#### Asia-Pacific world {#asia-pacific-world}
 
-##### AC9HH8K12
+##### AC9HH8K12 {#ac9hh8k12}
 
 the significant social, religious, cultural, economic, environmental and/or political features of different groups in the Asian-Pacific society
 
@@ -211,7 +211,7 @@ the significant social, religious, cultural, economic, environmental and/or poli
 *  describing the way of life in one Polynesian society, including the social, cultural, economic and political features, such as the role of the ariki in Māori and in Rapa Nui society
 *  investigating the way of life of Easter Island (Rapa Nui) society; for example, fishing by the men; links between the household and the extended clan through the exchange of goods, wives and labour; the use of stone tools
 
-##### AC9HH8K13
+##### AC9HH8K13 {#ac9hh8k13}
 
 a significant development, event, turning point or challenge that contributed to continuity and change in the Asian-Pacific society
 
@@ -229,7 +229,7 @@ a significant development, event, turning point or challenge that contributed to
 *  explaining the significance of Rahui as a way of prohibiting the collection of resources to ensure their sustainability as a response to the decline and extinction of animals such as the moa
 *  explaining how environmental challenges were overcome on different islands to make settlement possible; for example, the practice of aquaculture in Nauru and/or agricultural practices in Hawaii
 
-##### AC9HH8K14
+##### AC9HH8K14 {#ac9hh8k14}
 
 the experiences and perspectives of rulers and of subject peoples, and the interaction between power and/or authority in the Asian-Pacific society
 
@@ -239,7 +239,7 @@ the experiences and perspectives of rulers and of subject peoples, and the inter
 *  examining artefacts such as Lapita pottery from Vanuatu, tapa cloth and/or ship-building techniques to provide insight into those societies
 *  describing the responsibilities and privileges of being a chief in a society such as those in New Zealand, Hawaii, Tonga and/or the Society Islands
 
-##### AC9HH8K15
+##### AC9HH8K15 {#ac9hh8k15}
 
 the role and achievements of a significant individual and/or group in the Asian-Pacific society
 
@@ -248,7 +248,7 @@ the role and achievements of a significant individual and/or group in the Asian-
 *  explaining the legacy of Tokugawa Ieyasu as founder of the Edo Shogunate
 *  describing the achievements of one Polynesian group of people such as Māori, Samoan, Tahitian (Maohi), Tongans or Rapa Nui
 
-##### AC9HH8K16
+##### AC9HH8K16 {#ac9hh8k16}
 
 interpretations about the Asian-Pacific society and events, and/or individuals and/or groups connected to the society
 
@@ -257,11 +257,11 @@ interpretations about the Asian-Pacific society and events, and/or individuals a
 *  evaluating the significance of the range of reasons for Japan’s closure to foreigners under the Tokugawa Shogunate and the impact of US Commodore Perry’s visit in 1853
 *  explaining the challenges posed by the lack of written sources in understanding the history of Polynesia, such as changes in interpretations of Lapita culture being present in Vanuatu
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HH8S01
+##### AC9HH8S01 {#ac9hh8s01}
 
 develop historical questions about the past to inform historical inquiry
 
@@ -270,7 +270,7 @@ develop historical questions about the past to inform historical inquiry
 *  developing questions about historical significance such as “How many people were affected by the Black Death?” and “How long did it last?”
 *  reviewing questions when faced with unexpected or challenging developments posed by the historical investigation; for example, “How was the organisation of Japanese society influenced by world events?”
 
-##### AC9HH8S02
+##### AC9HH8S02 {#ac9hh8s02}
 
 locate and identify primary and secondary sources to use in historical inquiry
 
@@ -278,9 +278,9 @@ locate and identify primary and secondary sources to use in historical inquiry
 *  organising sources into categories such as primary and secondary sources and/or written, visual, material culture, and artefacts; for example, sources from the period investigated including journals, church records, paintings, artefacts, and sites and sources written after the period including fictional and artistic interpretations, and academic texts
 *  retrieving relevant information from multiple digital sources, including repositories of primary sources, maps and photographs of culturally significant artefacts such as online platforms, and using advanced search functions to refine the search
 
-#### Using historical sources
+#### Using historical sources {#using-historical-sources}
 
-##### AC9HH8S03
+##### AC9HH8S03 {#ac9hh8s03}
 
 identify the origin, content, context and purpose of primary and secondary sources
 
@@ -289,7 +289,7 @@ identify the origin, content, context and purpose of primary and secondary sourc
 *  explaining how clues within a source can be used to identify where it was made or who it was made by; for example, the place where it was found, the materials used, the condition of the object, decorative features
 *  discussing the difficulty of identifying the origin and purpose of some sources, and how this can impact on the source’s usefulness
 
-##### AC9HH8S04
+##### AC9HH8S04 {#ac9hh8s04}
 
 identify and describe the accuracy and usefulness of primary and secondary sources as evidence
 
@@ -298,9 +298,9 @@ identify and describe the accuracy and usefulness of primary and secondary sourc
 *  distinguishing between fact (for example, “The moai were constructed on Easter Island [Rapa Nui]”) and opinion or interpretation (for example, “The moai on Easter Island [Rapa Nui] are representations of gods”)
 *  using strategies to detect whether a statement is fact or opinion, including word choices that may indicate an opinion is being offered; for example, the use of conditionals “might” and “could”, and words such as “believe”, “think” and “suggests”
 
-#### Historical perspectives and interpretations
+#### Historical perspectives and interpretations {#historical-perspectives-and-interpretations}
 
-##### AC9HH8S05
+##### AC9HH8S05 {#ac9hh8s05}
 
 describe causes and effects, and explain continuities and changes
 
@@ -308,7 +308,7 @@ describe causes and effects, and explain continuities and changes
 *  sequencing historical events to identify broader patterns of cause and/or effect, and change and/or continuity across society, and explaining their observations with reference to key events, individuals, themes and sources of evidence
 *  describing continuities by highlighting the lack of deviation, the similarities of important aspects, and the widespread nature of similarities in the era, period or society despite an event, idea, person, group or movement achieving short-term significance
 
-##### AC9HH8S06
+##### AC9HH8S06 {#ac9hh8s06}
 
 identify perspectives, attitudes and values of the past in sources
 
@@ -316,7 +316,7 @@ identify perspectives, attitudes and values of the past in sources
 *  describing the values and attitudes revealed by a source such as an individual account, and using additional sources to show how they are broadly representative or contrast the values and attitudes of the society
 *  identifying the perspective in a source and discussing the values and attitudes of the society that produced it; for example, explaining why historians have different interpretations, including access to source material, personal views and other contextual factors influencing the time in which the historian was working
 
-##### AC9HH8S07
+##### AC9HH8S07 {#ac9hh8s07}
 
 explain historical interpretations about significant events, individuals and groups
 
@@ -325,9 +325,9 @@ explain historical interpretations about significant events, individuals and gro
 *  identifying different interpretations of an event or development, such as the influence of scientific ideas or the status of women, and accounting for the differences
 *  using historical interpretations to describe change in relation to quality, type, speed and impact
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HH8S08
+##### AC9HH8S08 {#ac9hh8s08}
 
 create descriptions, explanations and historical arguments, using historical knowledge, concepts and terms that reference evidence from sources
 
@@ -336,7 +336,7 @@ create descriptions, explanations and historical arguments, using historical kno
 *  presenting findings or historical knowledge in range of formats, such as a podcast, an oral presentation or an essay, appropriate to audience and purpose with reference to evidence
 *  developing descriptions and explanations, applying historical terms and concepts in their appropriate historical context
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8, students describe the historical significance of the periods between the ancient and modern past. They explain the causes and effects of events, developments, turning points or challenges in Medieval, Renaissance or pre-modern Europe, or in the societies connected to the empires or expansions, or the societies of the Asia-Pacific world during these periods. They describe the social, religious, cultural, economic, environmental and/or political aspects related to the changes and continuities in a society or a historical period. Students describe the role of significant individuals, groups and institutions connected to the societies of these periods and their influences on historical events.
 

--- a/curriculum/hass-history/year-9.md
+++ b/curriculum/hass-history/year-9.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - History 7-10 - Year 9
+# History - Year 9 {#history-year-9}
 
-## Level Description
+## Level Description {#level-description}
 
 The Year 9 curriculum provides a study of the history of the making of the modern world from 1750 to 1918. This was a period of industrialisation and rapid change in the ways people lived, worked and thought. It was an era of nationalism and imperialism, and expansion of European power, which had significant effects on First Nations Peoples globally. The period culminated in World War I (1914–1918), the “war to end all wars”.
 
@@ -16,13 +16,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   What were the perspectives of different people at the time?
 *   What are the contested debates and reasons for different historical interpretations?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Making and transforming the Australian nation (1750–1914)
+#### Making and transforming the Australian nation (1750–1914) {#making-and-transforming-the-australian-nation-17501914}
 
-##### AC9HH9K01
+##### AC9HH9K01 {#ac9hh9k01}
 
 the causes and effects of European imperial expansion and the movement of peoples in the late 18th and early 19th centuries, and the different responses to colonisation and migration
 
@@ -31,7 +31,7 @@ the causes and effects of European imperial expansion and the movement of people
 *  identifying and describing the effects of the movements of peoples on colonised peoples, such as dispossession, disease, and destruction of traditional society and culture
 *  examining data on the movement of peoples in the period, such as the number of slaves transported and the nations/places involved, including Portugal, Britain, France, Spain, North America, or the number of people forced to migrate from Ireland due to the potato famine, and the nations/places they emigrated to, such as the United States, Canada and Australia
 
-##### AC9HH9K02
+##### AC9HH9K02 {#ac9hh9k02}
 
 the key social, cultural, economic and political changes and their significance in the development of Australian society during the period
 
@@ -39,7 +39,7 @@ the key social, cultural, economic and political changes and their significance 
 *  examining the different contexts of the Australian colonies and explaining their influences; for example, analysing and evaluating the effects of physical isolation on the development of the Swan River Colony in Western Australia, the deliberate exclusion of convicts in the colonisation of South Australia, the discovery of gold on the development of Victoria, and the expansion across the Blue Mountains in New South Wales
 *  examining the development of Australia’s economy from the early days of settlement up to the First World War, in particular agricultural and pastoral industries, and the key role played by the “squattocracy” and figures such as Elizabeth Macarthur
 
-##### AC9HH9K03
+##### AC9HH9K03 {#ac9hh9k03}
 
 the causes and effects of European contact and extension of settlement, including their impact on the First Nations Peoples of Australia
 
@@ -51,7 +51,7 @@ the causes and effects of European contact and extension of settlement, includin
 *  investigating how First Nations Australians responded to colonisation, including through making important contributions to the various industries that were established on their lands and waters, adopting Christianity and other settler religions
 *  investigating the forcible removal of children from First Nations Australian families in the late 19th century and 20th century (leading to the Stolen Generations), including the motivations for the removal of children, the practices and laws that were in place, and experiences of separation
 
-##### AC9HH9K04
+##### AC9HH9K04 {#ac9hh9k04}
 
 significant events, ideas, people, groups and movements in the development of Australian society
 
@@ -63,7 +63,7 @@ significant events, ideas, people, groups and movements in the development of Au
 *  <p>analysing the significance of the advance of women’s voting rights to the development of Australian democracy, including the suffragist movements, the Christian Women's Temperance Union and the <em>Commonwealth Franchise Act</em> 1902</p>
 *  <p>investigating key people and groups involved in the Federation movement and the development of an Australian identity, such as Sir Henry Parkes, Sir Samuel Griffith, William Guthrie Spence, John Feltham Archibald, Catherine Helen Spence, Alfred Deakin, Tom Roberts, Frederick McCubbin, Arthur Streeton, Joseph Furphy, Barbara Baynton, Banjo Paterson, Henry Lawson, “Federation leagues”, the Australian Natives Association and <em>The Bulletin</em></p>
 
-##### AC9HH9K05
+##### AC9HH9K05 {#ac9hh9k05}
 
 continuities and changes and their effects on ways of life and living conditions, political and legal institutions, and cultural expression around the turn of the 20th century in Australian society
 
@@ -73,7 +73,7 @@ continuities and changes and their effects on ways of life and living conditions
 *  identifying the main features of housing, sanitation, transport, education, agriculture and industry that influenced living and working conditions in Australia around 1900 and comparing them with early colonisation around 1800
 *  explaining how laws made by the federal parliament, such as those resulting from the Harvester Judgement or the introduction of pensions, affected working conditions and standards of living
 
-##### AC9HH9K06
+##### AC9HH9K06 {#ac9hh9k06}
 
 different experiences and perspectives of colonisers, settlers and First Nations Australians and the impact of these experiences on changes to Australian society's ideas, beliefs and values
 
@@ -84,7 +84,7 @@ different experiences and perspectives of colonisers, settlers and First Nations
 *  examining the experiences of non-Europeans in Australia prior to the 1900s, such as Japanese pearlers in Darwin, Chinese people on the goldfields in Victoria and New South Wales, South Sea Islanders on sugar plantations in Queensland, and Afghan cameleers in central Australia
 *  exploring the perspectives and experiences of First Nations Australians, including discussing terms in relation to Australian history such as “invasion”, “colonisation” and “settlement”, and why these continue to be contested within society today
 
-##### AC9HH9K07
+##### AC9HH9K07 {#ac9hh9k07}
 
 the development of Australian society in relation to other nations in the world by 1914, including the effects of ideas and movements of people
 
@@ -92,9 +92,9 @@ the development of Australian society in relation to other nations in the world 
 *  <p>investigating how the major social legislation of the new Federal Government affected living and working conditions in Australia; for example, the Harvester Judgment, the <em>Immigration Restriction Act 1901</em>, invalid and old-age pensions, the maternity allowance scheme and the <em>Defence Act 1903</em></p>
 *  explaining the continuities and changes in the role of women, such as advocating for women’s rights, suffrage, political representation and pacificism; (for example, Elizabeth Macquarie, Caroline Chisholm, Catherine Helen Spence, Louisa Lawson, Muriel Matters, Vida Goldstein)
 
-#### First World War (1914–1918)
+#### First World War (1914–1918) {#first-world-war-19141918}
 
-##### AC9HH9K08
+##### AC9HH9K08 {#ac9hh9k08}
 
 the causes of the First World War and the reasons why Australians enlisted to fight in the war
 
@@ -106,7 +106,7 @@ the causes of the First World War and the reasons why Australians enlisted to fi
 *  listing the reasons why Australian men enlisted in the Australian Imperial Force; for example, the challenges of living on the land and a need for a regular pay; adventure; to do their duty for the British Empire; impact of persuasive propaganda posters, pamphlets and leaflets; peer and community pressure
 *  examining the stories of First Nations Australian men who enlisted in the Australian Imperial Force
 
-##### AC9HH9K09
+##### AC9HH9K09 {#ac9hh9k09}
 
 the places of significance where Australians fought, their perspectives and experiences, including the Gallipoli campaign, the Western Front and the Middle East
 
@@ -115,7 +115,7 @@ the places of significance where Australians fought, their perspectives and expe
 *  investigating the difficulties of trench warfare, the development of military technology such as the use of tanks, aeroplanes and chemical weapons (gas)
 *  comparing and contrasting the different experiences of war, such as those of foot soldiers on the Western Front compared with those of the Light Horse in Palestine
 
-##### AC9HH9K10
+##### AC9HH9K10 {#ac9hh9k10}
 
 significant events and turning points of the war and the nature of warfare, including the Western Front Battle of the Somme and the Armistice
 
@@ -124,7 +124,7 @@ significant events and turning points of the war and the nature of warfare, incl
 *  examining the perspectives of those who fought on both sides using sources such as diaries, letters and newspapers 
 *  evaluating the significance of the Russian Revolution, American entry into the war and the Armistice of November 1918 in ending the war 
 
-##### AC9HH9K11
+##### AC9HH9K11 {#ac9hh9k11}
 
 the effects of the First World War on Australian society, such as the role of women, political debates about conscription, relationships with the British Empire, and the experiences of returned soldiers
 
@@ -134,7 +134,7 @@ the effects of the First World War on Australian society, such as the role of wo
 *  examining the continuities and changes in Australia’s relationship with the British Empire, such as changing sentiments about Britain as the mother country
 *  explaining the effects of war on returned soldiers, including First Nations Australian soldiers, such as physical and psychological trauma, shell shock, employment opportunities, social and racial discrimination, service recognition, land allocation (Soldier Settlement Scheme), wage inequality, and access to health care and pensions
 
-##### AC9HH9K12
+##### AC9HH9K12 {#ac9hh9k12}
 
 the commemoration of the First World War, including different historical interpretations and debates about the nature and significance of the Anzac legend and the war
 
@@ -144,9 +144,9 @@ the commemoration of the First World War, including different historical interpr
 *  identifying differences between commemoration and glorification of war
 *  evaluating the fairness of post-war treaties on the defeated powers, such as the Treaty of Versailles on Germany
 
-#### The Industrial Revolution and the movement of peoples (1750–1900)
+#### The Industrial Revolution and the movement of peoples (1750–1900) {#the-industrial-revolution-and-the-movement-of-peoples-17501900}
 
-##### AC9HH9K13
+##### AC9HH9K13 {#ac9hh9k13}
 
 the social, economic, political, technological and/or environmental causes and effects of the Industrial Revolution on Europe in the late 18th and 19th century
 
@@ -156,7 +156,7 @@ the social, economic, political, technological and/or environmental causes and e
 *  analysing factors that caused the Industrial Revolution; for example, the Agricultural Revolution, Enlightenment ideas, access to raw materials, a growing population, a wealthy middle class, increased individual freedom, access to cheap labour, improvements to the transport system, inventions and innovations, trade and commerce, and an expanding empire
 *  evaluating the most significant effects of the Industrial Revolution, such as economic growth, changing economic and social structures, changes in working conditions, a rise in the standard of living, growth of the middle class, new ideas, imperialism and environmental impacts
 
-##### AC9HH9K014
+##### AC9HH9K014 {#ac9hh9k014}
 
 the changing population movements and settlement patterns during the period 1750 to 1900
 
@@ -165,7 +165,7 @@ the changing population movements and settlement patterns during the period 1750
 *  explaining the role of the Industrial Revolution in creating a growing need for labour and transportation
 *  identifying and describing the various push factors for the movement of peoples in the transatlantic slave trade, the Irish Potato Famine and convict transportation, such as the Agricultural Revolution, the Industrial Revolution, discrimination and persecution, and forced migration
 
-##### AC9HH9K15
+##### AC9HH9K15 {#ac9hh9k15}
 
 the short-, medium- and long-term effects of population movements and changing settlement patterns during this period, such as global demographic changes, transport, new ideas, and political and social reforms
 
@@ -174,7 +174,7 @@ the short-, medium- and long-term effects of population movements and changing s
 *  investigating the impact of the development of the steam engine on transport, manufacturing and trade
 *  explaining how social and political reforms resulted in higher standards of living for many, including in health care and education, and political and workplace reforms
 
-##### AC9HH9K16
+##### AC9HH9K16 {#ac9hh9k16}
 
 the different perspectives and experiences of men, women and children during the Industrial Revolution, and their changing way of life
 
@@ -183,7 +183,7 @@ the different perspectives and experiences of men, women and children during the
 *  investigating the changes in working conditions, such as longer working hours for low pay and the use of children as a cheap source of labour
 *  identifying the growth of trade unions as a response to the impacts of the Industrial Revolution on the working class
 
-##### AC9HH9K17
+##### AC9HH9K17 {#ac9hh9k17}
 
 the ideas that emerged and influenced change in society, such as nationalism, capitalism, imperialism, socialism, egalitarianism and Chartism
 
@@ -192,7 +192,7 @@ the ideas that emerged and influenced change in society, such as nationalism, ca
 *  examining the causes and impacts of the French Revolution on politics and citizens’ rights including in the United Kingdom and the USA
 *  examining the role of religious beliefs in the movement to end the slave trade, reforms to improve the negative effects of the Industrial Revolution, the enfranchisement of women and the rise of organised labour
 
-##### AC9HH9K18
+##### AC9HH9K18 {#ac9hh9k18}
 
 the role of a significant individual or group such as agricultural and factory workers, inventors and entrepreneurs, landowners, politicians and religious groups in promoting and enacting some of the ideas that emerged during the Industrial Revolution
 
@@ -200,9 +200,9 @@ the role of a significant individual or group such as agricultural and factory w
 *  <p>explaining responses to particular ideas; for example, how religious groups responded to ideas in Charles Darwin’s 1859 book <em>On the Origin of Species</em> or how workers responded to the idea of capitalism or socialism</p>
 *  investigating the role played by an individual or group in promoting a key idea; for example, the role of Adam Smith and entrepreneurs in promoting capitalism, Florence Nightingale in promoting reform to health care and the rights of women, Pope Leo XIII in promoting the rights of workers in capitalist economies, Chartist William Cuffay in Tasmania or British Chartists on the goldfields in Victoria and New South Wales
 
-#### Asia and the World (1750–1914)
+#### Asia and the World (1750–1914) {#asia-and-the-world-17501914}
 
-##### AC9HH9K19
+##### AC9HH9K19 {#ac9hh9k19}
 
 the key social, cultural, economic and political features of an Asian society during the 18th and early 19th Century
 
@@ -211,7 +211,7 @@ the key social, cultural, economic and political features of an Asian society du
 *  investigating the territorial extent of the Mughal Empire in India, the role and influence of the Mughal emperor, and the art and architecture of Mughal India, such as the Taj Mahal
 *  examining the influence of the Tokugawa Shogunate on Japan’s political, economic and social development
 
-##### AC9HH9K20
+##### AC9HH9K20 {#ac9hh9k20}
 
 the causes and effects of European contact, including colonialisation, on an Asian society
 
@@ -221,7 +221,7 @@ the causes and effects of European contact, including colonialisation, on an Asi
 *  examining the development of the British Raj and identifying British influences on Indian society
 *  investigating the short- and long-term effects of Dutch trade and colonisation on Indonesian society from the 17th century
 
-##### AC9HH9K21
+##### AC9HH9K21 {#ac9hh9k21}
 
 significant events, ideas, people, groups and/or movements in the development of an Asian society
 
@@ -232,7 +232,7 @@ significant events, ideas, people, groups and/or movements in the development of
 *  describing the role of the British East India Company, the Sepoy Rebellion, the Indian National Congress, Gopal Krishna Gokhale, Dadabhai Naoroji, Bal Gangadhar Tilak and Mohandas K. Gandhi in the development of Indian nationalism
 *  examining the contribution of Diponegoro, the Java War, Budi Utomo (Boedi Oetomo), Sarekat Islam, Sukarno, Mohammad Hatta, Sutan Sjahrir to Indonesian independence
 
-##### AC9HH9K22
+##### AC9HH9K22 {#ac9hh9k22}
 
 continuities and changes and their effects on the ways of life and living conditions, political and legal institutions, and cultural expression around the turn of the 20th century in an Asian society
 
@@ -242,7 +242,7 @@ continuities and changes and their effects on the ways of life and living condit
 *  investigating what remained the same or changed during this period as a result of contact with European powers such as describing the British Raj and identifying British influences on society (for example, the building of roads, an extensive railway network, schools and Christian missions) and the impact of the introduction of British government and law
 *  comparing the Cultivation System and the Ethical System in the Dutch East Indies (Indonesia)
 
-##### AC9HH9K23
+##### AC9HH9K23 {#ac9hh9k23}
 
 different experiences and perspectives of colonisers and Asian peoples from the time and the impact of changes to society, including events, ideas, beliefs and values
 
@@ -250,18 +250,18 @@ different experiences and perspectives of colonisers and Asian peoples from the 
 *  comparing and contrasting different perspectives about the effect of European colonisation on Asian countries for example, the views of people in various mainland provinces of China, the views of samurai on Meiji modernisation, views of British Raj families versus members of the Independence Movement in India, views of the Dutch colonials versus native Indonesians in the Dutch East Indies (Indonesia)
 *  comparing the similarities and differences in historians’ views about the significance of Western colonial influences on Asian countries, such as Americans in Japan, the British in India, or the Dutch in the Dutch East Indies (Indonesia)
 
-##### AC9HH9K24
+##### AC9HH9K24 {#ac9hh9k24}
 
 the development of an Asian society in relation to other nations in the world by 1914, including the effects of ideas such as nationalism and self-determination
 
 **Elaborations**
 *  investigating the confrontation between an Asian country and Western powers, such as the Sino–French war, the Russo–Japanese war, or the increasing demand for Indian or Indonesian independence and self-government 
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HH9S01
+##### AC9HH9S01 {#ac9hh9s01}
 
 develop and modify a range of historical questions about the past to inform historical inquiry
 
@@ -270,7 +270,7 @@ develop and modify a range of historical questions about the past to inform hist
 *  developing an inquiry question such as “What were the effects of the Industrial Revolution?” and refining it as further factors are introduced into the research process
 *  modifying questions using historical concepts such as cause, effect, change and continuity
 
-##### AC9HH9S02
+##### AC9HH9S02 {#ac9hh9s02}
 
 locate, identify and compare primary and secondary sources to use in historical inquiry
 
@@ -279,9 +279,9 @@ locate, identify and compare primary and secondary sources to use in historical 
 *  recognising the role of technology in providing access to sources, such as the ability to access resources that historians use 
 *  comparing sources to analyse changes over time, including data from online records such as immigration records
 
-#### Using historical sources
+#### Using historical sources {#using-historical-sources}
 
-##### AC9HH9S03
+##### AC9HH9S03 {#ac9hh9s03}
 
 identify the origin and content of sources, and explain the purpose and context of primary and secondary sources
 
@@ -291,7 +291,7 @@ identify the origin and content of sources, and explain the purpose and context 
 *  explaining the events, ideas and individuals represented in a visual source
 *  analysing the intent of the author and purpose of the source
 
-##### AC9HH9S04
+##### AC9HH9S04 {#ac9hh9s04}
 
 explain the usefulness of primary and secondary sources, and the reliability of the information as evidence
 
@@ -299,9 +299,9 @@ explain the usefulness of primary and secondary sources, and the reliability of 
 *  identifying that the reliability and usefulness of a source depends on the questions asked of it, such as an account having a particular historical perspective and therefore being of use in revealing past prevailing attitudes
 *  determining the extent to which the accuracy or purpose of a source affects its usefulness
 
-#### Historical perspectives and interpretations
+#### Historical perspectives and interpretations {#historical-perspectives-and-interpretations}
 
-##### AC9HH9S05
+##### AC9HH9S05 {#ac9hh9s05}
 
 analyse cause and effect, and evaluate patterns of continuity and change
 
@@ -309,7 +309,7 @@ analyse cause and effect, and evaluate patterns of continuity and change
 *  creating a timeline that identifies the significant events or individuals across a particular period, observing and discussing patterns of causation and change, and/or identifying parts of the world that were involved in or affected by a significant event
 *  organising a range of primary sources and/or perspectives in chronological order to support the development of a historical argument about continuities or changes
 
-##### AC9HH9S06
+##### AC9HH9S06 {#ac9hh9s06}
 
 compare perspectives in sources and explain how these are influenced by significant events, ideas, locations, beliefs and values
 
@@ -318,7 +318,7 @@ compare perspectives in sources and explain how these are influenced by signific
 *  comparing and contrasting the range of perspectives at the time surrounding a historical event, and consider voices that may be absent from the sources such as those of women, men, children, ethnic groups, Indigenous peoples and minority groups
 *  discussing whether the perspective of one individual in the period is representative of a majority or minority view at that time
 
-##### AC9HH9S07
+##### AC9HH9S07 {#ac9hh9s07}
 
 analyse different and contested historical interpretations
 
@@ -328,9 +328,9 @@ analyse different and contested historical interpretations
 *  identifying different interpretations of specific events (for example, the debate about conscription in Australia during the First World War)
 *  analysing how historians have changed the way they interpret the event under investigation over time, such as a change in view with the discovery of more sources (for example, as with frontier conflicts in Australia)
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HH9S08
+##### AC9HH9S08 {#ac9hh9s08}
 
 create descriptions, explanations and historical arguments, using historical knowledge, concepts and terms that incorporate and acknowledge evidence from sources
 
@@ -340,7 +340,7 @@ create descriptions, explanations and historical arguments, using historical kno
 *  developing an explanation, interpretation or argument using historical concepts and terms such as contested historical interpretations
 *  constructing a historical argument using selected evidence from sources to support an interpretation of the past; for example, to affect the audience or justify an argument about a commemoration, settler societies or the Industrial Revolution
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 9, students explain the historical significance of the period of the early modern world up to 1918. They explain the causes and effects of events, developments, turning points or movements globally, in Australia, and in relation to the First World War or in an Asian context. They describe the social, cultural, economic and/or political aspects related to the changes and continuities in a society or a historical period. Students explain the role of significant ideas, individuals, groups and institutions connected to the developments of this period and their influences on the historical events.
 

--- a/curriculum/hass/foundation-year.md
+++ b/curriculum/hass/foundation-year.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - HASS F-6 - Foundation Year
+# Foundation Year {#foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 In Foundation, the focus is on **"my personal world"**.
 
@@ -13,13 +13,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   Who am I, where do I live and who came before me?
 *   Why are some places and events special, and how do we know?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### History
+#### History {#history}
 
-##### AC9HSFK01
+##### AC9HSFK01 {#ac9hsfk01}
 
 the people in their family, where they were born and raised, and how they are related to each other
 
@@ -28,7 +28,7 @@ the people in their family, where they were born and raised, and how they are re
 *  creating drawings of family members accompanied by information collected from questions and observations to share details of that person’s life, including the places they were born and raised
 *  creating concept maps of their family with pictures or photographs to show connections to those people who make up their family
 
-##### AC9HSFK02
+##### AC9HSFK02 {#ac9hsfk02}
 
 the celebrations and commemorations of significant events shared with their families and others
 
@@ -36,9 +36,9 @@ the celebrations and commemorations of significant events shared with their fami
 *  responding to a provided calendar of events that students, their family and friends celebrate or commemorate; for example, birthdays; religious festivals such as Easter, Ramadan, Buddha’s Birthday, Feast of Passover and Coming of the Light; family reunions; cultural festivals; and community commemorations such as NAIDOC Week and Anzac Day, and discussing why they are important
 *  discussing ways of celebrating these significant occasions; for example, special meals, family gatherings, visiting special places, and the role of art, music, telling stories and handing on traditions from generation to generation for First Nations Australians
 
-#### Geography
+#### Geography {#geography}
 
-##### AC9HSFK03
+##### AC9HSFK03 {#ac9hsfk03}
 
 the features of familiar places they belong to, why some places are special and how places can be looked after
 
@@ -48,7 +48,7 @@ the features of familiar places they belong to, why some places are special
 *  identifying reasons why people live in or visit places, such as the provision of basic needs (water, food, shelter), to enhance lives (holiday places, places for recreation, for religious observance) and to maintain cultural connections to Country/Place
 *  discussing different ways they could or do contribute to caring for special places, including those that are unique; for example, planting trees for a local endangered species, cleaning up litter at a local park or beach, or planting flora in a local wetland
 
-##### AC9HSFK04
+##### AC9HSFK04 {#ac9hsfk04}
 
 the importance of Country/Place to First Nations Australians and the Country/Place on which the school is located
 
@@ -58,11 +58,11 @@ the importance of Country/Place to First Nations Australians and the Country/
 *  listening and responding to invited members of the Traditional Owner group talking about Country/Place, and places of cultural and historical significance to the First Nations Australian community in the local neighbourhood, suburb, town or rural area
 *  identifying local places of significance for First Nations Australians in the local area
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HSFS01
+##### AC9HSFS01 {#ac9hsfs01}
 
 pose questions about familiar objects, people, places and events
 
@@ -71,7 +71,7 @@ pose questions about familiar objects, people, places and events
 *  posing questions about the features of places and how they can look after them, after being encouraged to observe them using various senses
 *  posing questions about what makes events and places special; for example “What special events do my family celebrate?”, “What makes my favourite places special?”
 
-##### AC9HSFS02
+##### AC9HSFS02 {#ac9hsfs02}
 
 sort and record information including pictorial timelines and locations on pictorial maps or models
 
@@ -79,9 +79,9 @@ sort and record information including pictorial timelines and locations on picto
 *  sorting and displaying sources (for example, historical sources such as pictures, photographs and family mementoes) to organise a display about a family member or significant family event and creating pictorial timelines, such as adding photos or drawings of significant events as they happen, to create a timeline of events over the year
 *  identifying features on a provided pictorial map or oblique aerial photograph of a familiar place and linking the representation of specific features to pictures they have drawn of those features; for example, using a pictorial map of a visited site such as a public garden or an oblique aerial photograph of their school to find familiar features, and then linking drawings of those features with lines to the features in the map or aerial photograph
 
-#### Interpreting, analysing and evaluating
+#### Interpreting, analysing and evaluating {#interpreting-analysing-and-evaluating}
 
-##### AC9HSFS03
+##### AC9HSFS03 {#ac9hsfs03}
 
 share a perspective on information, such as stories about significant events and special places
 
@@ -89,9 +89,9 @@ share a perspective on information, such as stories about significant events and
 *  sharing aspects of events special to past generations of their family from provided stories and discussing why those events and places are special
 *  identifying a place in their local area that they like, and talking about why they like it and how they could care for it
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HSFS04
+##### AC9HSFS04 {#ac9hsfs04}
 
 draw conclusions in response to questions
 
@@ -101,9 +101,9 @@ draw conclusions in response to questions
 *  exploring the location and features of places they belong to and what makes those places special
 *  suggesting ways that they are going to care for their classroom, bedroom or playground
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HSFS05
+##### AC9HSFS05 {#ac9hsfs05}
 
 share narratives and observations, using sources and terms about the past and places
 
@@ -112,7 +112,7 @@ share narratives and observations, using sources and terms about the past and pl
 *  using terms about time when talking about their experiences; for example, “then”, “now”, “yesterday”, “today”, “tomorrow”
 *  using appropriate terms to describe the direction and location of a place such as “near and far”, “above and below”, “beside and opposite”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Foundation, students identify significant people and events in their own lives, and how significant events are celebrated or commemorated. Students recognise the features of familiar places, why some places are special to people and the ways they can care for them.
 

--- a/curriculum/hass/year-1.md
+++ b/curriculum/hass/year-1.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - HASS F-6 - Year 1
+# Humanities and Social Sciences - Year 1 {#humanities-and-social-sciences-year-1}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 1, the focus is on **"how my world is different from the past and can change in the future"**.
 
@@ -13,13 +13,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How has family life and the place we live in changed and stayed the same over time?
 *   What events, activities and places do I care about? Why?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### History
+#### History {#history}
 
-##### AC9HS1K01
+##### AC9HS1K01 {#ac9hs1k01}
 
 differences in family structures and roles today, and how these have changed or remained the same over time
 
@@ -28,7 +28,7 @@ differences in family structures and roles today, and how these have changed or 
 *  comparing families in the present with those from the recent past, for example, the size of families across the generations
 *  examining the roles of family members over time, such as roles of parents, children and extended family members, and comparing these with family roles today
 
-##### AC9HS1K02
+##### AC9HS1K02 {#ac9hs1k02}
 
 continuity and change between aspects of their daily lives and their parents’ and grandparents’ childhoods
 
@@ -38,9 +38,9 @@ continuity and change between aspects of their daily lives and their parents’
 *  examining the traditional toys used by First Nations Australian children to play and learn; for example, Arrernte children learn to play string games so they can remember stories they have been told
 *  identifying similarities and differences in classroom equipment, learning activities, school playgrounds and playground games through observations of provided artefacts and photos, and asking questions of adults from different generations
 
-#### Geography
+#### Geography {#geography}
 
-##### AC9HS1K03
+##### AC9HS1K03 {#ac9hs1k03}
 
 the natural, managed and constructed features of local places, and their location
 
@@ -51,7 +51,7 @@ the natural, managed and constructed features of local places, and their locat
 *  describing the daily and seasonal weather of their place using simple terms such as “rainy”, “hot”, “cold”, “windy” and “cloudy”, and comparing it with the weather of other places that they know or are aware of; for example, “It was windy at the beach but not at my house”, “It is colder on the mountain”, “It is rainy in the winter”, “It is hot in the summer”
 *  explaining to classmates where places are and the directions to be followed when moving from one place to another, with the use of appropriate terms for direction and location; for example, terms such as “beside”, “forward”, “up”, “down”, “by”, “near”, “further”, “close to”, “before”, “after”, “here”, “there”, “at”
 
-##### AC9HS1K04
+##### AC9HS1K04 {#ac9hs1k04}
 
 how places change and how they can be cared for by different groups including First Nations Australians
 
@@ -62,11 +62,11 @@ how places change and how they can be cared for by different groups including 
 *  describing local features that people look after, finding out why and how these features need to be cared for, and who provides this care; for example, bushland, wetlands, a park or a heritage building
 *  investigating examples of how First Nations Australians manage and care for places
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HS1S01
+##### AC9HS1S01 {#ac9hs1s01}
 
 develop questions about objects, people, places and events in the past and present
 
@@ -75,7 +75,7 @@ develop questions about objects, people, places and events in the past and 
 *  asking questions before, during and after listening to stories about people and places, and about their past and present
 *  preparing questions for parents and members of older generations about how and where they lived in the past, and the places they value
 
-##### AC9HS1S02
+##### AC9HS1S02 {#ac9hs1s02}
 
 collect, sort and record information and data from observations and from provided sources, including unscaled timelines and labelled maps or models
 
@@ -86,9 +86,9 @@ collect, sort and record information and data from observations and from prov
 *  creating a peg timeline in which labelled, drawn or photographic representations of events or objects from different generations are pegged onto string in the correct sequence
 *  recording data about the locations of places and their features on maps and/or plans; for example, labelling the location of their home on a map of the local area, using a provided plan of their classroom and labelling its activity spaces 
 
-#### Interpreting, analysing and evaluating
+#### Interpreting, analysing and evaluating {#interpreting-analysing-and-evaluating}
 
-##### AC9HS1S03
+##### AC9HS1S03 {#ac9hs1s03}
 
 interpret information and data from observations and provided sources, including the comparison of objects from the past and present
 
@@ -99,7 +99,7 @@ interpret information and data from observations and provided sources, includi
 *  exploring traditional and contemporary First Nations Australian stories about places and the past, and how places have changed
 *  categorising objects, drawings or images by their features and explaining the reason for their categorisation; for example, categorising the features of a local place into natural (such as a native forest), constructed (such as a street of houses) and managed (such as a windbreak of trees)
 
-##### AC9HS1S04
+##### AC9HS1S04 {#ac9hs1s04}
 
 discuss perspectives related to objects, people, places and events
 
@@ -107,9 +107,9 @@ discuss perspectives related to objects, people, places and events
 *  comparing students’ daily lives with those of their parents, grandparents, elders or a familiar older person and identifying which aspects of the past they would or would not want to experience
 *  sharing personal preferences about their world (for example, their favourite weather, activities, places, celebrations, objects from the past) and explaining why they are favoured
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HS1S05
+##### AC9HS1S05 {#ac9hs1s05}
 
 draw conclusions and make proposals
 
@@ -118,9 +118,9 @@ draw conclusions and make proposals
 *  describing features of a space or place that is important to them and explaining what they could do to care for it; for example, a chicken coop, a play area, their bedroom, the reading corner, the beach
 *  imagining how a local feature or place might change in the future and proposing action they could take to improve a place or influence a positive future
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HS1S06
+##### AC9HS1S06 {#ac9hs1s06}
 
 develop narratives and share observations, using sources, and subject-specific terms
 
@@ -128,7 +128,7 @@ develop narratives and share observations, using sources, and subject-specific t
 *  retelling stories about life in the past through spoken narratives and the use of pictures, role-plays or photographs
 *  using terms to denote the sequence of time; for example, “then”, “now”, “yesterday”, “today”, “past”, “present”, “later on”, “before I was born”, “in the future”, “generations”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 1, students identify continuity and change in family structures, roles and significant aspects of daily life. They identify the location and nature of the natural, managed and constructed features of local places, the ways places change, and how they can be cared for by people.
 

--- a/curriculum/hass/year-2.md
+++ b/curriculum/hass/year-2.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - HASS F-6 - Year 2
+# Humanities and Social Sciences - Year 2 {#humanities-and-social-sciences-year-2}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 2, the focus is on **"past and present connections to people and places"**.
 
@@ -14,13 +14,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How are people connected to their place and other places, past or present?
 *   How has technology affected daily life over time and the connections between people in different places?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### History
+#### History {#history}
 
-##### AC9HS2K01
+##### AC9HS2K01 {#ac9hs2k01}
 
 a local individual, group, place or building and the reasons for their importance, including social, cultural or spiritual significance
 
@@ -31,7 +31,7 @@ a local individual, group, place or building and the reasons for their importan
 *  identifying and visiting, where appropriate, local sites, places and landscapes of significance to First Nations Australians; for example, engraving sites, rock paintings, natural sites or features such as the creeks or mountains
 *  identifying and designing a local historical tour of a building or site; for example, one related to a particular cultural group
 
-##### AC9HS2K02
+##### AC9HS2K02 {#ac9hs2k02}
 
 how technological developments changed people’s lives at home, and in the ways they worked, travelled and communicated
 
@@ -42,9 +42,9 @@ how technological developments changed people’s lives at home, and in the way
 *  identifying the technologies used by local First Nations Australians for aspects of daily life such as providing food, shelter and transportation
 *  identifying the ways current communication and transport technologies impact on our interconnections with other places; for example, online communication, accessibility to other places through different types of transport
 
-#### Geography
+#### Geography {#geography}
 
-##### AC9HS2K03
+##### AC9HS2K03 {#ac9hs2k03}
 
 how places can be spatially represented in geographical divisions from local to regional to state/territory, and how people and places are interconnected across those scales
 
@@ -54,7 +54,7 @@ how places can be spatially represented in geographical divisions from local 
 *  identifying links they and other people in their community have with people and places at the regional and/or state/territory scale; for example, where produce in their supermarket comes from or produce from their farms goes to, relatives they visit, places they go for holidays
 *  describing how communication and transport technologies connect their place to other places at the regional and/or state/territory level; for example, online communication, phone, road, rail, planes, ferries
 
-##### AC9HS2K04
+##### AC9HS2K04 {#ac9hs2k04}
 
 the interconnections of First Nations Australians to a local Country/Place
 
@@ -63,11 +63,11 @@ the interconnections of First Nations Australians to a local Country/Place
 *  liaising with community to identify language groups of First Nations Australians who belong to the local area and exploring the relationship between language, Country/Place and spirituality (this is intended to be a local area study with a focus on one language group; however, if information or sources are not readily available, another representative area may be studied)
 *  discussing when to use Acknowledgement of Country and Welcome to Country at ceremonies and events to respectfully recognise the Country/Place and Traditional Owners and Custodians of the land, sea, waterways, and sky
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HS2S01
+##### AC9HS2S01 {#ac9hs2s01}
 
 develop questions about objects, people, places and events in the past and present
 
@@ -76,7 +76,7 @@ develop questions about objects, people, places and events in the past and 
 *  developing inquiry questions about places; for example, “What are the features of the place?”, “How far away is it?”, “How easy is it to get to?”, “How am I connected to it?”, “How is it connected to other places?”
 *  posing questions using the stems, “How do I feel about …?”, ‘What would it be like to …?” and “What effect …?”
 
-##### AC9HS2S02
+##### AC9HS2S02 {#ac9hs2s02}
 
 collect, sort and record information and data from observations and from provided sources, including unscaled timelines and labelled maps or models
 
@@ -86,9 +86,9 @@ collect, sort and record information and data from observations and from pr
 *  locating the places they are connected to, such as through family, travel or friends, or the places they visit for shopping, recreation or other reasons on a print, electronic or wall map
 *  ordering key events in the history of the local community or in its development using formats such as unscaled timelines, slideshows or stories; for example, the history of a person, place or building, or the developmental stages of telecommunications technologies
 
-#### Interpreting, analysing and evaluating
+#### Interpreting, analysing and evaluating {#interpreting-analysing-and-evaluating}
 
-##### AC9HS2S03
+##### AC9HS2S03 {#ac9hs2s03}
 
 interpret information and data from observations and provided sources, including the comparison of objects from the past and present
 
@@ -98,7 +98,7 @@ interpret information and data from observations and provided sources, includ
 *  interpreting symbols and codes that provide information, such as map legends
 *  identifying how objects and activities are similar or different depending on conditions in local and distant places; for example, clothes, transport, technology
 
-##### AC9HS2S04
+##### AC9HS2S04 {#ac9hs2s04}
 
 discuss perspectives related to objects, people, places and events
 
@@ -107,9 +107,9 @@ discuss perspectives related to objects, people, places and events
 *  examining the points of view of older generations about changes over time; for example, changes to the natural or built environment, changes to daily living
 *  exploring how the same place has significance to different groups for different reasons; for example, traditional meeting places for First Nations Australians within an urban area that include buildings or monuments that are important to other cultural groups.
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HS2S05
+##### AC9HS2S05 {#ac9hs2s05}
 
 draw conclusions and make proposals
 
@@ -120,9 +120,9 @@ draw conclusions and make proposals
 *  identifying how knowledge of special places and natural systems in their local area contributes to behaviour, and ideas about how to care for these places and to preserve their significance
 *  using their knowledge about a familiar place or site to imagine how it might change in the future and how they can influence a positive future for it
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HS2S06
+##### AC9HS2S06 {#ac9hs2s06}
 
 develop narratives and share observations, using sources, and subject-specific terms
 
@@ -131,7 +131,7 @@ develop narratives and share observations, using sources, and subject-specific t
 *  sharing observations using sources such as how access to and use of a place has changed over time
 *  sharing with their teacher, other students and members of their family what they know about the past, using terms in speech and writing to denote the passing of time (for example, “in the past”, “years ago”, “the olden days”, “in the future”) and to describe direction and location of a place (for example, “north”, “south”, “opposite”, “near”, “far”)
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 2, students identify the significance of a local person, group, place and/or building. They identify the effects of changes in technologies on people’s lives. Students identify that places can be spatially represented in different geographical divisions. They identify how people and places are interconnected both at local and broader scales.
 

--- a/curriculum/hass/year-3.md
+++ b/curriculum/hass/year-3.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - HASS F-6 - Year 3
+# Humanities and Social Sciences - Year 3 {#humanities-and-social-sciences-year-3}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 3, the focus is on **"diverse communities and places, and the contributions people make"**.
 
@@ -12,13 +12,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How do people contribute to their communities, past and present?
 *   How are people in Australia connected to places and what are the similarities and differences between those places?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### History
+#### History {#history}
 
-##### AC9HS3K01
+##### AC9HS3K01 {#ac9hs3k01}
 
 causes and effects of changes to the local community, and how people who may be from diverse backgrounds have contributed to these changes
 
@@ -28,7 +28,7 @@ causes and effects of changes to the local community, and how people who may be 
 *  identifying individuals and groups of diverse backgrounds from the past, who have contributed to the community’s economic, social, cultural, civic and environmental development and character
 *  investigating reasons for change in the local community, why change was brought about and what happened because of it; for example, the change in use of a building, wasteland turning to wetland
 
-##### AC9HS3K02
+##### AC9HS3K02 {#ac9hs3k02}
 
 significant events, symbols and emblems that are important to Australia’s identity and diversity, and how they are celebrated, commemorated or recognised in Australia, including Australia Day, Anzac Day, NAIDOC Week, National Sorry Day, Easter, Christmas, and other religious and cultural festivals
 
@@ -39,9 +39,9 @@ significant events, symbols and emblems that are important to Australia’s iden
 *  examining the symbolism found in the design and positioning of flags (for example, the Australian flag, First Nations Australians’ flags) and recognising special occasions when they are flown (for example, all three flags are flown during NAIDOC Week, National Reconciliation Week, National Sorry Day and Mabo Day)
 *  examining the roles, rights and responsibilities the community has when observing protocols around flag flying
 
-#### Geography
+#### Geography {#geography}
 
-##### AC9HS3K03
+##### AC9HS3K03 {#ac9hs3k03}
 
 the representation of contemporary Australia as states and territories, and as the Countries/Places of First Nations Australians prior to colonisation, and the locations of Australia’s neighbouring regions and countries
 
@@ -50,7 +50,7 @@ the representation of contemporary Australia as states and territories, and as t
 *  using a globe or digital source to locate the Pacific Island nations, New Zealand, Papua New Guinea, Timor-Leste, Indonesia and countries relevant to students, labelling them on a map and identifying the direction of each country from Australia
 *  using the Australian Institute of Aboriginal and Torres Strait Islander Studies Map of Indigenous Australia and a states and territories map of Australia to compare the boundaries of Aboriginal Countries and Torres Strait Islander Places with the surveyed boundaries between Australian states and territories, to gain an appreciation of the different ways Australia can be represented
 
-##### AC9HS3K04
+##### AC9HS3K04 {#ac9hs3k04}
 
 the ways First Nations Australians in different parts of Australia are interconnected with Country/Place
 
@@ -59,7 +59,7 @@ the ways First Nations Australians in different parts of Australia are interconn
 *  discussing how some people are connected to one Country; for example, because it is “Mother’s” Country or “Father’s” Country
 *  exploring the ways Australian First Nations Peoples connect to Country/Place, by reading and viewing poems, songs, paintings and stories from different groups outside the local area
 
-##### AC9HS3K05
+##### AC9HS3K05 {#ac9hs3k05}
 
 the similarities and differences between places in Australia and neighbouring countries in terms of their natural, managed and constructed features
 
@@ -70,9 +70,9 @@ the similarities and differences between places in Australia and neighbouring co
 *  exploring different types of settlement and classifying them into hierarchical categories, such as isolated dwellings, outstations, villages, towns, regional centres and large cities
 *  choosing a place in a neighbouring country, such as Indonesia or Pacific Island nations, to compare with a place in Australia in terms of managed and built features to explore the reasons for similarities and differences
 
-#### Civics and Citizenship
+#### Civics and Citizenship {#civics-and-citizenship}
 
-##### AC9HS3K06
+##### AC9HS3K06 {#ac9hs3k06}
 
 who makes rules, why rules are important in the school and/or the local community, and the consequences of rules not being followed
 
@@ -83,7 +83,7 @@ who makes rules, why rules are important in the school and/or the local communit
 *  discussing situations where it is not fair to have one rule that treats everyone the same; for example, if some people, such as students with disability, have different needs or would be unable to follow the rules
 *  exploring cultural norms behind some rulemaking; for example, removing shoes before entering places of cultural or religious significance
 
-##### AC9HS3K07
+##### AC9HS3K07 {#ac9hs3k07}
 
 why people participate within communities and how students can actively participate and contribute to communities
 
@@ -93,11 +93,11 @@ why people participate within communities and how students can actively particip
 *  investigating how an individual’s contribution can be recognised; for example, an Order of Australia award
 *  exploring the motivations of individuals who contribute to communities, such as local community volunteers, leaders and Elders
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HS3S01
+##### AC9HS3S01 {#ac9hs3s01}
 
 develop questions to guide investigations about people, events, places and issues
 
@@ -106,7 +106,7 @@ develop questions to guide investigations about people, events, places and issue
 *  asking probing questions during an investigation (for example, “Why is that so?”, “What else do we need to know?”)
 *  posing questions to compare such as “How have things changed?” and “How is my house the same or different to one in a neighbouring country?”
 
-##### AC9HS3S02
+##### AC9HS3S02 {#ac9hs3s02}
 
 locate, collect and record information and data from a range of sources, including annotated timelines and maps
 
@@ -118,9 +118,9 @@ locate, collect and record information and data from a range of sources, includi
 *  acquiring geographical information from schools in geographically contrasting parts of Australia and neighbouring countries and recording that information by constructing and annotating maps, using the appropriate cartographic conventions, including map symbols, title and north point
 *  creating tables or picture and column graphs to show patterns in data collected from class vote on participation in community activities
 
-#### Interpreting, analysing and evaluating
+#### Interpreting, analysing and evaluating {#interpreting-analysing-and-evaluating}
 
-##### AC9HS3S03
+##### AC9HS3S03 {#ac9hs3s03}
 
 interpret information and data displayed in different formats
 
@@ -131,7 +131,7 @@ interpret information and data displayed in different formats
 *  interpreting data to identify patterns of change over time: for example, examine building dates to make inferences about changing designs and materials used
 *  using maps, ground and aerial photographs, and a digital source such as online satellite images to identify, locate and describe features, including the interpretation of cartographic information such as titles, map symbols, north point and compass direction
 
-##### AC9HS3S04
+##### AC9HS3S04 {#ac9hs3s04}
 
 analyse information and data, and identify perspectives
 
@@ -141,9 +141,9 @@ analyse information and data, and identify perspectives
 *  analysing information collected from interviews with different people, such as children, teachers, coaches and community members, about rules and how decisions are made
 *  using visible thinking strategies to examine a group of paintings and/or maps across a period of time, to explore evidence of continuity and change, and significant events in the local area
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HS3S05
+##### AC9HS3S05 {#ac9hs3s05}
 
 draw conclusions based on analysis of information
 
@@ -152,7 +152,7 @@ draw conclusions based on analysis of information
 *  drawing conclusions about the preservation of unique features of the natural environment
 *  drawing conclusions about the ways people are connected with places, and the similarities and differences of places in Australia and those of neighbouring countries
 
-##### AC9HS3S06
+##### AC9HS3S06 {#ac9hs3s06}
 
 propose actions or responses to an issue or challenge that consider possible effects of actions
 
@@ -162,9 +162,9 @@ propose actions or responses to an issue or challenge that consider possible eff
 *  developing a plan of action to achieve a set goal; for example, to protect a place, to participate in a community festival or commemoration, to raise awareness about an issue, to raise money for a purpose
 *  arguing a point of view on a civics and citizenship issue relevant to their lives (for example, the consequences of breaking school rules, the value of contributing to their community, the need to preserve an endangered species) and making effective use of persuasive language such as “I think” and “I dis/agree that” to gain the support of others
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HS3S07
+##### AC9HS3S07 {#ac9hs3s07}
 
 present descriptions and explanations, using ideas from sources and relevant subject-specific terms
 
@@ -172,7 +172,7 @@ present descriptions and explanations, using ideas from sources and relevant sub
 *  selecting ideas from sources such as graphs, tables, timelines, photographs and pictures
 *  using appropriate terms when speaking, writing and illustrating; for example, historical terms such as “immigration”, “exploration”, “development”, “settlement”, “naming days of commemoration” and “emblems”; geographical terms such as “climate”, “environment”, “natural” and “constructed”; and civics terms such as “community”, “decision-making” and “participation”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 3, students describe the causes, effects and contributions of people to change. They identify the significance of events, symbols and emblems to Australia’s identity and diversity. They describe the representation of places within and near Australia. They identify the similarities, differences and connections of people to places across those scales. Students describe the importance of rules and people’s contributions to communities.
 

--- a/curriculum/hass/year-4.md
+++ b/curriculum/hass/year-4.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - HASS F-6 - Year 4
+# Humanities and Social Sciences - Year 4 {#humanities-and-social-sciences-year-4}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 4, the focus is on **"how people, places and environments interact, past and present"**.
 
@@ -13,13 +13,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   What were the effects of European colonisation on Australia, and on Australian First Nations Peoples?
 *   What is the significance of the environment, and what are different views on how it can be used and sustained, past and present?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### History
+#### History {#history}
 
-##### AC9HS4K01
+##### AC9HS4K01 {#ac9hs4k01}
 
 the diversity of First Nations Australians, their social organisation and their continuous connection to Country/Place
 
@@ -29,7 +29,7 @@ the diversity of First Nations Australians, their social organisation and their 
 *  investigating archaeological sites (for example, Nauwalabila, Devil’s Lair, Lake Mungo) that show the continuous connection of early First Peoples of Australia to Country/Place and the early lifestyles of First Nations Australians
 *  investigating the diversity and significance of trade and exchange of ideas to First Nations Australians, including with groups outside Australia such as the Macassans
 
-##### AC9HS4K02
+##### AC9HS4K02 {#ac9hs4k02}
 
 the causes of the establishment of the first British colony in Australia in 1788
 
@@ -39,7 +39,7 @@ the causes of the establishment of the first British colony in Australia in 178
 *  describing the journeys of James Cook, and that of Joseph Banks, and their role in the establishment of a British colony in Australia, including reference to Cook’s “secret instructions”
 *  investigating the reasons for the colonisation of Australia, including Britain needing a penal colony, the impact of the American War of Independence, the creation of a base in the global south and resources
 
-##### AC9HS4K03
+##### AC9HS4K03 {#ac9hs4k03}
 
 the experiences of individuals and groups, including military and civilian officials, and convicts involved in the establishment of the first British colony
 
@@ -50,7 +50,7 @@ the experiences of individuals and groups, including military and civilian offic
 *  investigating attitudes to the poor, the treatment of prisoners and the social standing of those who travelled to Australia on the First Fleet, including families, children and convict guards
 *  investigating daily life in the Port Jackson penal settlement, the challenges experienced by the people there and how they were managed
 
-##### AC9HS4K04
+##### AC9HS4K04 {#ac9hs4k04}
 
 the effects of contact with other people on First Nations Australians and their Countries/Places following the arrival of the First Fleet and how this was viewed by First Nations Australians as an invasion
 
@@ -59,9 +59,9 @@ the effects of contact with other people on First Nations Australians and thei
 *  exploring early contact of First Nations Australians with the British, including individuals such as Pemulwuy, Windradyne and Bennelong, and considering the differing perspectives of the interactions between Europeans and First Nations Australians, and how interactions could be interpreted as negative for one group and positive for the other
 *  examining paintings and accounts by individuals involved in exploration and colonisation to explore the impact that British colonisation had on the lives of First Nations Australians; for example, dispossession, dislocation and the loss of lives through frontier conflict, disease, and loss of food sources and medicines, the embrace of some colonial technologies, the practice of colonial religion, and intermarriage between colonists and Australian First Nations Peoples
 
-#### Geography
+#### Geography {#geography}
 
-##### AC9HS4K05
+##### AC9HS4K05 {#ac9hs4k05}
 
 the importance of environments, including natural vegetation and water sources, to people and animals in Australia and on another continent
 
@@ -72,7 +72,7 @@ the importance of environments, including natural vegetation and water sources, 
 *  exploring strategies to protect particular environments that provide habitats for animals; for example, planting bird-attracting vegetation
 *  identifying the importance of water to the environment and to sustaining the lives of people and animals
 
-##### AC9HS4K06
+##### AC9HS4K06 {#ac9hs4k06}
 
 sustainable use and management of renewable and non-renewable resources, including the custodial responsibility First Nations Australians have for Country/Place
 
@@ -80,9 +80,9 @@ sustainable use and management of renewable and non-renewable resources, inc
 *  exploring how some resources are used and managed in sustainable and non-sustainable ways; for example, auditing use of renewable and non-renewable resources in the classroom, investigating recycling and waste disposal of non-renewable resources in the school and by local government, reducing waste through “nude food” lunch boxes and using recycled toilet paper, examining how renewable resources such as timber are managed
 *  investigating how First Nations Australians adapted ways using knowledge and practices linked to the sustainable use of resources and environments (for example, rotational use and harvesting of resources; mutton-bird harvesting in Tasmania; the use of fire; the use of vegetation endemic in the local area for food, shelter, medicine, tools and weapons; and the collection of bush food from semi-arid rangelands), and how this knowledge can be taught through stories and songs, reflecting their inherent, custodial responsibilities
 
-#### Civics and Citizenship
+#### Civics and Citizenship {#civics-and-citizenship}
 
-##### AC9HS4K07
+##### AC9HS4K07 {#ac9hs4k07}
 
 the differences between “rules” and “laws”, why laws are important and how they affect the lives of people
 
@@ -92,7 +92,7 @@ the differences between “rules” and “laws”, why laws are important a
 *  investigating the impact of laws, such as environmental laws, native title laws and laws concerning sacred sites, on specific groups, including First Nations Australians
 *  investigating the customary lore of First Nations Australians and how they relate to people and places; for example, the lore covers rules of living, skin groups, broad roles of men and women, economic affairs, marriage and other activities
 
-##### AC9HS4K08
+##### AC9HS4K08 {#ac9hs4k08}
 
 the roles of local government and how members of the community use and contribute to local services
 
@@ -101,7 +101,7 @@ the roles of local government and how members of the community use and contrib
 *  exploring what local government does, including the services it provides, such as environment and waste management, libraries, health services, parks, cultural events, pools and sport facilities, arts and pet management
 *  describing how local government services impact on the lives of students, and discussing how local groups/organisations and children can use their voices and make responsible choices about the services that impact them and their environment
 
-##### AC9HS4K09
+##### AC9HS4K09 {#ac9hs4k09}
 
 diversity of cultural, religious and/or social groups to which they and others in the community belong, and their importance to identity
 
@@ -110,11 +110,11 @@ diversity of cultural, religious and/or social groups to which they and others i
 *  listing and comparing the different beliefs, traditions and symbols used by groups
 *  recognising that the identity of First Nations Australians is shaped by Country/Place, language and knowledge traditions
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HS4S01
+##### AC9HS4S01 {#ac9hs4s01}
 
 develop questions to guide investigations about people, events, places and issues
 
@@ -124,7 +124,7 @@ develop questions to guide investigations about people, events, places and issue
 *  discussing how an investigation about the past, such as through a museum display, video or interactive website, is guided by questions at different stages, including “Why is that important now?”
 *  developing questions that address the disciplinary concepts; for example, “What was the cause…?”, “Why was this event significant?”, “How did daily life change?”, “What are the characteristics of this place?”, “How can we manage resources sustainably?”, “What rules are used by different groups I belong to?” and “What laws protect our local environment?”
 
-##### AC9HS4S02
+##### AC9HS4S02 {#ac9hs4s02}
 
 locate, collect and record information and data from a range of sources, including annotated timelines and maps
 
@@ -134,9 +134,9 @@ locate, collect and record information and data from a range of sources, inclu
 *  exploring stories about the groups people belong to; for example, cultural groups such as groups that value First Nations Australian or Asian heritage; interest and community groups such as recreational and volunteering organisations; and gender or religious groups
 *  using graphic organisers, timelines, maps, graphs or tables to display data and information (for example, a food web; consequence wheels for an issue; creating a timeline related to the First Fleet; mapping locations of different types of vegetation, the loss of native species, the movement of peoples over time, or social, cultural and religious groups in Australia’s society) and using digital applications as appropriate
 
-#### Interpreting, analysing and evaluating
+#### Interpreting, analysing and evaluating {#interpreting-analysing-and-evaluating}
 
-##### AC9HS4S03
+##### AC9HS4S03 {#ac9hs4s03}
 
 interpret information and data displayed in different formats
 
@@ -146,7 +146,7 @@ interpret information and data displayed in different formats
 *  interpreting thematic maps and using online satellite images to describe the environmental characteristics of a continent or region, or to identify a particular characteristic, such as equatorial rainforests or clearance of natural vegetation for farming and settlement
 *  comparing environments in places of similar climate and vegetation that are located on different continents; for example, sandy, icy and stony deserts of Australia, Africa and South America
 
-##### AC9HS4S04
+##### AC9HS4S04 {#ac9hs4s04}
 
 analyse information and data, and identify perspectives
 
@@ -156,9 +156,9 @@ analyse information and data, and identify perspectives
 *  analysing information gathered through visible thinking strategies to examine a group of paintings and/or maps across a period of time to explore evidence of continuity and change, and significant events in Australia pre- and post-1788 (for example, images of First Nations Australian rock painting depicting early interactions and trade with the Macassans) and comparing it with written information from a historian
 *  exploring different perspectives about a historical event (for example, the perspectives of convicts, soldiers, free settlers and First Nations Australians on the arrival of the First Fleet) or a contemporary issue, such as a school issue or an environmental issue
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HS4S05
+##### AC9HS4S05 {#ac9hs4s05}
 
 draw conclusions based on analysis of information
 
@@ -167,7 +167,7 @@ draw conclusions based on analysis of information
 *  explaining how seeking resources is connected to trade, world exploration, colonisation, economic development and environmental change
 *  analysing sources to draw conclusions; for example, 'What are the relationships between plants and animals in an ecosystem?", 'What can local government do to improve services?' and 'How do students benefit from school rules?'
 
-##### AC9HS4S06
+##### AC9HS4S06 {#ac9hs4s06}
 
 propose actions or responses to an issue or challenge that consider possible effects of actions
 
@@ -177,9 +177,9 @@ propose actions or responses to an issue or challenge that consider possible e
 *  reflecting on personal behaviours and identifying attitudes that may affect aspects of the environment at a local or global level; for example, pouring paints down the sink, using products sourced from cleared rainforests and proposing awareness-raising strategies to reduce impacts on the environment
 *  proposing possible actions that could be taken to address an issue (for example, improving the management of waste in the school, choosing products not made from endangered species or their habitats) and identifying resources needed to support the actions and likely outcomes (for example, composting lunch waste and using it on the school garden, making socially responsible decisions)
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HS4S07
+##### AC9HS4S07 {#ac9hs4s07}
 
 present descriptions and explanations, using ideas from sources and relevant subject-specific terms
 
@@ -187,7 +187,7 @@ present descriptions and explanations, using ideas from sources and relevant sub
 *  describing the relative location of different features in a place by distance and compass direction; for example, the distance from their home to the local waste management site, the route of a navigator
 *  using accurate and subject-appropriate terms when speaking, writing and illustrating; for example, using historical terms such as “exploration”, “navigation”, “trade”, “penal”, “transportation”, “contact” and “colonisation”; using geographical terms such as “continents”, “countries”, “natural resources”, “vegetation”, “environments”, “ecosystems”, “sustainability”, “consumption”, “waste” and “management”; and using civic terms such as “local government”, “decision-making”, “services”, “roles”, “responsibilities”, “rules”, “laws” and “belonging”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 4, students describe the diversity of experiences of people in Australia prior to and following 1788. They describe the events and causes of the establishment of the first British colony in Australia. They describe the effects of colonisation on people and environments. Students describe the importance of environments, and sustainable allocation and management of resources. They describe the importance and role of local government, community members and laws, and the cultural and social factors that shape identity.
 

--- a/curriculum/hass/year-5.md
+++ b/curriculum/hass/year-5.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - HASS F-6 - Year 5
+# Humanities and Social Sciences - Year 5 {#humanities-and-social-sciences-year-5}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 5, the focus is on **"Australian communities – their past, present and possible futures"**.
 
@@ -12,13 +12,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How do people influence environments, and how do consumers and citizens contribute to a sustainable Australia?
 *   How have people enacted their values, beliefs and responsibilities about people, places and events, past and present?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### History
+#### History {#history}
 
-##### AC9HS5K01
+##### AC9HS5K01 {#ac9hs5k01}
 
 the economic, political and social causes of the establishment of British colonies in Australia after 1800
 
@@ -28,7 +28,7 @@ the economic, political and social causes of the establishment of British co
 *  investigating political reasons for the establishment of different colonies in Australia, such as expanding the British empire and the threat that other countries might want to expand their territories
 *  investigating social causes of the establishment of different colonies in Australia, such as overcrowded cities, high crime rates and overflowing prisons
 
-##### AC9HS5K02
+##### AC9HS5K02 {#ac9hs5k02}
 
 the impact of the development of British colonies in Australia on the lives of First Nations Australians, the colonists and convicts, and on the natural environment
 
@@ -36,7 +36,7 @@ the impact of the development of British colonies in Australia on the lives of F
 *  investigating colonial life to discover what life was like at that time for different inhabitants (for example, a First Nations Australian community and a European community, a convict and a free settler, a “squatter”, a sugarcane farmer and an indentured labourer), the challenges they faced and responses they made in terms of clothing, access to food and water, leisure, paid and unpaid work, use of technologies, shopping or trade, language, housing and children’s lives
 *  mapping settlement patterns in the 1800s, noting factors that shaped these patterns (for example, geographical features, climate, access to land for farming and grazing, water resources, the discovery of gold, transport and access to port facilities) and the impact these settlement patterns had on the local environment and its ecosystems (for example, comparing the present and past landscape, and the flora and fauna of the local community, including introduced species)
 
-##### AC9HS5K03
+##### AC9HS5K03 {#ac9hs5k03}
 
 the role of a significant individual or group, including First Nations Australians and those who migrated to Australia, in the development of events in an Australian colony
 
@@ -48,9 +48,9 @@ the role of a significant individual or group, including First Nations Australia
 *  examining the roles and impacts of key administrative and political figures, such as early colonial governors, and First Nations warriors such as Windradyne
 *  examining the development of at least one primary industry sector of the economy during the 1800s, such as wheat, wool, meat, whaling, sugar cane, pearling or mining, including the involvement of First Nations Australians
 
-#### Geography
+#### Geography {#geography}
 
-##### AC9HS5K04
+##### AC9HS5K04 {#ac9hs5k04}
 
 the influence of people, including First Nations Australians and people in other countries, on the characteristics of a place
 
@@ -60,7 +60,7 @@ the influence of people, including First Nations Australians and people in othe
 *  exploring examples of positive influences people have on the characteristics of places; for example, reforestation, land-care groups, rehabilitating former mining, industrial or waste disposal sites
 *  identifying positive and negative influences of people on places in other countries, including countries in Asia, Europe and North America
 
-##### AC9HS5K05
+##### AC9HS5K05 {#ac9hs5k05}
 
 the management of Australian environments, including managing severe weather events such as bushfires, floods, droughts or cyclones, and their consequences
 
@@ -68,9 +68,9 @@ the management of Australian environments, including managing severe weather eve
 *  exploring how environments are used and managed, such as the practices and laws that aim to manage human impact, the use of zoning to manage local environments, creation of wildlife corridors and national parks
 *  examining how changes due to environmental practices create issues, such as water shortages and increased floods and bushfires, the impact of issues on places and communities, and how people can mitigate the impacts, for example through building codes, zoning, firebreaks and controlled burns, and efficient irrigation
 
-#### Civics and Citizenship
+#### Civics and Citizenship {#civics-and-citizenship}
 
-##### AC9HS5K06
+##### AC9HS5K06 {#ac9hs5k06}
 
 the key values and features of Australia’s democracy, including elections, and the roles and responsibilities of elected representatives
 
@@ -83,7 +83,7 @@ the key values and features of Australia’s democracy, including elections, and
 *  considering the responsibilities of electors, including enrolling to vote, being informed and voting responsibly
 *  identifying the characteristics that would make for a “good” representative at the local, state/territory or national level
 
-##### AC9HS5K07
+##### AC9HS5K07 {#ac9hs5k07}
 
 how citizens (members of communities) with shared beliefs and values work together to achieve a civic goal
 
@@ -92,9 +92,9 @@ how citizens (members of communities) with shared beliefs and values work tog
 *  using social media to share and discuss ideas about how people can work together as local, regional and global citizens; for example, to promote access to educational opportunities for women and girls in developing countries
 *  examining First Nations Australian organisations and the services they provide
 
-#### Economics and Business
+#### Economics and Business {#economics-and-business}
 
-##### AC9HS5K08
+##### AC9HS5K08 {#ac9hs5k08}
 
 types of resources, including natural, human and capital, and how they satisfy needs and wants
 
@@ -103,11 +103,11 @@ types of resources, including natural, human and capital, and how they satis
 *  identifying and categorising the factors of production used in the production of goods and services that satisfy the needs and wants of a local community
 *  distinguishing between needs and wants, and how resources might be used more sustainably to meet these needs and wants into the future
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HS5S01
+##### AC9HS5S01 {#ac9hs5s01}
 
 develop questions to investigate people, events, developments, places and systems
 
@@ -116,7 +116,7 @@ develop questions to investigate people, events, developments, places and system
 *  developing different types of questions for different purposes, such as probing questions to seek details, open-ended questions to elicit more ideas, and practical questions to guide financial choices
 *  developing questions to guide the identification and location of useful sources for an investigation or project; for example, “Is this source useful?”, “Who can help us do this project?”, “What rules/protocols must we follow when we do this inquiry/project?”, “What resources do we need to conduct this project?”
 
-##### AC9HS5S02
+##### AC9HS5S02 {#ac9hs5s02}
 
 locate, collect and organise information and data from primary and secondary sources in a range of formats
 
@@ -127,9 +127,9 @@ locate, collect and organise information and data from primary and secondary
 *  categorising information using digital and non-digital graphic organisers, such as flow charts, consequence wheels, futures timelines, Venn diagrams, decision-making matrixes and bibliography templates, for an appropriate purpose; for example, creating flow charts that show the steps in an electoral process such as a class vote or a local council election, or the sequence of steps to rehabilitate a natural area, or the sequence of actions in achieving a civic goal
 *  constructing timelines, maps, tables and graphs using appropriate digital applications and cartographic conventions, such as border, source, scale, legend, title and north point, to display data and information; for example, the movement of peoples over time in a colony, a sequence of key events, the population growth of an Australian colony, cultural and religious groups in Australia at different times, information on needs and wants
 
-#### Interpreting, analysing and evaluating
+#### Interpreting, analysing and evaluating {#interpreting-analysing-and-evaluating}
 
-##### AC9HS5S03
+##### AC9HS5S03 {#ac9hs5s03}
 
 evaluate information and data in a range of formats to identify and describe patterns and trends, or to infer relationships
 
@@ -138,7 +138,7 @@ evaluate information and data in a range of formats to identify and describe p
 *  examining visual and written sources to infer relationships; for example, examining photographs to see how people respond to droughts in enterprising ways; examining maps to investigate patterns in the characteristics of a place; investigating written sources to explore patterns in the development of colonial society
 *  exploring maps and sources showing First Nations Australians’ language groups and Countries/Places, to explain the diversity of their connections to Country/Place
 
-##### AC9HS5S04
+##### AC9HS5S04 {#ac9hs5s04}
 
 evaluate primary and secondary sources to determine origin, purpose and perspectives
 
@@ -147,9 +147,9 @@ evaluate primary and secondary sources to determine origin, purpose and perspect
 *  evaluating the accuracy and the perspectives in information gained from primary and secondary sources; for example, checking publication details for the author of speeches, advertisements, campaign materials, symbols and how-to-vote cards, or comparing sources of evidence to identify similarities and/or differences in accounts of the past that reflect different perspectives
 *  comparing sources of evidence to identify similarities and/or differences in accounts of and perspectives on the past; for example, comparing the differing experiences and feelings of miners, Chinese workers, women, children, leaders and First Nations Australian occupants during the Eureka Stockade; comparing colonial descriptions of Burke and Wills’ achievements with those that have been recently published giving First Nations Australian perspectives; comparing representations of Ned Kelly in past and present publications
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HS5S05
+##### AC9HS5S05 {#ac9hs5s05}
 
 develop evidence-based conclusions
 
@@ -160,7 +160,7 @@ develop evidence-based conclusions
 *  drawing conclusions about a community and/or the environment; for example, changing democratic values from past to present, patterns of human consumption and changes in environments
 *  considering the primary and secondary sources used and how this may have influenced the validity of the conclusions of the inquiry; for example, the reliability of information in a source such as a government agency website versus a private blog, the date a secondary source was created and the views that prevailed at the time
 
-##### AC9HS5S06
+##### AC9HS5S06 {#ac9hs5s06}
 
 propose actions or responses to issues or challenges and use criteria to assess the possible effects
 
@@ -172,9 +172,9 @@ propose actions or responses to issues or challenges and use criteria to assess 
 *  making judgements about how effectively challenges have been addressed in the past (for example, relative success of a response to challenges during colonial settlement) or how effectively a current challenge is being addressed (for example, a response to an environmental issue or a strategy for economic development)
 *  using criteria to evaluate the possible options that people could take to resolve challenges, such as improving water quality, managing excess waste and providing resources, and using criteria to improve responses in communities to environmental hazards; for example, considering economic factors such as needs, wants and costs, as well as environmental, health and social factors
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HS5S07
+##### AC9HS5S07 {#ac9hs5s07}
 
 present descriptions and explanations, drawing ideas, findings and viewpoints from sources, and using relevant terms and conventions
 
@@ -182,7 +182,7 @@ present descriptions and explanations, drawing ideas, findings and viewpoints fr
 *  selecting and referencing ideas and viewpoints from letters, graphs, tables, timelines, photographs and pictures, in descriptions and explanations
 *  using accurate and subject-appropriate terms; for example, historical terms such as “colonial”, “the gold era”, “migration” and “penal”; geographic terms such as “characteristics”, “environmental”, “human”, “ecosystems”, “sustainable”, “settlement” and “management”; civics terms such as “electoral process”, “democracy”, “shared beliefs”; and economic terms such as “scarcity”, “choices”, “resources”, and “needs and wants”
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 5, students explain the causes for the establishment of the British colonies in Australia after 1800. They explain the roles of significant individuals or groups in the development of an Australian colony and the impact of those developments. They explain the influence of people on the characteristics of places and in the management of spaces. Students explain the key values and features of Australia’s democracy and how people achieve civic goals. They explain the nature of resources, and how they meet needs and wants.
 

--- a/curriculum/hass/year-6.md
+++ b/curriculum/hass/year-6.md
@@ -1,6 +1,6 @@
-# Humanities and Social Sciences - HASS F-6 - Year 6
+# Humanities and Social Sciences - Year 6 {#humanities-and-social-sciences-year-6}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 6, the focus is **"Australia in the past and present, and its connections with a diverse world"**.
 
@@ -12,13 +12,13 @@ Inquiry questions provide a framework for developing students’ knowledge, unde
 *   How have experiences of democracy and citizenship differed between groups over time and place, and what is the role of citizens in contributing to environmental, economic and social sustainability?
 *   How has Australia developed as a society with global connections, and in what ways is Australia similar and different to other countries?
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### History
+#### History {#history}
 
-##### AC9HS6K01
+##### AC9HS6K01 {#ac9hs6k01}
 
 significant individuals, events and ideas that led to Australia’s Federation, the Constitution and democratic system of government
 
@@ -27,7 +27,7 @@ significant individuals, events and ideas that led to Australia’s Federation, 
 *  exploring how the United States of America’s model of federalism (the Washington system) contributed to the ideas for Andrew Clark’s first draft of the Constitution
 *  investigating how Australia’s system of law and government has origins in the Magna Carta, the English Civil War and Westminster system and, therefore, why we have a constitutional monarchy and why there was a separation of powers (legislative, executive, judiciary)
 
-##### AC9HS6K02
+##### AC9HS6K02 {#ac9hs6k02}
 
 changes in Australia's political system and to Australian citizenship after Federation and throughout the 20th century that impacted First Nations Australians, migrants, women and children
 
@@ -37,7 +37,7 @@ changes in Australia's political system and to Australian citizenship after Fede
 *  investigating the developments in advancing democracy and citizenship for all citizens, including migrant groups; for example, the establishment of the minimum wage, anti-discrimination legislation and official national multicultural policy
 *  investigating the experiences of children who were placed in orphanages, homes and other institutions; for example, their food and shelter, protection, education and contacts with family
 
-##### AC9HS6K03
+##### AC9HS6K03 {#ac9hs6k03}
 
 the motivation of people migrating to Australia since Federation and throughout the 20th century, their stories and effects on Australian society, including migrants from the Asia region
 
@@ -49,9 +49,9 @@ the motivation of people migrating to Australia since Federation and throughout 
 *  investigating the role of specific cultural groups in Australia’s economic and social development in, for example, the cattle industry, the Snowy Mountains Scheme and the pearling industry
 *  considering the contributions to Australia of notable Australians who were migrants or from migrant families, across a range of fields; for example, Hieu Van Le (the 35th Governor of South Australia), Sir Frank Lowy, Marita Cheng, Dame Marie Bashir
 
-#### Geography
+#### Geography {#geography}
 
-##### AC9HS6K04
+##### AC9HS6K04 {#ac9hs6k04}
 
 the geographical diversity and location of places in the Asia region, and its location in relation to Australia
 
@@ -63,7 +63,7 @@ the geographical diversity and location of places in the Asia region, and 
 *  identifying examples of Indigenous peoples who live in different regions in Asia, such as Orang Asli of Malaysia and Indonesia, the Tibetans and the Mongols, and appreciating their similarities and differences, and the ways they have lived sustainably over time
 *  researching the proportion of the Australian population and of the population from their local area who were born in each world cultural region, using data from the Australian Bureau of Statistics, and then comparing aspects of selected cultures
 
-##### AC9HS6K05
+##### AC9HS6K05 {#ac9hs6k05}
 
 Australia’s interconnections with other countries and how these change people and places
 
@@ -72,9 +72,9 @@ Australia’s interconnections with other countries and how these change peopl
 *  researching connections between Australia and countries in the Asia and Pacific regions in terms of migration, trade, tourism, aid, education, defence or cultural influences, and explaining the effects of at least one of these connections on their own place and another place in Australia
 *  exploring the provision of Australian government or non-government aid to a country in the Asia and Pacific regions or elsewhere in the world and analysing its effects on places in that country
 
-#### Civics and Citizenship
+#### Civics and Citizenship {#civics-and-citizenship}
 
-##### AC9HS6K06
+##### AC9HS6K06 {#ac9hs6k06}
 
 the key institutions of Australia’s system of government, how it is based on the Westminster system, and the key values and beliefs of Western democracies
 
@@ -86,7 +86,7 @@ the key institutions of Australia’s system of government, how it is based on
 *  examining the role of the Executive in relation to the development of policies and the introduction of bills, including the role of Cabinet in approving the drafting of a bill and the role of the public service in drafting and implementing legislation
 *  investigating the impact of the Western democracies such as France and the United States of America on our constitution, and the impact of British law on the Australian system of law, as well as the origin of values such as freedom of speech, equality before the law and social justice
 
-##### AC9HS6K07
+##### AC9HS6K07 {#ac9hs6k07}
 
 the roles and responsibilities of the 3 levels of government in Australia
 
@@ -97,9 +97,9 @@ the roles and responsibilities of the 3 levels of government in Australia
 *  identifying instances where there may be multiple levels of government involved; for example, in relation to the environment such as management of the Murray–Darling river system
 *  categorising the different types of laws and regulations in their community, which level of government makes those laws, and who enforces them; for example, road laws, health laws, pollution laws
 
-#### Economics and Business
+#### Economics and Business {#economics-and-business}
 
-##### AC9HS6K08
+##### AC9HS6K08 {#ac9hs6k08}
 
 influences on consumer choices and strategies that can be used to help make informed personal consumer and financial choices
 
@@ -111,11 +111,11 @@ influences on consumer choices and strategies that can be used to help make info
 *  exploring how a decision to buy an item at the local supermarket affects the family (for example, “Did the family have to put off buying another item to have this one?”) and the local community, such as providing jobs
 *  considering if their actions affect the environment; for example, “Does choosing local products rather than imports affect the environment?”
 
-### Skills
+### Skills {#skills}
 
-#### Questioning and researching
+#### Questioning and researching {#questioning-and-researching}
 
-##### AC9HS6S01
+##### AC9HS6S01 {#ac9hs6s01}
 
 develop questions to investigate people, events, developments, places and systems
 
@@ -124,7 +124,7 @@ develop questions to investigate people, events, developments, places and system
 *  developing different types of research questions for different purposes, such as probing questions to seek details, open-ended questions to elicit more ideas, practical questions to guide the application of enterprising behaviours, and ethical questions regarding sensitivities and cultural protocol
 *  mind-mapping a concept to create research questions that reveal connections between economic, political, and/or environmental systems; for example, “How do the purchases my family makes influence the environment?”, “How do laws aim to ensure sustainable use of resources in the products we use?”, “What actions can consumers take to ensure their purchases protect the environment?”
 
-##### AC9HS6S02
+##### AC9HS6S02 {#ac9hs6s02}
 
 locate, collect and organise information and data from primary and secondary sources in a range of formats
 
@@ -135,9 +135,9 @@ locate, collect and organise information and data from primary and secondary
 *  creating maps, using spatial technologies and cartographic conventions as appropriate, including border, source, scale, legend, title and north point, to show information and data such as location; for example, a large-scale map to show the location of places and their features in Australia and countries of Asia; a flow map or small-scale map to show the connections Australia has with Asian countries such as shipping or migration
 *  developing flow charts to show steps in a sequence; for example, the flow of goods and services, the passage of a bill through parliament, the chain of events leading to the Formal Apology to the Stolen Generations, and timelines to show the chronological sequence of key events, ideas, movements and lives
 
-#### Interpreting, analysing and evaluating
+#### Interpreting, analysing and evaluating {#interpreting-analysing-and-evaluating}
 
-##### AC9HS6S03
+##### AC9HS6S03 {#ac9hs6s03}
 
 evaluate information and data in a range of formats to identify and describe patterns and trends, or to infer relationships
 
@@ -147,7 +147,7 @@ evaluate information and data in a range of formats to identify and describe p
 *  evaluating attitudes and actions of the past that now seem strange and unacceptable, and imagining what aspects of current society may be viewed in this way in the future
 *  proposing reasons why socially sustainable practices such as negotiation, arbitration, reconciliation and cultural mediation resolve issues peacefully
 
-##### AC9HS6S04
+##### AC9HS6S04 {#ac9hs6s04}
 
 evaluate primary and secondary sources to determine origin, purpose and perspectives
 
@@ -157,9 +157,9 @@ evaluate primary and secondary sources to determine origin, purpose and persp
 *  discussing issues explored through sources where there are, or were, a range of views, such as deportation of South Sea Islanders from 1901, the vote for women, how to manage an environment more sustainably and the encouragement of migration, and proposing reasons for different perspectives
 *  evaluating points of view about a sustainability issue; for example, considering producers’ and consumers’ views on the sustainable use of resources and the expertise of people expressing views
 
-#### Concluding and decision-making
+#### Concluding and decision-making {#concluding-and-decision-making}
 
-##### AC9HS6S05
+##### AC9HS6S05 {#ac9hs6s05}
 
 develop evidence-based conclusions
 
@@ -168,7 +168,7 @@ develop evidence-based conclusions
 *  drawing conclusions based on identified evidence; for example, using census data to construct arguments for and against migration; using business council information to identify the ways different businesses provide goods and services to a community
 *  drawing conclusions that demonstrate consideration of questions, understanding of disciplinary concepts and evidence
 
-##### AC9HS6S06
+##### AC9HS6S06 {#ac9hs6s06}
 
 propose actions or responses to issues or challenges and use criteria to assess the possible effects
 
@@ -179,9 +179,9 @@ propose actions or responses to issues or challenges and use criteria to assess 
 *  determining a preferred option for action by identifying the advantages and disadvantages of different proposals, surveying people’s views and opinions, analysing the data, and debating and voting on alternatives
 *  identifying the possible social, cultural, economic and environmental effects of consumer or financial choices and developing strategies to minimise negative effects
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9HS6S07
+##### AC9HS6S07 {#ac9hs6s07}
 
 present descriptions and explanations, drawing ideas, findings and viewpoints from sources, and using relevant terms and conventions
 
@@ -189,7 +189,7 @@ present descriptions and explanations, drawing ideas, findings and viewpoints fr
 *  composing informative and persuasive texts, supported by evidence, to describe and explain conclusions from their economic, civic, historical and geographical inquiries
 *  selecting and referencing findings and viewpoints from sources and visual materials such as journals, diaries, graphs, tables, timelines, photographs and pictures, in descriptions and explanations
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 6, students explain the roles of significant people, events and ideas that led to Australian Federation, democracy and citizenship. They explain the causes and effects of migration to Australia since Federation. They explain the geographical diversity of places and the effects of interconnections with other countries. Students explain the key institutions, roles and responsibilities of Australia’s levels of government, and democratic values and beliefs. They explain influences on consumers and strategies for informed consumer and financial choices.
 

--- a/curriculum/hpe/foundation-year.md
+++ b/curriculum/hpe/foundation-year.md
@@ -1,6 +1,6 @@
-# Health and Physical Education - Foundation Year
+# Health and Physical Education - Foundation Year {#health-and-physical-education-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 The Foundation curriculum builds on the Early Years Learning Framework and each student's prior learning and experiences. In the early years, priority is given to the development of movement skills, participation in physical activity, and development of safe and healthy personal practices.
 
@@ -16,13 +16,13 @@ In the Foundation Year, students practise and develop locomotor and non-locomoto
 
 Through participation in active play, small group games and minor games, students explore ways to move safely and investigate why and how following rules promotes fair play.
 
-## Strands
+## Strands {#strands}
 
-### Personal, social and community health
+### Personal, social and community health {#personal-social-and-community-health}
 
-#### Identities and change
+#### Identities and change {#identities-and-change}
 
-##### AC9HPFP01
+##### AC9HPFP01 {#ac9hpfp01}
 
 investigate who they are and the people in their world
 
@@ -34,9 +34,9 @@ investigate who they are and the people in their world
 *  identifying ways they use their strengths in physical activities to help themselves and others to be successful
 *  recognising that they have a right to belong and contribute to a variety of groups
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9HPFP02
+##### AC9HPFP02 {#ac9hpfp02}
 
 practise personal and social skills to interact respectfully with others
 
@@ -46,7 +46,7 @@ practise personal and social skills to interact respectfully with others
 *  cooperating, collaborating and negotiating with others when participating in physical activities to achieve agreed outcomes
 *  identifying behaviours that may be disrespectful and cause hurt or harm to others during play
 
-##### AC9HPFP03
+##### AC9HPFP03 {#ac9hpfp03}
 
 express and describe emotions they experience
 
@@ -58,7 +58,7 @@ express and describe emotions they experience
 *  talking about connections between feelings, body reactions and body language
 *  expressing a variety of emotions, thoughts and views in a range of situations
 
-##### AC9HPFP04
+##### AC9HPFP04 {#ac9hpfp04}
 
 explore how to seek, give or deny permission respectfully when sharing possessions or personal space
 
@@ -67,9 +67,9 @@ explore how to seek, give or deny permission respectfully when sharing possessio
 *  negotiating roles and demonstrating awareness of rights (such as body autonomy/integrity) and respect for different perspectives through imaginative and shared play experiences
 *  exploring the importance of asking for permission and giving permission when sharing or negotiating in play and respecting someone’s right to say no
 
-#### Making healthy and safe choices
+#### Making healthy and safe choices {#making-healthy-and-safe-choices}
 
-##### AC9HPFP05
+##### AC9HPFP05 {#ac9hpfp05}
 
 demonstrate protective behaviours, name body parts and rehearse help-seeking strategies that help keep them safe
 
@@ -80,7 +80,7 @@ demonstrate protective behaviours, name body parts and rehearse help-seeking str
 *  identifying a support network of adults they can trust to help them if they feel unsafe, uncomfortable or scared
 *  recognising that all people have the right to bodily autonomy: the right to make choices about what others ask them to do with and to their bodies
 
-##### AC9HPFP06
+##### AC9HPFP06 {#ac9hpfp06}
 
 identify health symbols, messages and strategies in their community that support their health and safety
 
@@ -91,11 +91,11 @@ identify health symbols, messages and strategies in their community that support
 *  exploring different community strategies that keep children safe; for example, pedestrian crossings and traffic lights, safety procedures at swimming pools and beaches, and traffic controllers at school crossings
 *  recognising and following safety symbols and procedures at home and in water and road environments
 
-### Movement and physical activity
+### Movement and physical activity {#movement-and-physical-activity}
 
-#### Moving our bodies
+#### Moving our bodies {#moving-our-bodies}
 
-##### AC9HPFM01
+##### AC9HPFM01 {#ac9hpfm01}
 
 practise fundamental movement skills in minor game and play situations
 
@@ -107,7 +107,7 @@ practise fundamental movement skills in minor game and play situations
 *  demonstrating how to transfer weight from one part of the body to another
 *  applying fundamental movement skills for purpose and enjoyment in natural environments
 
-##### AC9HPFM02
+##### AC9HPFM02 {#ac9hpfm02}
 
 experiment with different ways of moving their body safely and manipulating objects and space
 
@@ -118,9 +118,9 @@ experiment with different ways of moving their body safely and manipulating obje
 *  manipulating equipment in a range of different movement situations and tasks, including in minor games, imaginative play and when practising fundamental movement skills
 *  demonstrating spatial awareness when moving around and through indoor and outdoor (natural) environments confidently and safely
 
-#### Making active choices
+#### Making active choices {#making-active-choices}
 
-##### AC9HPFM03
+##### AC9HPFM03 {#ac9hpfm03}
 
 participate in a range of activities in natural and outdoor settings and explore the benefits of being physically active
 
@@ -130,9 +130,9 @@ participate in a range of activities in natural and outdoor settings and explore
 *  discussing opportunities to be active in spaces in and around their homes
 *  exploring strategies for taking considered risks and developing self-regulation skills when moving and playing in outdoor settings
 
-#### Learning through movement
+#### Learning through movement {#learning-through-movement}
 
-##### AC9HPFM04
+##### AC9HPFM04 {#ac9hpfm04}
 
 follow rules to promote fair play in a range of physical activities
 
@@ -141,7 +141,7 @@ follow rules to promote fair play in a range of physical activities
 *  demonstrating how to play fairly in a range of minor games and play situations
 *  discussing rules of different games that relate to safety, boundaries and appropriate use of equipment
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 The Foundation curriculum builds on the Early Years Learning Framework and each student's prior learning and experiences. In the early years, priority is given to the development of movement skills, participation in physical activity, and development of safe and healthy personal practices.
 

--- a/curriculum/hpe/years-1-and-2.md
+++ b/curriculum/hpe/years-1-and-2.md
@@ -1,6 +1,6 @@
-# Health and Physical Education - Years 1 and 2
+# Health and Physical Education - Years 1 and 2 {#health-and-physical-education-years-1-and-2}
 
-## Level Description
+## Level Description {#level-description}
 
 The Years 1­–2 curriculum builds on each student’s prior learning. In the early years, priority is given to the development of movement skills, participation in physical activity, and development of safe and healthy personal practices.
 
@@ -16,13 +16,13 @@ Students are supported in increasing the range and complexity of their fundament
 
 Through participation in active play, small group games and minor games, students apply different ways to move safely, and investigate how to select and apply fundamental movement skills individually, in groups and in teams in a range of movement situations.
 
-## Strands
+## Strands {#strands}
 
-### Personal, social and community health
+### Personal, social and community health {#personal-social-and-community-health}
 
-#### Identities and change
+#### Identities and change {#identities-and-change}
 
-##### AC9HP2P01
+##### AC9HP2P01 {#ac9hp2p01}
 
 describe their personal qualities and those of others, and explain how they contribute to developing identities
 
@@ -34,9 +34,9 @@ describe their personal qualities and those of others, and explain how they cont
 *  participating in physical activities and describing how their own and others’ personal qualities contribute to successful outcomes
 *  describing personal achievements and sharing how they felt and how it influenced their personal identities
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9HP2P02
+##### AC9HP2P02 {#ac9hp2p02}
 
 identify and explore skills and strategies to develop respectful relationships
 
@@ -47,7 +47,7 @@ identify and explore skills and strategies to develop respectful relationships
 *  discussing strategies we can use to show respect to First Nations Australians and acknowledge difference using appropriate language
 *  describing behaviours that may cause hurt or harm to others, or cause them to feel disrespected, including verbal and physical forms of bullying
 
-##### AC9HP2P03
+##### AC9HP2P03 {#ac9hp2p03}
 
 identify how different situations influence emotional responses
 
@@ -59,7 +59,7 @@ identify how different situations influence emotional responses
 *  predicting how a person or character might be feeling based on the words they use, their facial expressions and body language
 *  recognising how self and others are feeling in a range of situations
 
-##### AC9HP2P04
+##### AC9HP2P04 {#ac9hp2p04}
 
 practise strategies they can use when they need to seek, give or deny permission respectfully
 
@@ -68,9 +68,9 @@ practise strategies they can use when they need to seek, give or deny permission
 *  practising ways to interact with others in a fair and respectful way in play and other activities, regardless of differences in gender, abilities, race or personality
 *  exploring situations where they need to seek, give or deny permission and practising strategies to assert themselves; for example, saying no to inappropriate touching
 
-#### Making healthy and safe choices
+#### Making healthy and safe choices {#making-healthy-and-safe-choices}
 
-##### AC9HP2P05
+##### AC9HP2P05 {#ac9hp2p05}
 
 identify and demonstrate protective behaviours and help-seeking strategies they can use to help them and others stay safe
 
@@ -82,7 +82,7 @@ identify and demonstrate protective behaviours and help-seeking strategies they 
 *  discussing the importance of seeking help when problems are too big to solve by themselves
 *  exploring how characters in texts use protective behaviours and help-seeking strategies to keep themselves and others safe
 
-##### AC9HP2P06
+##### AC9HP2P06 {#ac9hp2p06}
 
 investigate a range of health messages and practices in their community and discuss their purposes
 
@@ -93,11 +93,11 @@ investigate a range of health messages and practices in their community and disc
 *  exploring sustainable practices that students can implement in the classroom to improve the health and wellbeing of the class, such as composting food waste, creating an edible garden and reducing single-use plastics
 *  creating rules and applying them at school and home to implement healthy and manageable practices with their use of digital tools
 
-### Movement and physical activity
+### Movement and physical activity {#movement-and-physical-activity}
 
-#### Moving our bodies
+#### Moving our bodies {#moving-our-bodies}
 
-##### AC9HP2M01
+##### AC9HP2M01 {#ac9hp2m01}
 
 practise fundamental movement skills and apply them in a variety of movement situations
 
@@ -108,7 +108,7 @@ practise fundamental movement skills and apply them in a variety of movement sit
 *  practising gliding forward and backward in the water using arm and kicking movements
 *  demonstrating balances and describing what helps to maintain stable positions
 
-##### AC9HP2M02
+##### AC9HP2M02 {#ac9hp2m02}
 
 investigate different ways of moving their body, and manipulating objects and space, and draw conclusions about their effectiveness
 
@@ -119,9 +119,9 @@ investigate different ways of moving their body, and manipulating objects and sp
 *  using different types of equipment to create an original game or solve a movement challenge and evaluating the game or solution against a set of criteria
 *  participating in activities that require students to move around different outdoor spaces and discussing which types of movement are most appropriate to move around safely and efficiently
 
-#### Making active choices
+#### Making active choices {#making-active-choices}
 
-##### AC9HP2M03
+##### AC9HP2M03 {#ac9hp2m03}
 
 participate in a range of physical activities in natural and outdoor settings, and investigate factors and settings that make physical activity enjoyable
 
@@ -131,9 +131,9 @@ participate in a range of physical activities in natural and outdoor settings, a
 *  participating in a range of minor games and exploring which ones they enjoy and what makes them enjoyable
 *  comparing the characteristics and benefits of physical activities that can take place in an outdoor setting to those that take place inside
 
-#### Learning through movement
+#### Learning through movement {#learning-through-movement}
 
-##### AC9HP2M04
+##### AC9HP2M04 {#ac9hp2m04}
 
 co-construct and apply rules to promote fair play in a range of physical activities
 
@@ -142,7 +142,7 @@ co-construct and apply rules to promote fair play in a range of physical activit
 *  explaining how rules contribute to fair play and applying them in group activities
 *  demonstrating turn-taking and sharing equipment when participating in play and minor games
 
-##### AC9HP2M05
+##### AC9HP2M05 {#ac9hp2m05}
 
 apply strategies to work collaboratively when participating in physical activities
 
@@ -151,7 +151,7 @@ apply strategies to work collaboratively when participating in physical activiti
 *  describing and demonstrating how to include others in physical activities
 *  proposing and trialling how a game can be changed so that everyone can be included
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 The Years 1­–2 curriculum builds on each student’s prior learning. In the early years, priority is given to the development of movement skills, participation in physical activity, and development of safe and healthy personal practices.
 

--- a/curriculum/hpe/years-3-and-4.md
+++ b/curriculum/hpe/years-3-and-4.md
@@ -1,6 +1,6 @@
-# Health and Physical Education - Years 3 and 4
+# Health and Physical Education - Years 3 and 4 {#health-and-physical-education-years-3-and-4}
 
-## Level Description
+## Level Description {#level-description}
 
 The Years 3–4 curriculum builds on each student’s prior learning. During this time, students are further developing their understanding of themselves and others, and the changing world in which they live.
 
@@ -14,13 +14,13 @@ Students develop greater proficiency across the range of fundamental movement sk
 
 Students combine different movement skills in game-like situations to create more complex movement patterns and sequences. Through exploration of, and participation in, a variety of physical activities, students further develop their knowledge about movement, how the body moves and the benefits of regular physical activity.
 
-## Strands
+## Strands {#strands}
 
-### Personal, social and community health
+### Personal, social and community health {#personal-social-and-community-health}
 
-#### Identities and change
+#### Identities and change {#identities-and-change}
 
-##### AC9HP4P01
+##### AC9HP4P01 {#ac9hp4p01}
 
 investigate how success, challenge, setbacks and failure strengthen resilience and identities in a range of contexts
 
@@ -31,7 +31,7 @@ investigate how success, challenge, setbacks and failure strengthen resilience a
 *  exploring how responses to success, challenge, setbacks and failures are influenced by cultural beliefs and values
 *  recognising how success, challenge, failure and enjoyment of physical activities influence identities
 
-##### AC9HP4P02
+##### AC9HP4P02 {#ac9hp4p02}
 
 plan, rehearse and reflect on strategies to cope with the different changes and transitions they experience, such as the changes associated with puberty
 
@@ -42,7 +42,7 @@ plan, rehearse and reflect on strategies to cope with the different changes and 
 *  practising and refining coping skills they can use when faced with challenges or changes, such as positive self-talk, problem-solving, mindfulness, seeking help from families, peers and teachers
 *  identifying scenarios in texts where characters experience and react to change and transition, evaluating the effectiveness of these responses and identifying other possible options that may be helpful
 
-##### AC9HP4P03
+##### AC9HP4P03 {#ac9hp4p03}
 
 describe how choices and actions can be influenced by stereotypes
 
@@ -52,9 +52,9 @@ describe how choices and actions can be influenced by stereotypes
 *  describing ways to make roles and responsibilities at home, at school and in communities fair, equitable and inclusive
 *  practising ways in which they can contribute to people of different genders being treated in fair and equal ways
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9HP4P04
+##### AC9HP4P04 {#ac9hp4p04}
 
 select, use and refine personal and social skills to establish, manage and strengthen relationships
 
@@ -65,7 +65,7 @@ select, use and refine personal and social skills to establish, manage and stren
 *  discussing how demonstrating respect and empathy for First Nations Australians can build positive relationships
 *  recognising that bullying behaviour can take many forms, including online, and proposing strategies to challenge bullying in and out of school
 
-##### AC9HP4P05
+##### AC9HP4P05 {#ac9hp4p05}
 
 describe how valuing diversity influences wellbeing and identify actions that promote inclusion in their communities
 
@@ -77,7 +77,7 @@ describe how valuing diversity influences wellbeing and identify actions that pr
 *  recognising the important role of cultural narratives in describing the diversity, and sharing beliefs and practices, of First Nations Australian communities
 *  exploring the diversity of backgrounds, experiences, beliefs and practices of different cultures, including the cultures of Asia
 
-##### AC9HP4P06
+##### AC9HP4P06 {#ac9hp4p06}
 
 explain how and why emotional responses can vary and practise strategies to manage their emotions
 
@@ -88,7 +88,7 @@ explain how and why emotional responses can vary and practise strategies to mana
 *  explaining the strategies characters in texts use to identify and manage their emotions before deciding to act
 *  implementing self-regulation strategies to manage the expression of emotional responses
 
-##### AC9HP4P07
+##### AC9HP4P07 {#ac9hp4p07}
 
 rehearse and refine strategies for seeking, giving and denying permission respectfully and describe situations when permission is required
 
@@ -97,9 +97,9 @@ rehearse and refine strategies for seeking, giving and denying permission respec
 *  exploring actions they can take if someone has done something hurtful or disrespectful to them without their permission or consent including in online environments
 *  exploring actions they can take when they or others are unsafe, such as saying no, leaving the situation and reporting the incident, and discussing how to use these strategies in situations in which someone posts an embarrassing picture online without permission, touches private parts of their body, or uses violence against them
 
-#### Making healthy and safe choices
+#### Making healthy and safe choices {#making-healthy-and-safe-choices}
 
-##### AC9HP4P08
+##### AC9HP4P08 {#ac9hp4p08}
 
 describe and apply protective behaviours and help-seeking strategies in a range of online and offline situations
 
@@ -111,7 +111,7 @@ describe and apply protective behaviours and help-seeking strategies in a range 
 *  proposing strategies for managing online safety by recognising when they feel uncomfortable or unsafe, and identifying steps for reporting negative or harmful behaviour
 *  discussing different protective behaviours and help-seeking strategies characters in texts use to keep themselves and others safe
 
-##### AC9HP4P09
+##### AC9HP4P09 {#ac9hp4p09}
 
 interpret the nature and intention of health information and messages, and reflect on how they influence personal decisions and behaviours
 
@@ -121,7 +121,7 @@ interpret the nature and intention of health information and messages, and refle
 *  identifying, examining and combining information and opinions from a range of sources to inform decisions and behaviours on a range of health issues
 *  investigating the level of influence health messages from different people and sources may have on their health decisions
 
-##### AC9HP4P10
+##### AC9HP4P10 {#ac9hp4p10}
 
 investigate and apply behaviours that contribute to their own and others’ health, safety, relationships and wellbeing
 
@@ -135,11 +135,11 @@ investigate and apply behaviours that contribute to their own and others’ heal
 *  identifying ways they can change their behaviours to support the sustainability of the Earth’s systems; for example, recycling or composting systems to minimise waste in the school, and community fruit and vegetable gardens to create healthy and sustainable lunches or snacks
 *  practising strategies for enhancing mental wellbeing such as positive self-talk, mindfulness and meditation
 
-### Movement and physical activity
+### Movement and physical activity {#movement-and-physical-activity}
 
-#### Moving our bodies
+#### Moving our bodies {#moving-our-bodies}
 
-##### AC9HP4M01
+##### AC9HP4M01 {#ac9hp4m01}
 
 refine and apply fundamental movement skills in new movement situations
 
@@ -150,7 +150,7 @@ refine and apply fundamental movement skills in new movement situations
 *  coordinating kicking with arm movements to move the body through the water using different types of strokes
 *  performing routines incorporating different jumping, landing and balancing techniques, and connecting movements to create a movement sequence
 
-##### AC9HP4M02
+##### AC9HP4M02 {#ac9hp4m02}
 
 apply and adapt movement strategies to achieve movement outcomes
 
@@ -160,7 +160,7 @@ apply and adapt movement strategies to achieve movement outcomes
 *  manipulating centre of gravity to enhance stability as they perform a range of balance activities and explaining how centre of gravity and base of support influence stability
 *  evaluating the outcome of a game tactic that has been adapted to improve scoring options using set criteria
 
-##### AC9HP4M03
+##### AC9HP4M03 {#ac9hp4m03}
 
 demonstrate how movement concepts related to effort, space, time, objects and people can be applied when performing movement sequences
 
@@ -170,9 +170,9 @@ demonstrate how movement concepts related to effort, space, time, objects and pe
 *  using the body to demonstrate an understanding of symmetry, shapes and angles when performing movement skills, balances or movement sequences
 *  exploring different ways of manipulating space to receive passes, maintain possession, or increase or decrease scoring opportunities in invasion, net/court, striking and fielding, and target games
 
-#### Making active choices
+#### Making active choices {#making-active-choices}
 
-##### AC9HP4M04
+##### AC9HP4M04 {#ac9hp4m04}
 
 participate in physical activities to explore how their body feels and describe how regular physical activity helps the body stay healthy and well
 
@@ -181,7 +181,7 @@ participate in physical activities to explore how their body feels and describe 
 *  performing warm-up and stretching routines to understand how to prepare the body to be active
 *  investigating the influence of regular physical activity on quality of sleep, concentration and overall wellbeing
 
-##### AC9HP4M05
+##### AC9HP4M05 {#ac9hp4m05}
 
 participate in physical activities in natural and outdoor settings to examine factors that can influence their own and others’ participation
 
@@ -191,7 +191,7 @@ participate in physical activities in natural and outdoor settings to examine fa
 *  participating in physical activities they can do at home and exploring how they can be more active at home using everyday items as equipment
 *  exploring ways in which people can connect with other members of their community through participating in physical activities
 
-##### AC9HP4M06
+##### AC9HP4M06 {#ac9hp4m06}
 
 explore recommendations about physical activity and sedentary behaviours, and discuss strategies to achieve the recommendations
 
@@ -200,9 +200,9 @@ explore recommendations about physical activity and sedentary behaviours, and di
 *  examining the benefits of regular physical activity, including the influence on sleep, concentration and wellbeing
 *  exploring physical activity and screen-usage time recommendations in the Australian 24-Hour Movement Guidelines for Children and Young People and proposing how they can meet these recommendations
 
-#### Learning through movement
+#### Learning through movement {#learning-through-movement}
 
-##### AC9HP4M07
+##### AC9HP4M07 {#ac9hp4m07}
 
 apply creative thinking when designing movement sequences and solving movement problems
 
@@ -211,7 +211,7 @@ apply creative thinking when designing movement sequences and solving movement p
 *  drawing on prior knowledge from other physical activity experiences to solve challenges faced when participating in outdoor activities
 *  developing questions and seeking and trialling answers with others as a strategy for solving movement challenges, such as partner or group balance challenges, game tactics to increase scoring chances and obstacle course challenges
 
-##### AC9HP4M08
+##### AC9HP4M08 {#ac9hp4m08}
 
 apply rules and scoring systems to promote fair play when participating or designing physical activities
 
@@ -221,7 +221,7 @@ apply rules and scoring systems to promote fair play when participating or desig
 *  interpreting and applying rules fairly in physical activities where they are in the role of officiating
 *  exploring rules and scoring systems used in traditional games of First Nations Australians and comparing them to rules and systems used in other games they have played
 
-##### AC9HP4M09
+##### AC9HP4M09 {#ac9hp4m09}
 
 perform a range of roles in respectful ways to achieve successful outcomes in group or team movement activities
 
@@ -230,7 +230,7 @@ perform a range of roles in respectful ways to achieve successful outcomes in gr
 *  working cooperatively with team members to maintain possession in a game by passing to other players and listening to teammates
 *  modifying physical activities to ensure that everyone is included, such as changing equipment, rules or playing space
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 The Years 3–4 curriculum builds on each student’s prior learning. During this time, students are further developing their understanding of themselves and others, and the changing world in which they live.
 

--- a/curriculum/hpe/years-5-and-6.md
+++ b/curriculum/hpe/years-5-and-6.md
@@ -1,6 +1,6 @@
-# Health and Physical Education - Years 5 and 6
+# Health and Physical Education - Years 5 and 6 {#health-and-physical-education-years-5-and-6}
 
-## Level Description
+## Level Description {#level-description}
 
 The Years 5–6 curriculum builds on each student’s prior learning. During this time, students are taking more responsibility for their own health, physical activity and personal safety.
 
@@ -14,13 +14,13 @@ Students have frequent opportunities to apply and transfer the movement skills a
 
 Students begin to explore more complex movement concepts and promote safe, equitable and fair participation for all. Students further develop and refine a range of communication and conflict resolution skills and processes, enabling them to interact appropriately and respectfully with others in a range of different movement and social situations.
 
-## Strands
+## Strands {#strands}
 
-### Personal, social and community health
+### Personal, social and community health {#personal-social-and-community-health}
 
-#### Identities and change
+#### Identities and change {#identities-and-change}
 
-##### AC9HP6P01
+##### AC9HP6P01 {#ac9hp6p01}
 
 explain how identities can be influenced by people and places, and how we can create positive self-identities
 
@@ -32,7 +32,7 @@ explain how identities can be influenced by people and places, and how we can cr
 *  exploring the different levels of connection within First Nations Australian communities, such as cultural group, clan, Country/Place, skin names and social standing within community
 *  exploring how family, peers, popular culture, gender stereotypes and the media influence developing identities
 
-##### AC9HP6P02
+##### AC9HP6P02 {#ac9hp6p02}
 
 investigate resources and strategies to manage changes and transitions, including changes associated with puberty
 
@@ -44,7 +44,7 @@ investigate resources and strategies to manage changes and transitions, includin
 *  analysing how roles and responsibilities change as people grow older and examining strategies for managing these increasing responsibilities
 *  examining how the developmental changes that occur through puberty prepare a persons' body for reproduction
 
-##### AC9HP6P03
+##### AC9HP6P03 {#ac9hp6p03}
 
 investigate how the portrayal of societal roles and responsibilities can be influenced by gender stereotypes
 
@@ -54,9 +54,9 @@ investigate how the portrayal of societal roles and responsibilities can be infl
 *  investigating how social and cultural norms about gender can influence the roles and responsibilities of family members and people within their community
 *  identifying those gender norms that can have limiting and harmful effects, and proposing strategies to advance gender equality and respect for human rights
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9HP6P04
+##### AC9HP6P04 {#ac9hp6p04}
 
 describe and demonstrate how respect and empathy can be expressed to positively influence relationships
 
@@ -67,7 +67,7 @@ describe and demonstrate how respect and empathy can be expressed to positively 
 *  recognising how words and labels used regarding First Nations Australians can cause offence and how this awareness can support and strengthen respectful relationships
 *  examining the behaviours people demonstrate when treating others in respectful ways, and comparing to those behaviours that constitute forms of bullying, racism or gender-based violence
 
-##### AC9HP6P05
+##### AC9HP6P05 {#ac9hp6p05}
 
 describe and implement strategies to value diversity in their communities
 
@@ -79,7 +79,7 @@ describe and implement strategies to value diversity in their communities
 *  exploring the importance of cultural expressions of First Nations Australians in maintaining a continuing deep connection to Country/Place and its influence on wellbeing
 *  examining how beliefs, values and cultural practices convey meaning and influence peoples’ sense of identity and belonging, including Australians of Asian heritage
 
-##### AC9HP6P06
+##### AC9HP6P06 {#ac9hp6p06}
 
 apply strategies to manage emotions and analyse how emotional responses influence interactions
 
@@ -88,7 +88,7 @@ apply strategies to manage emotions and analyse how emotional responses influenc
 *  analysing situations in which emotions can influence decision-making, including in peer-group, family and movement situations
 *  exploring when emotional responses can be intense or unpredictable, including feelings of grief associated with loss, and practising strategies to self-regulate and manage expression of strong emotions
 
-##### AC9HP6P07
+##### AC9HP6P07 {#ac9hp6p07}
 
 describe strategies for seeking, giving or denying consent and rehearse how to communicate their intentions effectively and respectfully
 
@@ -97,9 +97,9 @@ describe strategies for seeking, giving or denying consent and rehearse how to c
 *  practising and refining strategies for interpreting verbal and non-verbal cues related to seeking, giving and denying consent in a range of situations
 *  analysing how a person’s reaction to being denied permission to do something can affect others’ feelings and discussing options for dealing with situations when this may occur; for example, feelings of disappointment, shame and anger associated with rejection
 
-#### Making healthy and safe choices
+#### Making healthy and safe choices {#making-healthy-and-safe-choices}
 
-##### AC9HP6P08
+##### AC9HP6P08 {#ac9hp6p08}
 
 analyse and rehearse protective behaviours and help-seeking strategies that can be used in a range of online and offline situations
 
@@ -111,7 +111,7 @@ analyse and rehearse protective behaviours and help-seeking strategies that can 
 *  proposing strategies they can use if they witness others in unsafe situations, such as accessing support networks or telling an adult they trust
 *  analysing the responses of characters in TV shows or movies when in unsafe or risky situations and discussing the efficacy of their response to the situation
 
-##### AC9HP6P09
+##### AC9HP6P09 {#ac9hp6p09}
 
 investigate different sources and types of health information and how these apply to their own and others’ health choices
 
@@ -121,7 +121,7 @@ investigate different sources and types of health information and how these appl
 *  identifying trusted people in their lives with whom they can share their health needs and concerns, and rehearsing ways to communicate concerns about their health to a variety of support people
 *  examining and comparing relevant health information and opinions, and identifying which aspects can be verified as accurate and reliable
 
-##### AC9HP6P10
+##### AC9HP6P10 {#ac9hp6p10}
 
 analyse how behaviours influence the health, safety, relationships and wellbeing of individuals and communities
 
@@ -135,11 +135,11 @@ analyse how behaviours influence the health, safety, relationships and wellbeing
 *  examining sustainable food practices to measure the quality of food available in the school canteen or local area
 *  describing strategies to support a sense of belonging and connection, and recognising the importance of social support for enhancing mental health and wellbeing
 
-### Movement and physical activity
+### Movement and physical activity {#movement-and-physical-activity}
 
-#### Moving our bodies
+#### Moving our bodies {#moving-our-bodies}
 
-##### AC9HP6M01
+##### AC9HP6M01 {#ac9hp6m01}
 
 adapt and modify movement skills across a variety of situations
 
@@ -150,7 +150,7 @@ adapt and modify movement skills across a variety of situations
 *  combining surface propulsion and underwater skills in an aquatic environment
 *  composing and performing a range of static and dynamic balances on different body parts, rotating and pivoting to change direction of movement
 
-##### AC9HP6M02
+##### AC9HP6M02 {#ac9hp6m02}
 
 transfer familiar movement strategies to different movement situations
 
@@ -160,7 +160,7 @@ transfer familiar movement strategies to different movement situations
 *  transferring strategies they have used to maintain balance to safely traverse a natural environment
 *  making judgements, based on agreed criteria, about the effectiveness of transferring strategies from one game to another
 
-##### AC9HP6M03
+##### AC9HP6M03 {#ac9hp6m03}
 
 investigate how different movement concepts related to effort, space, time, objects and people can be applied to improve movement outcomes
 
@@ -170,9 +170,9 @@ investigate how different movement concepts related to effort, space, time, obje
 *  working with a partner to explore pushing and pulling movements and how these can be manipulated to generate and perform counterbalances
 *  developing strategies that exploit the playing space to create overlaps and extra attackers
 
-#### Making active choices
+#### Making active choices {#making-active-choices}
 
-##### AC9HP6M04
+##### AC9HP6M04 {#ac9hp6m04}
 
 participate in physical activities to investigate the body’s reaction to different levels of intensity
 
@@ -181,7 +181,7 @@ participate in physical activities to investigate the body’s reaction to diffe
 *  designing and modelling different warm-up and cool-down routines for the class and discussing their importance for reducing the chance of injuries or soreness after activity
 *  participating in and designing physical activity opportunities that support their health and fitness goals
 
-##### AC9HP6M05
+##### AC9HP6M05 {#ac9hp6m05}
 
 participate in physical activities that enhance health and wellbeing in natural and outdoor settings, and analyse the steps and resources needed to promote participation
 
@@ -191,7 +191,7 @@ participate in physical activities that enhance health and wellbeing in natural 
 *  researching the Australian 24-Hour Movement Guidelines for Children and Young People, comparing their daily habits of physical activity to the recommendations and proposing strategies for enhancing or maintaining their levels of activity
 *  discussing how a connection to a community space or special place can influence the types of physical activity options people will choose to participate in, such as links to skate parks, surf beaches or bushwalking trails
 
-##### AC9HP6M06
+##### AC9HP6M06 {#ac9hp6m06}
 
 propose and explain strategies to increase physical activity and reduce sedentary behaviour levels in their lives
 
@@ -200,9 +200,9 @@ propose and explain strategies to increase physical activity and reduce sedentar
 *  examining the benefits of physical activity for social health and mental wellbeing, and researching options for participating in physical activities in the local area
 *  investigating the resources needed and steps required to set up a lunchtime sports competition, activity circuit or playground games aimed at increasing levels of physical activity among students and staff
 
-#### Learning through movement
+#### Learning through movement {#learning-through-movement}
 
-##### AC9HP6M07
+##### AC9HP6M07 {#ac9hp6m07}
 
 predict and test the effectiveness of applying different skills and strategies in a range of movement situations
 
@@ -211,7 +211,7 @@ predict and test the effectiveness of applying different skills and strategies i
 *  adapting movement skills and strategies from other contexts to generate creative solutions to unfamiliar movement challenges when participating in outdoor activities
 *  co-developing criteria to assess effectiveness of responses to movement challenges, predicting the effectiveness of each, then testing and refining solutions against the criteria in order to achieve successful outcomes
 
-##### AC9HP6M08
+##### AC9HP6M08 {#ac9hp6m08}
 
 devise and test alternative rules and game modifications to support fair play and inclusive participation
 
@@ -221,7 +221,7 @@ devise and test alternative rules and game modifications to support fair play an
 *  discussing where and when they have witnessed fairness and inclusion in a game situation and explaining what factors led to the game being inclusive and fair
 *  investigating the effectiveness of rules used in traditional games of First Nations Australians to promote participation, such as Inkanyi: a cooperative running game played by the Pitjantjatjara / Yankunytjatjara of central Australia where there are no winners and Barambah gimbe: a throwing and catching game from the lands of the Wakka Wakka where catchers can be nominated to increase participation
 
-##### AC9HP6M09
+##### AC9HP6M09 {#ac9hp6m09}
 
 participate positively in groups and teams by contributing to group activities, encouraging others and negotiating roles and responsibilities
 
@@ -230,7 +230,7 @@ participate positively in groups and teams by contributing to group activities, 
 *  demonstrating negotiation skills when dealing with conflicts or disagreements in movement situations
 *  using reflective listening and assertive communication when working in small groups on movement tasks or challenges
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 The Years 5–6 curriculum builds on each student’s prior learning. During this time, students are taking more responsibility for their own health, physical activity and personal safety.
 

--- a/curriculum/hpe/years-7-and-8.md
+++ b/curriculum/hpe/years-7-and-8.md
@@ -1,6 +1,6 @@
-# Health and Physical Education - Years 7 and 8
+# Health and Physical Education - Years 7 and 8 {#health-and-physical-education-years-7-and-8}
 
-## Level Description
+## Level Description {#level-description}
 
 The Years 7–8 curriculum builds on each student’s prior learning. During this time, a major influence on students is the world around them, and their peers become a key source of motivation and support when managing their health and wellbeing.
 
@@ -14,13 +14,13 @@ Students practise and apply more complex combinations of skills and strategies i
 
 Students have opportunities to practise using creative and collaborative processes to work in a group or team to communicate effectively, solve problems, resolve conflicts, and make decisions in movement and social contexts.
 
-## Strands
+## Strands {#strands}
 
-### Personal, social and community health
+### Personal, social and community health {#personal-social-and-community-health}
 
-#### Identities and change
+#### Identities and change {#identities-and-change}
 
-##### AC9HP8P01
+##### AC9HP8P01 {#ac9hp8p01}
 
 analyse and reflect on the influence of values and beliefs on the development of identities
 
@@ -30,7 +30,7 @@ analyse and reflect on the influence of values and beliefs on the development of
 *  examining how cultural values and beliefs influence the way young people view themselves, including young Australians of Asian heritage
 *  examining how cultural beliefs about the physical changes experienced during puberty can influence gender, cultural and sexual identities
 
-##### AC9HP8P02
+##### AC9HP8P02 {#ac9hp8p02}
 
 analyse the impact of changes and transitions, and devise strategies to support themselves and others through these changes
 
@@ -41,7 +41,7 @@ analyse the impact of changes and transitions, and devise strategies to support 
 *  examining the notion of “border crossing”; that is, how First Nations Australians live across multiple cultures, and how these transitions can impact on a sense of belonging to culture, family and peer groups
 *  evaluating and practising coping, communication and problem-solving skills to manage changes and emotions associated with puberty and getting older
 
-##### AC9HP8P03
+##### AC9HP8P03 {#ac9hp8p03}
 
 examine how roles, decision-making, and levels of power, coercion and control within relationships can be influenced by gender stereotypes
 
@@ -51,9 +51,9 @@ examine how roles, decision-making, and levels of power, coercion and control wi
 *  identifying those positive character attributes and strengths that are valued regardless of gender
 *  investigating strategies that have been successful in challenging harmful or limiting stereotypes, attitudes or practices
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9HP8P04
+##### AC9HP8P04 {#ac9hp8p04}
 
 examine the roles of respect, empathy, power and coercion in developing respectful relationships
 
@@ -64,7 +64,7 @@ examine the roles of respect, empathy, power and coercion in developing respectf
 *  proposing strategies for addressing racism towards First Nations Australians, including the role of bystanders in promoting respectful interactions and challenging disrespect and discrimination
 *  examining what constitutes disrespectful, harmful or violent behaviour within peer, family and intimate relationships
 
-##### AC9HP8P05
+##### AC9HP8P05 {#ac9hp8p05}
 
 investigate strategies that influence how communities value diversity and propose actions they can take to promote inclusion in their communities
 
@@ -76,7 +76,7 @@ investigate strategies that influence how communities value diversity and propos
 *  investigating events and strategies that value the contributions of First Nations Australians and strengthen relationships, such as Indigenous rounds in sporting codes and NAIDOC Week
 *  identifying examples of beliefs and cultural practices within, between and across cultural groups, including cultural groups from the Asian region, and describing how they have changed or remained the same over time
 
-##### AC9HP8P06
+##### AC9HP8P06 {#ac9hp8p06}
 
 analyse factors that influence emotional responses and devise strategies to self-manage emotions
 
@@ -85,7 +85,7 @@ analyse factors that influence emotional responses and devise strategies to self
 *  exploring different viewpoints, practising being empathetic and considering alternative ways to respond in a variety of situations, which take into account how they may affect others
 *  recognising and interpreting emotional responses to stressful situations and proposing strategies for ensuring those responses don’t have a negative impact on others
 
-##### AC9HP8P07
+##### AC9HP8P07 {#ac9hp8p07}
 
 explain and apply skills and strategies to communicate assertively and respectfully when seeking, giving or denying consent
 
@@ -94,9 +94,9 @@ explain and apply skills and strategies to communicate assertively and respectfu
 *  understanding and applying online and social protocols to enhance relationships with others and protect their own wellbeing, including recognising and responding to online content that may be harmful for themselves or others (such as grooming or image-based abuse), respectfully communicating needs or concerns to others
 *  examining the nature of consent in different types of relationships, and proposing and practising strategies for seeking, giving and denying consent respectfully
 
-#### Making healthy and safe choices
+#### Making healthy and safe choices {#making-healthy-and-safe-choices}
 
-##### AC9HP8P08
+##### AC9HP8P08 {#ac9hp8p08}
 
 refine protective behaviours and evaluate community resources to seek help for themselves and others
 
@@ -108,7 +108,7 @@ refine protective behaviours and evaluate community resources to seek help for t
 *  analysing how bystanders play a role in ensuring online spaces are positive and safe, and examining how support services such as kidshelpline and the eSafety Commissioner can provide support for young people who feel unsafe, bullied or abused online
 *  exploring help-seeking scenarios young people may encounter and sharing strategies for dealing with each situation, including situations linked to substance use, mental health issues, safety and risk-taking, and sexual health
 
-##### AC9HP8P09
+##### AC9HP8P09 {#ac9hp8p09}
 
 investigate how media and influential people impact attitudes, beliefs, decisions and behaviours in relation to health, safety, relationships and wellbeing
 
@@ -119,7 +119,7 @@ investigate how media and influential people impact attitudes, beliefs, decision
 *  exploring health campaigns targeting First Nations Australian young people and discussing the messages and strategies used to promote and enhance their health; for example, Deadly Choices, Don’t Make Smokes Your Story and Yarn Safe
 *  analysing how messages related to sexual relationships are portrayed in different forms of media and how they may influence the way people act within relationships
 
-##### AC9HP8P10
+##### AC9HP8P10 {#ac9hp8p10}
 
 plan and implement strategies, using health resources, to enhance their own and others’ health, safety, relationships and wellbeing
 
@@ -133,11 +133,11 @@ plan and implement strategies, using health resources, to enhance their own and 
 *  investigating tools and designing routines that help to regulate the use of digital environments and tools and ensure a healthy pattern of use, such as using “do not disturb” mode or turning off notifications
 *  investigating different approaches and developing personal plans for promoting their own positive mental health and wellbeing, such as mindfulness, relaxation techniques and healthy eating
 
-### Movement and physical activity
+### Movement and physical activity {#movement-and-physical-activity}
 
-#### Moving our bodies
+#### Moving our bodies {#moving-our-bodies}
 
-##### AC9HP8M01
+##### AC9HP8M01 {#ac9hp8m01}
 
 analyse, refine and transfer movement skills in a variety of movement situations
 
@@ -149,7 +149,7 @@ analyse, refine and transfer movement skills in a variety of movement situations
 *  using feedback from others to refine the composition of a group dance sequence
 *  using feedback from others to safely and efficiently travel around, over, up, under and through natural or built obstacles
 
-##### AC9HP8M02
+##### AC9HP8M02 {#ac9hp8m02}
 
 design and demonstrate how movement strategies can be manipulated to improve movement outcomes
 
@@ -159,7 +159,7 @@ design and demonstrate how movement strategies can be manipulated to improve mov
 *  exploring similarities between the bases of support and flow of movements when performing different movement sequences that require static and dynamic balance
 *  predicting the effectiveness of changes in tactics or strategies on scoring opportunities and suggesting reasons for any unexpected results
 
-##### AC9HP8M03
+##### AC9HP8M03 {#ac9hp8m03}
 
 demonstrate and explain how movement concepts related to effort, space, time, objects and people can be manipulated to improve movement outcomes
 
@@ -169,9 +169,9 @@ demonstrate and explain how movement concepts related to effort, space, time, ob
 *  creating, performing and appraising rhythmic movement sequences that demonstrate variations in flow of movements, use of space and relationships to other performers
 *  designing and refining performances to demonstrate how to manipulate space and relationships between players in the space to achieve successful movement outcomes
 
-#### Making active choices
+#### Making active choices {#making-active-choices}
 
-##### AC9HP8M04
+##### AC9HP8M04 {#ac9hp8m04}
 
 participate in physical activities designed to improve fitness and wellbeing to investigate the impact of regular participation on health, fitness and wellbeing
 
@@ -180,7 +180,7 @@ participate in physical activities designed to improve fitness and wellbeing to 
 *  designing and performing a fitness circuit they could implement at home (with minimal equipment) that improves one or more fitness components
 *  researching and participating in new activities to explore how they can enhance health, fitness and wellbeing, such as yoga, mindfulness meditation, gym classes, HIIT sessions
 
-##### AC9HP8M05
+##### AC9HP8M05 {#ac9hp8m05}
 
 participate in physical activities that utilise community spaces and outdoor settings, and evaluate strategies to support increased use of these spaces
 
@@ -190,7 +190,7 @@ participate in physical activities that utilise community spaces and outdoor set
 *  designing and evaluating physical activity options that reimagine the use of community spaces to encourage more active lifestyles among their peer group
 *  promoting an understanding of minimal-impact outdoor recreation in the local area
 
-##### AC9HP8M06
+##### AC9HP8M06 {#ac9hp8m06}
 
 design and justify strategies to increase physical activity levels to achieve health and wellbeing outcomes
 
@@ -199,9 +199,9 @@ design and justify strategies to increase physical activity levels to achieve he
 *  investigating which physical activities people engage in to maintain emotional and social wellbeing, and designing a program of activities aimed at increasing social connection and wellbeing
 *  comparing their current physical activity levels, amount of sleep and sedentary activity time with Australia’s 24-Hour Movement Guidelines for Children and Young People and suggesting strategies for themselves and others to meet these recommendations
 
-#### Learning through movement
+#### Learning through movement {#learning-through-movement}
 
-##### AC9HP8M07
+##### AC9HP8M07 {#ac9hp8m07}
 
 propose and evaluate movement strategies and skills that would be most effective in different movement situations
 
@@ -210,7 +210,7 @@ propose and evaluate movement strategies and skills that would be most effective
 *  explaining and justifying the movement strategies selected in response to movement challenges when participating in outdoor or nature-based activities such as rope courses, bushwalking, orienteering or canoeing
 *  putting their movement solutions into action by predicting outcomes and testing the approach proposed to achieve successful movement outcomes
 
-##### AC9HP8M08
+##### AC9HP8M08 {#ac9hp8m08}
 
 investigate modifications to equipment, rules and scoring systems that support fair play and inclusive participation
 
@@ -220,7 +220,7 @@ investigate modifications to equipment, rules and scoring systems that support f
 *  analysing the benefits and potential drawbacks of activities where players, rather than an independent official, are responsible for officiating the game
 *  exploring rules, equipment and scoring systems of traditional games of First Nations Australians and investigating how they support skill development and fair and inclusive play
 
-##### AC9HP8M09
+##### AC9HP8M09 {#ac9hp8m09}
 
 practise and apply leadership, collaboration and group decision-making processes when participating in a range of physical activities
 
@@ -230,7 +230,7 @@ practise and apply leadership, collaboration and group decision-making processes
 *  reflecting on their role and articulating how the actions they initiated in that role led to the achievement of successful outcomes
 *  undertaking various roles as a leader or collaborator to support the planning of physical activities for their team or peer group
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 The Years 7–8 curriculum builds on each student’s prior learning. During this time, a major influence on students is the world around them, and their peers become a key source of motivation and support when managing their health and wellbeing.
 

--- a/curriculum/hpe/years-9-and-10.md
+++ b/curriculum/hpe/years-9-and-10.md
@@ -1,6 +1,6 @@
-# Health and Physical Education - Years 9 and 10
+# Health and Physical Education - Years 9 and 10 {#health-and-physical-education-years-9-and-10}
 
-## Level Description
+## Level Description {#level-description}
 
 The Years 9–10 curriculum builds on each student’s prior learning. During this time, students refine their understanding of how they can contribute to individual and community health and wellbeing. Students have frequent opportunities to participate in physical activities, including in outdoor settings, to value the importance of active recreation as a way of enhancing their health and wellbeing throughout their lives.
 
@@ -16,13 +16,13 @@ Students practise and refine more specialised movement skills and complex moveme
 
 Students further investigate techniques to assess the quality of movement performances. They adapt and improvise their movements to respond to different movement situations, stimuli and challenges. Students refine and consolidate their leadership, teamwork and collaborative skills through participation in a range of physical activities.
 
-## Strands
+## Strands {#strands}
 
-### Personal, social and community health
+### Personal, social and community health {#personal-social-and-community-health}
 
-#### Identities and change
+#### Identities and change {#identities-and-change}
 
-##### AC9HP10P01
+##### AC9HP10P01 {#ac9hp10p01}
 
 analyse factors that shape identities and evaluate how individuals influence the identities of others
 
@@ -33,7 +33,7 @@ analyse factors that shape identities and evaluate how individuals influence the
 *  analysing the role of family, friends and community in supporting an individual’s identities, and proposing strategies to enhance their own and others’ wellbeing
 *  examining how societal norms, stereotypes and expectations influence perceptions of movement competence
 
-##### AC9HP10P02
+##### AC9HP10P02 {#ac9hp10p02}
 
 refine, evaluate and adapt strategies for managing changes and transitions
 
@@ -44,7 +44,7 @@ refine, evaluate and adapt strategies for managing changes and transitions
 *  discussing the impact of border crossing on the development of identities for First Nations Australians
 *  rehearsing strategies to respectfully assert their stance on a situation, dilemma or decision by expressing thoughts, opinions and beliefs that acknowledge the feelings of others
 
-##### AC9HP10P03
+##### AC9HP10P03 {#ac9hp10p03}
 
 investigate how gender equality and challenging assumptions about gender can prevent violence and abuse in relationships
 
@@ -54,9 +54,9 @@ investigate how gender equality and challenging assumptions about gender can pre
 *  evaluating how gender equality can empower people to develop equal and respectful relationships
 *  exploring scenarios in texts that demonstrate how gender inequality can arise from intergenerational patterns of inequity and unequal power in relationships, and proposing strategies for challenging inequality in their communities
 
-#### Interacting with others
+#### Interacting with others {#interacting-with-others}
 
-##### AC9HP10P04
+##### AC9HP10P04 {#ac9hp10p04}
 
 evaluate the influence of respect, empathy, power and coercion on establishing and maintaining respectful relationships
 
@@ -67,7 +67,7 @@ evaluate the influence of respect, empathy, power and coercion on establishing a
 *  identifying the ways in which historical patterns of inequity, violence and discrimination can have lasting intergenerational effects on wellbeing, and considering strategies to build the cultural awareness, empathy, compassion and respect that contribute to reconciliation
 *  investigating how bullying, racism and gender-based violence can take different forms, including verbal, physical, emotional, sexual and economic forms, and can occur in both face-to-face and online environments
 
-##### AC9HP10P05
+##### AC9HP10P05 {#ac9hp10p05}
 
 propose strategies and actions individuals and groups can implement to challenge biases, stereotypes, prejudices and discrimination, and promote inclusion in their communities
 
@@ -79,7 +79,7 @@ propose strategies and actions individuals and groups can implement to challenge
 *  designing strategies and actions they can implement to challenge stereotypes, prejudices and discrimination, and publicly acknowledge the contributions First Nations Australians make to Australia’s sporting and health fields
 *  proposing strategies to challenge prejudices, biases and discrimination that target specific cultural groups, including Australians of Asian heritage
 
-##### AC9HP10P06
+##### AC9HP10P06 {#ac9hp10p06}
 
 evaluate emotional responses in different situations to refine strategies for managing emotions
 
@@ -88,7 +88,7 @@ evaluate emotional responses in different situations to refine strategies for ma
 *  reflecting on the possible consequences of not recognising their own or others’ emotions in a range of challenging situations, including responses to rejection, failure, harassment and violence
 *  evaluating situations where an individual may react with extreme or uncontrolled emotion and reflecting on the impact that this response may have on the situation and/or their relationships
 
-##### AC9HP10P07
+##### AC9HP10P07 {#ac9hp10p07}
 
 examine how strategies, such as communicating choices, seeking, giving and denying consent, and expressing opinions and needs can support the development of respectful relationships, including sexual relationships
 
@@ -98,9 +98,9 @@ examine how strategies, such as communicating choices, seeking, giving and denyi
 *  reflecting on the potential impact of their own behaviour on others and the importance of taking responsibility for their own actions to ensure they do no harm to others
 *  refining strategies to communicate clearly and respectfully their choices, needs and opinions in a range of relationship scenarios, such as in peer group, family or work situations
 
-#### Making healthy and safe choices
+#### Making healthy and safe choices {#making-healthy-and-safe-choices}
 
-##### AC9HP10P08
+##### AC9HP10P08 {#ac9hp10p08}
 
 plan, rehearse and evaluate strategies for managing situations where their own or others’ health, safety or wellbeing may be at risk
 
@@ -112,7 +112,7 @@ plan, rehearse and evaluate strategies for managing situations where their own o
 *  understanding the factors that impact a person’s ability to seek, give or deny consent, including when a person is affected by alcohol and other drugs, or there is an imbalance of power or coercion within the relationship
 *  examining practices, policies and processes for ensuring safe blood practices in a range of situations, including not sharing needles, precautions when participating in physical activities and safe practices during sexual activity, including use of condoms and dams
 
-##### AC9HP10P09
+##### AC9HP10P09 {#ac9hp10p09}
 
 critique health information, services and media messaging about relationships, lifestyle choices, health decisions and behaviours to evaluate their influence on individual attitudes and actions
 
@@ -123,7 +123,7 @@ critique health information, services and media messaging about relationships, l
 *  investigating health issues specific to First Nations Australian communities and proposing proactive community strategies for promoting better access and health outcomes; for example, remote area dialysis buses and community-based treatment options
 *  discussing how the portrayal of sexual relationships in TV shows, advertisements, movies, popular music and online content (such as pornography) may influence people’s beliefs about respectful, safe and consensual relationships
 
-##### AC9HP10P10
+##### AC9HP10P10 {#ac9hp10p10}
 
 plan, justify and critique strategies to enhance their own and others’ health, safety, relationships and wellbeing
 
@@ -137,11 +137,11 @@ plan, justify and critique strategies to enhance their own and others’ health,
 *  proposing constructive, healthy and manageable actions when using tools and digital environments to promote respect, inclusion and the wellbeing of others, such as researching what to do if they, or someone they know, is being targeted online
 *  designing and evaluating strategies that enhance their own and others’ mental health and wellbeing, such as regular physical activity, positive self-talk, consistent sleep habits, mindfulness and social connection
 
-### Movement and physical activity
+### Movement and physical activity {#movement-and-physical-activity}
 
-#### Moving our bodies
+#### Moving our bodies {#moving-our-bodies}
 
-##### AC9HP10M01
+##### AC9HP10M01 {#ac9hp10m01}
 
 analyse, adapt and refine their own and others’ movement skills in a range of challenging movement situations to enhance performance
 
@@ -152,7 +152,7 @@ analyse, adapt and refine their own and others’ movement skills in a range of 
 *  analysing their own and others’ performances, such as at a swimming, cross-country or athletics carnival, and propose strategies for refining techniques to improve performance
 *  providing constructive feedback on their own and others' group performance of a movement sequence
 
-##### AC9HP10M02
+##### AC9HP10M02 {#ac9hp10m02}
 
 create and refine movement strategies to achieve successful outcomes across a range of challenging movement situations
 
@@ -162,7 +162,7 @@ create and refine movement strategies to achieve successful outcomes across a ra
 *  adapting and refining movement strategies to enhance movement outcomes when using different types of equipment
 *  evaluating the effectiveness of a range of strategies in game situations using a personally developed set of criteria and suggesting how to adapt to improve performance
 
-##### AC9HP10M03
+##### AC9HP10M03 {#ac9hp10m03}
 
 apply movement concepts in new or challenging movement situations and analyse the impact each concept has on movement outcomes
 
@@ -172,9 +172,9 @@ apply movement concepts in new or challenging movement situations and analyse th
 *  creating and evaluating a group performance that demonstrates synchronous and individual movements
 *  analysing and describing how individual or team performance has improved through modifications to the use of space and time
 
-#### Making active choices
+#### Making active choices {#making-active-choices}
 
-##### AC9HP10M04
+##### AC9HP10M04 {#ac9hp10m04}
 
 participate in physical activities designed to enhance health, wellbeing and fitness, and design, apply and evaluate strategies for incorporating these activities into their lives
 
@@ -183,7 +183,7 @@ participate in physical activities designed to enhance health, wellbeing and fit
 *  performing a range of activities designed to improve fitness and analysing how the activities improve individual components of fitness
 *  setting realistic physical activity goals, and designing, implementing and evaluating a personalised program to incorporate regular physical activity into their weekly routines
 
-##### AC9HP10M05
+##### AC9HP10M05 {#ac9hp10m05}
 
 participate in physical activities that promote health and social outcomes to design and evaluate participation strategies for themselves and others
 
@@ -193,7 +193,7 @@ participate in physical activities that promote health and social outcomes to de
 *  investigating community-based campaigns to promote physical activity participation and determining key elements of success that could be replicated in a school-based campaign
 *  identifying local natural resources and community spaces where individuals and groups can connect and participate in physical and social activities
 
-##### AC9HP10M06
+##### AC9HP10M06 {#ac9hp10m06}
 
 design, implement and evaluate personalised plans for improving or maintaining their own or others’ physical activity levels to achieve fitness, health and wellbeing outcomes
 
@@ -202,9 +202,9 @@ design, implement and evaluate personalised plans for improving or maintaining t
 *  justifying the selection of physical activities included in a personalised plan linked to physical activity goals and wellbeing outcomes they wish to improve or maintain
 *  investigating target training heart-rate zones for a range of different people, how these zones can be measured and how they relate to health, wellbeing and fitness levels
 
-#### Learning through movement
+#### Learning through movement {#learning-through-movement}
 
-##### AC9HP10M07
+##### AC9HP10M07 {#ac9hp10m07}
 
 transfer and adapt skills and strategies from previous experiences to create successful outcomes in unfamiliar movement situations
 
@@ -213,7 +213,7 @@ transfer and adapt skills and strategies from previous experiences to create suc
 *  speculating on possible outcomes of innovative solutions to movement challenges based on past experiences when participating in outdoor or nature-based activities, such as rope climbing, bushwalking, abseiling or kayaking
 *  reflecting on the effectiveness of movement solutions, suggesting improvements that can be made and proposing how the solution can be transferred to other movement situations
 
-##### AC9HP10M08
+##### AC9HP10M08 {#ac9hp10m08}
 
 demonstrate fair play and reflect on how ethical behaviour can influence physical activity outcomes for individuals and groups
 
@@ -223,7 +223,7 @@ demonstrate fair play and reflect on how ethical behaviour can influence physica
 *  discussing the role of organisations such as Sports Integrity Australia, sporting tribunals, the Australian Human Rights Commission and the Court of Arbitration for Sport, in promoting fairness and ethical behaviour in sport
 *  analysing how First Nations Australian athletes have been treated in different sports and evaluating the impact that may have on the participation of young First Nations Australians in sport and physical activity
 
-##### AC9HP10M09
+##### AC9HP10M09 {#ac9hp10m09}
 
 devise, implement and refine strategies for decision-making when working in groups or teams that demonstrate leadership and collaboration skills
 
@@ -233,7 +233,7 @@ devise, implement and refine strategies for decision-making when working in grou
 *  creating and implementing self-assessment and peer-assessment tools to evaluate performance in a variety of roles
 *  identifying and critiquing leadership styles and group dynamics through collaboratively solving initiative games
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 The Years 9–10 curriculum builds on each student’s prior learning. During this time, students refine their understanding of how they can contribute to individual and community health and wellbeing. Students have frequent opportunities to participate in physical activities, including in outdoor settings, to value the importance of active recreation as a way of enhancing their health and wellbeing throughout their lives.
 

--- a/curriculum/index.md
+++ b/curriculum/index.md
@@ -1,67 +1,67 @@
-### English
+### English {#english}
 
 [Foundation](/english/foundation-year) / [Year 1](/english/year-1) / [Year 2](/english/year-2) / [Year 3](/english/year-3) / [Year 4](/english/year-4) / [Year 5](/english/year-5) / [Year 6](/english/year-6) / [Year 7](/english/year-7) / [Year 8](/english/year-8) / [Year 9](/english/year-9) / [Year 10](/english/year-10)
 
-### Humanities and Social Sciences (HASS)
+### Humanities and Social Sciences (HASS) {#humanities-and-social-sciences-hass}
 
 [Foundation](/hass-hass/foundation-year) / [Year 1](/hass-hass/year-1) / [Year 2](/hass-hass/year-2) / [Year 3](/hass-hass/year-3) / [Year 4](/hass-hass/year-4) / [Year 5](/hass-hass/year-5) / [Year 6](/hass-hass/year-6)
 
-#### Civics and Citizenship
+#### Civics and Citizenship {#civics-and-citizenship}
 
 [Year 6](/hass-civics-and-citizenship/year-6) / [Year 7](/hass-civics-and-citizenship/year-7) / [Year 8](/hass-civics-and-citizenship/year-8) / [Year 9](/hass-civics-and-citizenship/year-9) / [Year 10](/hass-civics-and-citizenship/year-10)
 
-#### Economics and Business
+#### Economics and Business {#economics-and-business}
 
 [Year 7](/hass-economics-and-business/year-7) / [Year 8](/hass-economics-and-business/year-8) / [Year 9](/hass-economics-and-business/year-9) / [Year 10](/hass-economics-and-business/year-10)
 
-#### Geography
+#### Geography {#geography}
 
 [Year 7](/hass-geography/year-7) / [Year 8](/hass-geography/year-8) / [Year 9](/hass-geography/year-9) / [Year 10](/hass-geography/year-10)
 
-#### History
+#### History {#history}
 
 [Year 7](/hass-history/year-7) / [Year 8](/hass-history/year-8) / [Year 9](/hass-history/year-9) / [Year 10](/hass-history/year-10)
 
-### Health and Physical Education (HPE)
+### Health and Physical Education (HPE) {#health-and-physical-education-hpe}
 
 [Foundation](/hpe/foundation-year) / [Years 1–2](/hpe/years-1-and-2) / [Years 3–4](/hpe/years-3-and-4) / [Years 5–6](/hpe/years-5-and-6) / [Years 7–8](/hpe/years-7-and-8) / [Years 9–10](/hpe/years-9-and-10)
 
-### Mathematics
+### Mathematics {#mathematics}
 
 [Foundation](/maths/foundation-year) / [Year 1](/maths/year-1) / [Year 2](/maths/year-2) / [Year 3](/maths/year-3) / [Year 4](/maths/year-4) / [Year 5](/maths/year-5) / [Year 6](/maths/year-6) / [Year 7](/maths/year-7) / [Year 8](/maths/year-8) / [Year 9](/maths/year-9) / [Year 10](/maths/year-10)
 
-### Science
+### Science {#science}
 
 [Foundation](/science/foundation-year) / [Year 1](/science/year-1) / [Year 2](/science/year-2) / [Year 3](/science/year-3) / [Year 4](/science/year-4) / [Year 5](/science/year-5) / [Year 6](/science/year-6) / [Year 7](/science/year-7) / [Year 8](/science/year-8) / [Year 9](/science/year-9) / [Year 10](/science/year-10)
 
-### Technologies
+### Technologies {#technologies}
 
-#### Design and Technologies
+#### Design and Technologies {#design-and-technologies}
 
 [Foundation](/tech-design-and-technologies/foundation-year) / [Years 1–2](/tech-design-and-technologies/years-1-and-2) / [Years 3–4](/tech-design-and-technologies/years-3-and-4) / [Years 5–6](/tech-design-and-technologies/years-5-and-6) / [Years 7–8](/tech-design-and-technologies/years-7-and-8) / [Years 9–10](/tech-design-and-technologies/years-9-and-10)
 
-#### Digital Technologies
+#### Digital Technologies {#digital-technologies}
 
 [Foundation](/tech-digital-technologies/foundation-year) / [Years 1–2](/tech-digital-technologies/years-1-and-2) / [Years 3–4](/tech-digital-technologies/years-3-and-4) / [Years 5–6](/tech-digital-technologies/years-5-and-6) / [Years 7–8](/tech-digital-technologies/years-7-and-8) / [Years 9–10](/tech-digital-technologies/years-9-and-10)
 
-### The Arts
+### The Arts {#the-arts}
 
-#### Dance
+#### Dance {#dance}
 
 [Foundation](/arts-dance/foundation-year) / [Years 1–2](/arts-dance/years-1-and-2) / [Years 3–4](/arts-dance/years-3-and-4) / [Years 5–6](/arts-dance/years-5-and-6) / [Years 7–8](/arts-dance/years-7-and-8) / [Years 9–10](/arts-dance/years-9-and-10)
 
-#### Drama
+#### Drama {#drama}
 
 [Foundation](/arts-drama/foundation-year) / [Years 1–2](/arts-drama/years-1-and-2) / [Years 3–4](/arts-drama/years-3-and-4) / [Years 5–6](/arts-drama/years-5-and-6) / [Years 7–8](/arts-drama/years-7-and-8) / [Years 9–10](/arts-drama/years-9-and-10)
 
-#### Media Arts
+#### Media Arts {#media-arts}
 
 [Foundation](/arts-media-arts/foundation-year) / [Years 1–2](/arts-media-arts/years-1-and-2) / [Years 3–4](/arts-media-arts/years-3-and-4) / [Years 5–6](/arts-media-arts/years-5-and-6) / [Years 7–8](/arts-media-arts/years-7-and-8) / [Years 9–10](/arts-media-arts/years-9-and-10)
 
-#### Music
+#### Music {#music}
 
 [Foundation](/arts-music/foundation-year) / [Years 1–2](/arts-music/years-1-and-2) / [Years 3–4](/arts-music/years-3-and-4) / [Years 5–6](/arts-music/years-5-and-6) / [Years 7–8](/arts-music/years-7-and-8) / [Years 9–10](/arts-music/years-9-and-10)
 
-#### Visual Arts
+#### Visual Arts {#visual-arts}
 
 [Foundation](/arts-visual-arts/foundation-year) / [Years 1–2](/arts-visual-arts/years-1-and-2) / [Years 3–4](/arts-visual-arts/years-3-and-4) / [Years 5–6](/arts-visual-arts/years-5-and-6) / [Years 7–8](/arts-visual-arts/years-7-and-8) / [Years 9–10](/arts-visual-arts/years-9-and-10)

--- a/curriculum/maths/foundation-year.md
+++ b/curriculum/maths/foundation-year.md
@@ -1,6 +1,6 @@
-# Mathematics - Foundation Year
+# Mathematics - Foundation Year {#mathematics-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 In Foundation, learning in Mathematics builds on the Early Years Learning Framework and each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -13,11 +13,11 @@ Students further develop proficiency and positive dispositions towards mathemati
 *   learn to recognise repetition in pattern sequences and apply this to creatively build repeating patterns in a range of contexts
 *   develop a sense of sameness, difference and change when they engage in play-based activities.
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9MFN01
+##### AC9MFN01 {#ac9mfn01}
 
 name, represent and order numbers including zero to at least 20, using physical and virtual materials and numerals
 
@@ -28,7 +28,7 @@ name, represent and order numbers including zero to at least 20, using physical 
 *  recognising, writing and reading numerals written on familiar objects; for example, in images, text or illustrations in story books; writing a numeral on a container as a label to show how many objects it contains
 *  connecting quantities to number names and numerals when reading and reciting stories and playing counting games or determining and reasoning about the size of sets of objects within First Nation Australians’ instructive games; for example, Segur etug from Mer Island in the Torres Strait region
 
-##### AC9MFN02
+##### AC9MFN02 {#ac9mfn02}
 
 recognise and name the number of objects within a collection up to 5 using subitising
 
@@ -36,7 +36,7 @@ recognise and name the number of objects within a collection up to 5 using subit
 *  recognising how many objects are in a collection or in images on a card with a quick look and saying the associated number without counting
 *  playing instructive card games that rely on the recognition of numbers represented in different ways; for example, playing memory games, matching pairs of quantities on dot cards or similar where the arrangement on each is different; using subitising to compare and order collections and to say who has more when sharing items in a game
 
-##### AC9MFN03
+##### AC9MFN03 {#ac9mfn03}
 
 quantify and compare collections to at least 20 using counting and explain or demonstrate reasoning
 
@@ -47,7 +47,7 @@ quantify and compare collections to at least 20 using counting and explain or de
 *  discussing how different cultures may have alternative ways of representing the count; for example, discussing how people of the Asia region use an abacus or Chinese hand gestures
 *  using body-tallying that involves body parts and one-to-one correspondence from counting systems of First Nations Peoples of Australia, to count to \(20\)
 
-##### AC9MFN04
+##### AC9MFN04 {#ac9mfn04}
 
 partition and combine collections up to 10 using part-part-whole relationships and subitising to recognise and name the parts
 
@@ -57,7 +57,7 @@ partition and combine collections up to 10 using part-part-whole relationships a
 *  representing part-part-whole relationships in numbers up to \(10\) using physical or virtual materials; for example, identifying numbers represented by dots in standard number configurations such as dominos and dice by recognising parts that form the whole
 *  exploring number groupings in First Nations Australians’ counting systems and the different ways of representing these groupings to form and partition numbers, applying this to quantify collections of objects in the environment on Country/Place up to \(10\)
 
-##### AC9MFN05
+##### AC9MFN05 {#ac9mfn05}
 
 represent practical situations involving addition, subtraction and quantification with physical and virtual materials and use counting or subitising strategies
 
@@ -67,7 +67,7 @@ represent practical situations involving addition, subtraction and quantificatio
 *  representing situations expressed in First Nations Australians’ stories, such as “Tiddalick, the greedy frog”, that describe additive situations and their connections to Country/Place
 *  representing addition and subtraction situations found in leaf games involving sets of objects used to tell stories, such as games from the Warlpiri Peoples of Yuendumu in the Northern Territory
 
-##### AC9MFN06
+##### AC9MFN06 {#ac9mfn06}
 
 represent practical situations that involve equal sharing and grouping with physical and virtual materials and use counting or subitising strategies
 
@@ -76,9 +76,9 @@ represent practical situations that involve equal sharing and grouping with phys
 *  representing situations that involve counting several items; for example, \(9\) beads or \(6\) \(\$1\) coins, and sharing them equally between \(3\) people by subitising or counting each group by ones to decide how many beads or coins each person will receive
 *  exploring instructive games of First Nations Australians that involve sharing; for example, playing Yangamini of the Tiwi Peoples of Bathurst Island to investigate and discuss equal sharing
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9MFA01
+##### AC9MFA01 {#ac9mfa01}
 
 recognise, copy and continue repeating patterns represented in different ways
 
@@ -88,9 +88,9 @@ recognise, copy and continue repeating patterns represented in different ways
 *  recognising and discussing repeating patterns in images created using dynamic geometric software or a generative artificial intelligence tool, describing what has been repeated in the pattern
 *  recognising and describing repeating patterns that can be observed on Country/Place and in First Nation Australians artwork, cultural performances and material cultures; for example, shell and seed necklaces, dances and songs
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9MFM01
+##### AC9MFM01 {#ac9mfm01}
 
 identify and compare attributes of objects and events, including length, capacity, mass and duration, using direct comparisons and communicating reasoning
 
@@ -100,7 +100,7 @@ identify and compare attributes of objects and events, including length, capacit
 *  starting \(2\) events at the same time to decide which takes longer; for example, putting on a pair of sandals with buckles or Velcro, describing the duration using familiar terms and reasoning, “I took a longer time because I’m still learning to do up my buckles”
 *  directly comparing pairs of everyday objects from the kitchen pantry to say which is heavier/lighter; for example, hefting a tin of baked beans and a packet of marshmallows; comparing the same pair of objects to say which is longer/shorter and discussing comparisons
 
-##### AC9MFM02
+##### AC9MFM02 {#ac9mfm02}
 
 sequence days of the week and times of the day including morning, lunchtime, afternoon and night time, and connect them to familiar events and actions
 
@@ -111,9 +111,9 @@ sequence days of the week and times of the day including morning, lunchtime, aft
 *  creating, interpreting and discussing classroom rosters; for example, a roster for watering the classroom garden and asking, “Who watered the garden yesterday?” or “Whose turn is it today?”
 *  creating a pictorial diary to show the important events that happen on the various days of the week
 
-### Space
+### Space {#space}
 
-##### AC9MFSP01
+##### AC9MFSP01 {#ac9mfsp01}
 
 sort, name and create familiar shapes; recognise and describe familiar shapes within objects in the environment, giving reasons
 
@@ -124,7 +124,7 @@ sort, name and create familiar shapes; recognise and describe familiar shapes wi
 *  recognising and naming shapes that are (close to) rectangles, squares, triangles and circles in component parts of everyday items; for example, on bicycles, toy vehicles or kitchen pantry items
 *  describing and naming shapes within objects that can be observed on Country/Place, recreating and sorting into groups based on their shape
 
-##### AC9MFSP02
+##### AC9MFSP02 {#ac9mfsp02}
 
 describe the position and location of themselves and objects in relation to other people and objects within a familiar space
 
@@ -134,9 +134,9 @@ describe the position and location of themselves and objects in relation to othe
 *  describing the position of a robotic toy in relation to other objects as it moves around a familiar space; for example, describing the position of a robotic car as being under the desk or next to the chair
 *  exploring First Nations Australians’ instructive games; for example, Thapumpan from the Wik-Mungkan Peoples of Cape Bedford in north Queensland, describing position and movement of self in relation to other participants, objects or locations
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9MFST01
+##### AC9MFST01 {#ac9mfst01}
 
 collect, sort and compare data represented by objects and images in response to given investigative questions that relate to familiar situations
 
@@ -149,7 +149,7 @@ collect, sort and compare data represented by objects and images in response to 
 *  investigating statistical contexts after reading a story, such as "The Waterhole" by Graeme Base; asking and responding to questions like “What different animals did you see?”, “How many different types of animals were there?” or “Were there more tigers or kangaroos?”
 *  exploring what and how information from the environment is collected and used by First Nations Australians to predict weather events
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Foundation, learning in Mathematics builds on the Early Years Learning Framework and each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/maths/year-1.md
+++ b/curriculum/maths/year-1.md
@@ -1,6 +1,6 @@
-# Mathematics - Year 1
+# Mathematics - Year 1 {#mathematics-year-1}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 1, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -14,11 +14,11 @@ Students further develop proficiency and positive dispositions towards mathemati
 *   use simple surveys to collect and sort data, based on a question of interest, recognise that data can be represented in different ways, and explain patterns that they see in the results
 *   develop a sense of equivalence, fairness, repetition and variability when they engage in play-based and practical activities
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9M1N01
+##### AC9M1N01 {#ac9m1n01}
 
 recognise, represent and order numbers to at least 120 using physical and virtual materials, numerals, number lines and charts
 
@@ -28,7 +28,7 @@ recognise, represent and order numbers to at least 120 using physical and virtua
 *  using hundreds charts to build understanding and fluency with numbers; for example, collaboratively building a hundreds chart using cards numbered from zero to \(99\); colour code the count of tens in a hundreds chart using one colour to represent the number of tens and another to represent the number of ones
 *  recognising that numbers are used in all languages and cultures but may be represented differently in words and symbols; for example, through kanji numbers in Japanese and characters in Chinese, and that there are alternate numeration systems; for example, using special characters for \(10\) and \(100\) and other multiples of \(10\) in Japanese and Chinese numeration
 
-##### AC9M1N02
+##### AC9M1N02 {#ac9m1n02}
 
 partition one- and two-digit numbers in different ways using physical and virtual materials, including partitioning two-digit numbers into tens and ones
 
@@ -37,7 +37,7 @@ partition one- and two-digit numbers in different ways using physical and virtua
 *  using physical and virtual materials to partition numbers into counts of tens and ones; for example, recognise \(35\) as \(3\) tens and \(5\) ones or as \(2\) tens and \(15\) ones
 *  using part-part-whole reasoning and physical or virtual materials to represent \(24\), then partitioning \(24\) in different ways and recording the partitions using numbers; for example, \(10, 10\) and \(4\) combine to make \(24\) or \(10\) and \(14\) combine to make \(24\)
 
-##### AC9M1N03
+##### AC9M1N03 {#ac9m1n03}
 
 quantify sets of objects, to at least 120, by partitioning collections into equal groups using number knowledge and skip counting
 
@@ -46,7 +46,7 @@ quantify sets of objects, to at least 120, by partitioning collections into equa
 *  counting collections of objects such as pencils or images of birds in a tree, by grouping them in tens to enable efficient counting and connecting the digits in the number to the groups of tens and ones
 *  counting a large collection of Australian \(\$1\) coins by stacking them into piles of \(10\), skip counting in tens and including any leftover coins to determine the total value
 
-##### AC9M1N04
+##### AC9M1N04 {#ac9m1n04}
 
 add and subtract numbers within 20, using physical and virtual materials, part-part-whole knowledge to 10 and a variety of calculation strategies
 
@@ -57,7 +57,7 @@ add and subtract numbers within 20, using physical and virtual materials, part-p
 *  representing story problems involving addition and subtraction of numbers within \(20\) using a Think Board, recognising and using  + and – symbols and the equal sign to represent the operations of addition and subtraction; showing and explaining the connections between any materials used using the language of plus and minus, and the numbers within the story problem
 *  creating and performing addition and subtraction stories told through First Nations Australians’ dances  
 
-##### AC9M1N05
+##### AC9M1N05 {#ac9m1n05}
 
 use mathematical modelling to solve practical problems involving additive situations including simple money transactions; represent the situations with diagrams, physical and virtual materials, and use calculation strategies to solve the problem
 
@@ -66,7 +66,7 @@ use mathematical modelling to solve practical problems involving additive situat
 *  modelling simple money problems involving addition and subtraction using whole dollar amounts; for example, setting up a shop and role-playing practical problems of buying and selling of goods, using addition and subtraction with play money and prices in whole dollar amounts; solving the problem “I had \(\$14\) and was given \(\$15\) for my birthday” using addition to answer the problem
 *  modelling a variety of different additive situations to solve practical problems; for example, keeping track of the number of people on a bus as it stops to pick up and drop off passengers or the number of people entering a lift
 
-##### AC9M1N06
+##### AC9M1N06 {#ac9m1n06}
 
 use mathematical modelling to solve practical problems involving equal sharing and grouping; represent the situations with diagrams, physical and virtual materials, and use calculation strategies to solve the problem
 
@@ -75,9 +75,9 @@ use mathematical modelling to solve practical problems involving equal sharing a
 *  modelling practical problems involving equal sharing situations; for example, sharing a set of dominoes between the \(2\) players in a game, and then counting or subitising to ensure they both have the same number of tiles
 *  modelling money problems involving equal sharing; for example, sorting coins from a money box according to their denominations, sharing the coins equally between \(4\) people, and using counting or subitising to ensure they have equal amounts of each denomination
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9M1A01
+##### AC9M1A01 {#ac9m1a01}
 
 recognise, continue and create pattern sequences, with numbers, symbols, shapes and objects, formed by skip counting, initially by twos, fives and tens
 
@@ -89,7 +89,7 @@ recognise, continue and create pattern sequences, with numbers, symbols, shapes 
 *  role-playing being an industrial robot on an assembly line that packs various items into boxes or packets in groups of five or ten, keeping count of the total number of items produced
 *  <p>using different variations of the popular Korean counting game <em>Sam-yuk-gu</em> for generating skip counting pattern sequences</p>
 
-##### AC9M1A02
+##### AC9M1A02 {#ac9m1a02}
 
 recognise, continue and create repeating patterns with numbers, symbols, shapes and objects, identifying the repeating unit
 
@@ -101,9 +101,9 @@ recognise, continue and create repeating patterns with numbers, symbols, shapes 
 *  identifying the repeating patterns in First Nations Australians’ systems of counting, exploring different ways of representing numbers including oral and gestural language
 *  considering how the making of shell or seed necklaces by First Nations Australians’ includes practices such as sorting shells and beads based on colour, size and shape, and creating a repeating pattern sequence
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9M1M01
+##### AC9M1M01 {#ac9m1m01}
 
 compare directly and indirectly and order objects and events using attributes of length, mass, capacity and duration, communicating reasoning
 
@@ -114,7 +114,7 @@ compare directly and indirectly and order objects and events using attributes of
 *  creating sand timers from everyday items or recycled material and comparing them to order the duration of time required for the sand to run through
 *  investigating situations where First Nations Australians estimate, compare and communicate measurements; for example, the duration of seasons; understanding animal behaviour using the length of animal tracks; investigating capacity through water management techniques of First Nations Australians, such as traditional water carrying vessels and rock holes
 
-##### AC9M1M02
+##### AC9M1M02 {#ac9m1m02}
 
 measure the length of shapes and objects using informal units, recognising that units need to be uniform and used end-to-end
 
@@ -124,7 +124,7 @@ measure the length of shapes and objects using informal units, recognising that 
 *  measuring the distance between \(2\) locations using footsteps, comparing the results and explaining why there may be different results; for example, referring to the different length of footsteps as using different units
 *  measuring and comparing the length of objects using blocks; for example, comparing the height of \(2\) toys by stacking blocks one on top of the other and counting how many it takes to reach the height of each object to decide which is taller
 
-##### AC9M1M03
+##### AC9M1M03 {#ac9m1m03}
 
 describe the duration and sequence of events using years, months, weeks, days and hours
 
@@ -135,9 +135,9 @@ describe the duration and sequence of events using years, months, weeks, days an
 *  discussing events and activities and deciding whether they would take closer to an hour, a day, a week, a month or a year; for example, it takes a day for the sun to rise and fall and rise again, but it takes less than an hour for me to walk to school
 *  investigating durations of time represented in First Nations Australians’ seasonal calendars
 
-### Space
+### Space {#space}
 
-##### AC9M1SP01
+##### AC9M1SP01 {#ac9m1sp01}
 
 make, compare and classify familiar shapes; recognise familiar shapes and objects in the environment, identifying the similarities and differences between them
 
@@ -147,7 +147,7 @@ make, compare and classify familiar shapes; recognise familiar shapes and object
 *  comparing the different objects that can be built out of the same number of blocks or centi-cubes and discussing the differences between them
 *  exploring string games used in story telling by First Nations Australians; for example, Karda from the Yandruwandha Peoples of north-east South Australia, recognising, comparing, describing and classifying the shapes made by the string and their relationship to shapes and objects on Country/Place
 
-##### AC9M1SP02
+##### AC9M1SP02 {#ac9m1sp02}
 
 give and follow directions to move people and objects to different locations within a space
 
@@ -157,9 +157,9 @@ give and follow directions to move people and objects to different locations wit
 *  following directions to move people into different positions within a line using both ordinal and positional language to describe their position; for example, directly comparing heights and following directions using ordinal and positional language to line up in height order
 *  describing a familiar journey across Country/Place using directional language
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9M1ST01
+##### AC9M1ST01 {#ac9m1st01}
 
 acquire and record data for categorical variables in various ways including using digital tools, objects, images, drawings, lists, tally marks and symbols
 
@@ -171,7 +171,7 @@ acquire and record data for categorical variables in various ways including usin
 *  role-playing being a chatbot asking simple yes/no questions and collecting data, and representing the data using virtual manipulatives, stickers or emojis
 *  exploring ways of representing, sharing and communicating data through stories and symbols used by First Nations Australians
 
-##### AC9M1ST02
+##### AC9M1ST02 {#ac9m1st02}
 
 represent collected data for a categorical variable using one-to-one displays and digital tools where appropriate; compare the data using frequencies and discuss the findings
 
@@ -183,7 +183,7 @@ represent collected data for a categorical variable using one-to-one displays an
 *  discussing what data frequency means in terms of the total count for a particular category and relating the highest frequency to being the most popular category in the collected data
 *  exploring First Nations Australian children’s instructive games; for example, Kolap from Mer Island in the Torres Strait region, recording the outcomes, representing and discussing the results
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Year 1, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/maths/year-10.md
+++ b/curriculum/maths/year-10.md
@@ -1,6 +1,6 @@
-# Mathematics - Year 10
+# Mathematics - Year 10 {#mathematics-year-10}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 10, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -15,11 +15,11 @@ Students further develop proficiency and positive dispositions towards mathemati
 *   investigate conditional probability and its relation to dependent and independent events, including sampling with and without replacement; devise and use simulations to test intuitions involving chance events that may or may not be independent
 *   compare different ways of representing the distribution of continuous data and interpret key features of the distribution; explore association between pairs of variables, decide the form of representation, interpret the data with respect to the context and discuss possible conclusions; use scatterplots to informally discuss and consider association between 2 numerical variables and informally consider lines of good fit by eye, interpolation, extrapolation and limitations.
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9M10N01
+##### AC9M10N01 {#ac9m10n01}
 
 recognise the effect of using approximations of real numbers in repeated calculations and compare the results when using exact representations
 
@@ -27,9 +27,9 @@ recognise the effect of using approximations of real numbers in repeated calcula
 *  comparing and contrasting the effect of truncation or rounding on the final result of calculations when using approximations of real numbers rather than exact representations
 *  investigating the impact of approximation on multiple calculations in contexts that involve the area of compound shapes involving circles, the surface area and volume of compound objects, and repeated calculations of simple interest where the solutions are not exact cents
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9M10A01
+##### AC9M10A01 {#ac9m10a01}
 
 expand, factorise and simplify expressions and solve equations algebraically, applying exponent laws involving products, quotients and powers of variables, and the distributive property
 
@@ -37,7 +37,7 @@ expand, factorise and simplify expressions and solve equations algebraically, ap
 *  explaining the relationship between factorisation and expansion, including the completed square form for quadratic expressions
 *  applying knowledge of exponent laws to algebraic terms and using both positive and negative integral exponents to simplifying algebraic expressions and solve equations algebraically
 
-##### AC9M10A02
+##### AC9M10A02 {#ac9m10a02}
 
 solve linear inequalities and simultaneous linear equations in 2 variables; interpret solutions graphically and communicate solutions in terms of the situation
 
@@ -49,7 +49,7 @@ solve linear inequalities and simultaneous linear equations in 2 variables; inte
 *  testing when a circle of a specified radius has a corresponding area greater than a given value, or whether a point satisfies an inequality; for example, whether the point (\(3, 5\)) satisfies \(2y<x^2\)
 *  investigating the strategies inherent in First Nations Australian children’s instructive games; for example, Weme from the Warlpiri Peoples of central Australia, and their connection to strategies to solve simultaneous linear equations in \(2\) variables
 
-##### AC9M10A03
+##### AC9M10A03 {#ac9m10a03}
 
 recognise the connection between algebraic and graphical representations of exponential relations and solve related exponential equations, using digital tools where appropriate
 
@@ -59,7 +59,7 @@ recognise the connection between algebraic and graphical representations of expo
 *  using digital tools with symbolic manipulation functionality to systematically explore exponential relations
 *  investigating First Nations Australian Ranger groups’ and other groups’ programs that attempt to eradicate feral animals for survival of native animals on Country/Place, exploring the competition between feral and native animals and their impact on natural resources by formulating exponential equations for population growth for each animal species
 
-##### AC9M10A04
+##### AC9M10A04 {#ac9m10a04}
 
 use mathematical modelling to solve applied problems involving growth and decay, including financial contexts; formulate problems, choosing to apply linear, quadratic or exponential models; interpret solutions in terms of the situation; evaluate and modify models as necessary and report assumptions, methods and findings
 
@@ -70,7 +70,7 @@ use mathematical modelling to solve applied problems involving growth and decay,
 *  modelling and investigating how exponential equations are used in carbon dating to estimate the age of First Nations Australians’ artefacts or material culture
 *  modelling and formulating situations involving population growths of native animals on Country/Place with varying reproductive behaviour, using exponential equations and critiquing their applicability to real-world situations
 
-##### AC9M10A05
+##### AC9M10A05 {#ac9m10a05}
 
 experiment with functions and relations using digital tools, making and testing conjectures and generalising emerging patterns
 
@@ -83,9 +83,9 @@ experiment with functions and relations using digital tools, making and testing 
 *  using a table of values to determine when an exponential growth or decay function exceeds or falls below a given value, such as monitoring the trend in value of a share price in a context of exponential growth or decay
 *  investigating how functions and relations serve as the mathematical underpinnings of machine learning, allowing data to be transformed, models to be defined and optimisation to occur
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9M10M01
+##### AC9M10M01 {#ac9m10m01}
 
 solve problems involving the surface area and volume of composite objects using appropriate units
 
@@ -94,7 +94,7 @@ solve problems involving the surface area and volume of composite objects using 
 *  estimating the surface area and volume of composite objects in practical contexts
 *  using mathematical modelling to provide solutions to problems involving surface area and volume; for example, ascertaining the rainfall that can be saved from a roof top and the optimal shape and dimensions for rainwater storage based on where it will be located on a property; determining whether to hire extra freezer space for the amount of ice cream required at a fundraising event for the school or community
 
-##### AC9M10M02
+##### AC9M10M02 {#ac9m10m02}
 
 interpret and use logarithmic scales  in applied contexts involving small and large quantities and change
 
@@ -105,7 +105,7 @@ interpret and use logarithmic scales  in applied contexts involving small
 *  investigating how logarithmic scaling can be used in machine learning algorithms to compress large values while preserving small ones, allowing the algorithms to efficiently work on problems with a wide range of values
 *  investigating dating methods of geological sites to provide evidence of First Peoples of Australia’s human presence in Australia, including the Madjedbebe dig in the Northern Territory, that use logarithmic scales (scientific notation) and measurement accuracy in the dating
 
-##### AC9M10M03
+##### AC9M10M03 {#ac9m10m03}
 
 solve practical problems applying Pythagoras’ theorem and trigonometry of right-angled triangles, including problems involving direction and angles of elevation and depression
 
@@ -117,7 +117,7 @@ solve practical problems applying Pythagoras’ theorem and trigonometry of rig
 *  investigating how autonomous vehicles use algorithms that use Pythagoras' theorem and trigonometry to calculate distance and navigate spaces; for example, if  an autonomous vehicle knows its current position \((x, y)\) and the coordinates of a target location \((x', y')\), it can determine the straight-line distance between them using the formula distance \(=\sqrt{(x'-x)^2 + (y'-y)^2}\)
 *  exploring navigation, design of technologies or surveying by First Nations Australians, investigating geometric and spatial reasoning, and how these connect to trigonometry
 
-##### AC9M10M04
+##### AC9M10M04 {#ac9m10m04}
 
 identify the impact of measurement errors on the accuracy of results in practical contexts
 
@@ -128,7 +128,7 @@ identify the impact of measurement errors on the accuracy of results in practica
 *  investigating the impact of measurement errors in the perception and control systems of autonomous vehicles, such as measurement errors due to sensor limitations
 *  investigating scientific measuring techniques, including dating methods and genetic sequencing, applied to First Peoples of Australia and their artefacts, and the social impact of measurement errors
 
-##### AC9M10M05
+##### AC9M10M05 {#ac9m10m05}
 
 use mathematical modelling to solve practical problems involving proportion and scaling of objects; formulate problems and interpret solutions in terms of the situation; evaluate and modify models as necessary, and report assumptions, methods and findings
 
@@ -139,9 +139,9 @@ use mathematical modelling to solve practical problems involving proportion and
 *  investigating compliance with building codes and standards in design and construction, such as for escalators in shopping centres
 *  investigating how artificial intelligence  image generators use proportion and scaling techniques, such as aspect ratio preservation, to ensure that the generated content adheres to realistic visual principles and maintains appropriate relationships between objects and elements within the scene
 
-### Space
+### Space {#space}
 
-##### AC9M10SP01
+##### AC9M10SP01 {#ac9m10sp01}
 
 apply deductive reasoning to proofs involving shapes in the plane and use theorems to solve spatial problems
 
@@ -153,7 +153,7 @@ apply deductive reasoning to proofs involving shapes in the plane and use theor
 *  using dynamic geometric software to investigate the shortest path that touches 3 sides of a rectangle, starting and finishing at the same point and proving that the path forms a parallelogram
 *  investigating how automated theorem provers (ATP) and interactive proof assistants (IPA) allow mathematicians and artificial intelligence systems to work collaboratively to construct or test formal proofs
 
-##### AC9M10SP02
+##### AC9M10SP02 {#ac9m10sp02}
 
 interpret networks and network diagrams used to represent relationships in practical situations and describe connectedness
 
@@ -166,7 +166,7 @@ interpret networks and network diagrams used to represent relationships in pract
 *  investigating the use of networks to represent authentic situations; for example, rail or air travel between or within London, Paris, Hong Kong; a food web representing a simple eco-system; metabolic networks and other chemical or biological structures
 *  representing First Nations Australians’ kinship systems using network diagrams and exploring the significance of relationships to Country/Place
 
-##### AC9M10SP03
+##### AC9M10SP03 {#ac9m10sp03}
 
 design, test and refine solutions to spatial problems using algorithms and digital tools; communicate and justify solutions
 
@@ -177,9 +177,9 @@ design, test and refine solutions to spatial problems using algorithms and digit
 *  designing, creating and testing algorithms using pseudocode or flow charts for producing self-similar patterns; validating algorithms using a range of test cases to compare their output
 *  exploring geospatial technologies used by First Nations Australians’ communities to consider spatial problems including position and transformation
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9M10ST01
+##### AC9M10ST01 {#ac9m10st01}
 
 analyse claims, inferences and conclusions of statistical reports in the media, including ethical considerations and identification of potential sources of bias
 
@@ -191,7 +191,7 @@ analyse claims, inferences and conclusions of statistical reports in the media, 
 *  recognising how the identification of bias is a critical aspect of machine learning and deep learning because biases can significantly impact the fairness, accuracy and ethical implications of artificial intelligence systems
 *  using the concept of Indigenous data sovereignty to critique and evaluate the Australian Government’s “Closing the Gap” report
 
-##### AC9M10ST02
+##### AC9M10ST02 {#ac9m10st02}
 
 compare data distributions for continuous numerical variables using appropriate data displays including boxplots; discuss the shapes of these distributions in terms of centre, spread, shape and outliers in the context of the data
 
@@ -203,7 +203,7 @@ compare data distributions for continuous numerical variables using appropriate 
 *  comparing the information that can be extracted and the stories that can be told about continuous and discrete numerical data sets that have been displayed in different ways, including histograms, dot plots, box plots and cumulative frequency graphs
 *  exploring how the identification and appropriate handling of outliers is an important step in machine learning to ensure that they don't unduly influence the model
 
-##### AC9M10ST03
+##### AC9M10ST03 {#ac9m10st03}
 
 construct scatterplots and comment on the association between the 2 numerical variables in terms of strength, direction and linearity
 
@@ -215,7 +215,7 @@ construct scatterplots and comment on the association between the 2 numerical va
 *  investigating artificial intelligence  systems that analyse bivariate data to forecast or make predictions based on association using correlation analysis and discussing limitations; for example, the artificial intelligence  may not capture the causality between variables or account for the contextual or ethical implications
 *  investigating the relationship between \(2\) variables of spear throwers used by First Peoples of Australia by using data to construct scatterplots, make comparisons and draw conclusions
 
-##### AC9M10ST04
+##### AC9M10ST04 {#ac9m10st04}
 
 construct two-way tables and discuss possible relationship between categorical variables
 
@@ -224,7 +224,7 @@ construct two-way tables and discuss possible relationship between categorical v
 *  recording data in two-way tables and using percentages and proportions to identify patterns and associations in the data
 *  conducting a litter survey around the school, considering the relationship between different categorical variables such as the day of the week as canteen specials might lead to different types of litter or the weather due to hot days leading to more ice blocks and cold drinks being sold
 
-##### AC9M10ST05
+##### AC9M10ST05 {#ac9m10st05}
 
 plan and conduct statistical investigations of situations that involve bivariate data; evaluate and report findings with consideration of limitations of any inferences
 
@@ -234,9 +234,9 @@ plan and conduct statistical investigations of situations that involve bivariate
 *  using a statistical investigation to address the question, “Is there a relationship between vaccines and immunity from a virus”
 *  investigating biodiversity changes in Australia before and after colonisation by comparing related bivariate numerical data, discussing and reporting on associations
 
-### Probability
+### Probability {#probability}
 
-##### AC9M10P01
+##### AC9M10P01 {#ac9m10p01}
 
 use the language of “if ... then”, “given”, “of”, “knowing that” to describe and interpret situations involving conditional probability
 
@@ -245,7 +245,7 @@ use the language of “if ... then”, “given”, “of”, “knowing that”
 *  using arrays and tree diagrams to represent, interpret and compare probabilities of dependent and independent events
 *  investigating how conditional probability is used in natural language processing tasks like text or image generation, language translation, data augmentation and recommendation systems
 
-##### AC9M10P02
+##### AC9M10P02 {#ac9m10p02}
 
 design and conduct repeated chance experiments and simulations using digital tools to model conditional probability and interpret results
 
@@ -256,7 +256,7 @@ design and conduct repeated chance experiments and simulations using digital t
 *  identifying situations in real-life where probability simulations are used for decision-making, such as supply and demand of product, insurance risk and queueing
 *  using simulation to predict the number of people likely to be infected with a strain of flu or virus
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Year 10, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/maths/year-2.md
+++ b/curriculum/maths/year-2.md
@@ -1,6 +1,6 @@
-# Mathematics - Year 2
+# Mathematics - Year 2 {#mathematics-year-2}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 2, learning in Mathematics builds on each student's prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -18,11 +18,11 @@ Students further develop proficiency with positive dispositions towards mathemat
 *   build the foundations for statistical inquiry by choosing questions based on their interests as they collect, represent, and interpret data, and recognise features of different representations
 *   develop a sense of equivalence, chance and variability when they engage in play-based and practical activities
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9M2N01
+##### AC9M2N01 {#ac9m2n01}
 
 recognise, represent and order numbers to at least 1000 using physical and virtual materials, numerals and number lines
 
@@ -32,7 +32,7 @@ recognise, represent and order numbers to at least 1000 using physical and virtu
 *  reading and writing numerals, and saying and ordering two-, three- and four-digit numbers using patterns in the number system, including numbers with zeros in different places, and numbers that look and sound similar such as \(808, 880, 818\) and \(881\)
 *  collecting large quantities of materials for recycling; for example, ring pulls, bottle tops and bread tags, and grouping them into ones, tens and hundreds; using the materials to show different representations of two- and three-digit numbers
 
-##### AC9M2N02
+##### AC9M2N02 {#ac9m2n02}
 
 partition, rearrange, regroup and rename two- and three-digit numbers using standard and non-standard groupings; recognise the role of a zero digit in place value notation
 
@@ -40,7 +40,7 @@ partition, rearrange, regroup and rename two- and three-digit numbers using stan
 *  comparing the digits of a number with materials grouped into hundreds, tens and ones, and explaining the meaning of each of the digits in the materials
 *  renaming numbers in different ways using knowledge of place value; for example, renaming \(245\) as \(24\) tens and \(5\) ones or \(2\) hundreds and \(45\) ones
 
-##### AC9M2N03
+##### AC9M2N03 {#ac9m2n03}
 
 recognise and describe one-half as one of 2 equal parts of a whole and connect halves, quarters and eighths through repeated halving
 
@@ -50,7 +50,7 @@ recognise and describe one-half as one of 2 equal parts of a whole and connect h
 *  using repeated halving to subdivide shapes and objects in different ways to make corresponding halves, quarters and eighths; naming the parts and comparing the size of them to notice that they are all the same size, and demonstrating that a quarter is a half of a half and that an eighth is a half of a quarter
 *  dividing a shape into equal parts and relating the number of parts to the unit fraction; for example, if there are \(4\) equal parts then each part is a one-quarter and if there are \(8\) equal parts then each is one-eighth
 
-##### AC9M2N04
+##### AC9M2N04 {#ac9m2n04}
 
 add and subtract one- and two-digit numbers, representing problems using number sentences, and solve using part-part-whole reasoning and a variety of calculation strategies
 
@@ -62,7 +62,7 @@ add and subtract one- and two-digit numbers, representing problems using number 
 *  using a physical or mental number line or hundreds chart to solve addition or subtraction problems, by moving along or up and down in tens and ones; for example, “I was given a \(\$100\) gift card for my birthday and spent \(\$38\) on a pair of shoes and \(\$15\) on a t-shirt. How much money do I have left on the card?”
 *  using First Nations Australians’ stories and dances to understand the balance and connection between addition and subtraction, representing relationships as number sentences 
 
-##### AC9M2N05
+##### AC9M2N05 {#ac9m2n05}
 
 multiply and divide by one-digit numbers using repeated addition, equal grouping, arrays, and partitioning to support a variety of calculation strategies
 
@@ -73,7 +73,7 @@ multiply and divide by one-digit numbers using repeated addition, equal grouping
 *  using a Think Board to solve partition and quotition division problems; for example, sharing a prize of \(\$36\) between \(4\) people, using materials, a diagram and skip counting to find the answer; explaining whether the answer \(9\) refers to people or dollars
 *  using materials or diagrams, and skip counting to solve repeated equal quantity multiplication problems; for example, “Four trays of biscuits with \(6\) on each tray, how many biscuits are there?”; writing a repeated addition number sentence and using skip counting to solve
 
-##### AC9M2N06
+##### AC9M2N06 {#ac9m2n06}
 
 use mathematical modelling to solve practical problems involving additive and multiplicative situations, including money transactions; represent situations and choose calculation strategies; interpret and communicate solutions in terms of the situation
 
@@ -84,9 +84,9 @@ use mathematical modelling to solve practical problems involving additive and mu
 *  modelling and solving the problem “How many days are there left in this year?” by using a calendar
 *  modelling problems involving equal grouping and sharing in First Nations Australian children’s instructive games; for example, Yangamini from the Tiwi Island Peoples, representing relationships with a number sentence and interpreting and communicating solutions in terms of the context
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9M2A01
+##### AC9M2A01 {#ac9m2a01}
 
 recognise, describe and create additive patterns that increase or decrease by a constant amount, using numbers, shapes and objects, and identify missing elements in the pattern
 
@@ -97,7 +97,7 @@ recognise, describe and create additive patterns that increase or decrease by a 
 *  using dynamic geometric software or a generative artificial intelligence tool to create patterns that increase or decrease by a constant amount; for example, creating a geometric pattern using shapes, that adds the same number of elements to the pattern as the pattern increases, and discussing what instructions they input to achieve the output
 *  recognising additive patterns in the environment on Country/Place and in First Nations Australians’ material culture; representing them using drawings, coloured counters and numbers
 
-##### AC9M2A02
+##### AC9M2A02 {#ac9m2a02}
 
 recall and demonstrate proficiency with addition facts to 20; extend and apply facts to develop related subtraction facts
 
@@ -106,7 +106,7 @@ recall and demonstrate proficiency with addition facts to 20; extend and apply f
 *  partitioning and rearranging collections to practice and develop fluency with addition and subtraction facts to \(20\) leading to the recall of these facts; for example, partitioning using materials and part-part-whole diagrams to develop subtraction facts related to addition facts, such as \(8 + 7 = 15\) therefore, \(15\space – \space7 = 8\) and \(15 \space– \space8 = 7\)
 *  using partitioning to develop and record facts systematically; for example, “How many ways can \(10\) birds be spread among \(2\) trees?”, \(10 = 10 + 0\), \(10 = 9 + 1\), \(10 = 8 + 2\), \(10 = 7 + 3\), …; explaining how they know they have found all possible partitions
 
-##### AC9M2A03
+##### AC9M2A03 {#ac9m2a03}
 
 recall and demonstrate proficiency with multiplication facts for twos; extend and apply facts to develop the related division facts using doubling and halving
 
@@ -116,9 +116,9 @@ recall and demonstrate proficiency with multiplication facts for twos; extend an
 *  establishing an understanding of doubles and near doubles using physical or virtual manipulatives; for example, using manipulatives to establish that doubling \(5\) gives you \(10\) then extending this doubling fact to respond to the question, “How can you use this fact to double \(6\) or double \(4\)?”
 *  develop fluency with doubling and halving numbers within \(20\) using physical or virtual materials and playing doubling and halving games; for example, using a physical or virtual dice and choosing whether to double or halve to reach a target number
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9M2M01
+##### AC9M2M01 {#ac9m2m01}
 
 measure and compare objects based on length, capacity and mass using appropriate uniform informal units and smaller units for accuracy when necessary
 
@@ -130,7 +130,7 @@ measure and compare objects based on length, capacity and mass using appropriate
 *  investigating First Nations Australians’ use of body parts, such as hands, as uniform informal units of measurement used to measure and compare objects; for example, in the manufacturing of nets for a particular purpose
 *  investigating and comparing measurable attributes that are interpreted by First Nations Australians to understand animal behaviour such as the length, width and depth of animal tracks
 
-##### AC9M2M02
+##### AC9M2M02 {#ac9m2m02}
 
 identify common uses and represent halves, quarters and eighths in relation to shapes, objects and events
 
@@ -141,7 +141,7 @@ identify common uses and represent halves, quarters and eighths in relation to s
 *  recognising that halves and quarters can be used to describe lengths, positions and distances; for example, describing the halfway point in a race or instructing someone to stand halfway between the \(2\) chairs
 *  discussing that halves and quarters are used to describe duration of time in sporting events, durations of time and what it means; for example, how the sirens used during an Australian Rules Football game represent quarters and half time during the game; recognising and using half or quarter of an hour to describe a duration of time
 
-##### AC9M2M03
+##### AC9M2M03 {#ac9m2m03}
 
 identify the date and determine the number of days between events using calendars
 
@@ -151,7 +151,7 @@ identify the date and determine the number of days between events using calendar
 *  using addition and a calendar to model and solve the problem “How many days there are in left in this year?” by identifying the number days of left in this month and in each of the remaining months, and using addition to model and solve the problem
 *  identifying and locating specific days or dates on a calendar; for example, school holidays, sports days, ANZAC Day, Easter, Diwali or Ramadan
 
-##### AC9M2M04
+##### AC9M2M04 {#ac9m2m04}
 
 recognise and read the time represented on an analog clock to the hour, half-hour and quarter-hour
 
@@ -160,7 +160,7 @@ recognise and read the time represented on an analog clock to the hour, half-hou
 *  recognising and describing the relationship between the movement of the hands on an analog clock and the duration of time it represents; for example, connecting the language of “half past” to mean when the “big hand” will be at half past the hour and recognising this position as being halfway around its full cycle
 *  dividing a clockface into halves and quarters, and connecting the subdivisions with telling the time to the half and quarter hour; explaining the meaning of “quarter past” and “quarter to” referring to the hour
 
-##### AC9M2M05
+##### AC9M2M05 {#ac9m2m05}
 
 identify, describe and demonstrate quarter, half, three-quarter and full measures of turn in everyday situations
 
@@ -170,9 +170,9 @@ identify, describe and demonstrate quarter, half, three-quarter and full measure
 *  investigating hands turning on a clock and relating quarter, half and full hours to angles and the language of clockwise or anti-clockwise
 *  giving or following directions to locate an object in the room, or provide a pathway through a grid, such as programming a robot, referring to quarter, half, three-quarter and full turns
 
-### Space
+### Space {#space}
 
-##### AC9M2SP01
+##### AC9M2SP01 {#ac9m2sp01}
 
 recognise, compare and classify shapes, referencing the number of sides and using spatial terms such as “opposite”, “parallel”, “curved” and “straight”
 
@@ -182,7 +182,7 @@ recognise, compare and classify shapes, referencing the number of sides and usin
 *  investigating the shapes of different sporting fields, describing and labelling their features including side lines, centre circles and goal squares; for example, labelling the lines on a basketball court and using spatial terms to describe them
 *  creating regular shapes using digital tools, describing and observing what happens when you manipulate them; for example, dragging or pushing vertices to produce irregular shapes, moving or rotating a shape
 
-##### AC9M2SP02
+##### AC9M2SP02 {#ac9m2sp02}
 
 locate positions in two-dimensional representations of a familiar space; move positions by following directions and pathways
 
@@ -193,9 +193,9 @@ locate positions in two-dimensional representations of a familiar space; move po
 *  following and creating movement instructions that need to be carried out to move through a \(4 \times 4\) grid mat on the classroom floor or on a computer screen; for example, one forward, \(2\) to the right and one backwards, and so on to reach a target square; using a robotic toy to follow a path on a street scene on a floor mat, adjusting their directions as they consider the order of their instructions, the direction and how far they want the toy to travel
 *  moving around a two-dimensional maze using directional language to describe turns and changes in direction including saying, for example, “clockwise”, “anticlockwise”, “quarter turn to the left”, and “take the path to the right”
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9M2ST01
+##### AC9M2ST01 {#ac9m2st01}
 
 acquire data for categorical variables through surveys, observation, experiment and using digital tools; sort data into relevant categories and display data using lists and tables
 
@@ -206,7 +206,7 @@ acquire data for categorical variables through surveys, observation, experiment 
 *  observing events and using the observations to design a table or list to record data; for example, observing students arriving at school prior to deciding the appropriate data categories for investigating the different ways students get to school
 *  exploring the ways First Nations Australians observe, collect, sort and record data
 
-##### AC9M2ST02
+##### AC9M2ST02 {#ac9m2st02}
 
 create different graphical representations of data using software where appropriate; compare the different representations, identify and describe common and distinctive features in response to questions
 
@@ -217,7 +217,7 @@ create different graphical representations of data using software where appropri
 *  comparing picture graphs with one-to-one column graphs of the same data, interpreting the data in each and saying how they are the same and how they are different; for example, collecting data on the country of birth of each student and creating different pictographs to represent classroom data
 *  using dot plots, sticker charts, picture graphs, bar charts and column graphs to represent data
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Year 2, learning in Mathematics builds on each student's prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/maths/year-3.md
+++ b/curriculum/maths/year-3.md
@@ -1,6 +1,6 @@
-# Mathematics - Year 3
+# Mathematics - Year 3 {#mathematics-year-3}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 3, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -19,11 +19,11 @@ Students further develop proficiency and positive dispositions towards mathemati
 *   develop a qualitative understanding of chance and use the language of chance to describe and compare the outcomes of familiar chance events
 *   become increasingly able to understand that different outcomes can be the results of random processes.
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9M3N01
+##### AC9M3N01 {#ac9m3n01}
 
 recognise, represent and order natural numbers using naming and writing conventions for numerals beyond 10 000
 
@@ -34,7 +34,7 @@ recognise, represent and order natural numbers using naming and writing conventi
 *  comparing the Hindu-Arabic numeral system to other numeral systems; for example, investigating the Japanese numeral system,  一、十、百、千、万
 *  comparing, reading and writing the numbers involved in the more than \(60 000\) years of First Peoples of Australia’s presence on the Australian continent through time scales relating to pre-colonisation and post-colonisation
 
-##### AC9M3N02
+##### AC9M3N02 {#ac9m3n02}
 
 recognise and represent unit fractions including \\(\\frac12\\), \\(\\frac13\\), \\(\\frac14\\), \\(\\frac15\\) and \\(\\frac1{10}\\) and their multiples in different ways; combine fractions with the same denominator to complete the whole
 
@@ -44,7 +44,7 @@ recognise and represent unit fractions including \\(\\frac12\\), \\(\\frac13\\),
 *  cutting objects such as oranges, sandwiches or playdough into halves, quarters or fifths and reassembling them to demonstrate; for example, two-halves make a whole, four-quarters make a whole, counting the fractions as they go
 *  sharing collections of objects, such as pop sticks or counters, between \(3, 4\) and \(5\) people and connecting division with fractions; for example, sharing between \(3\) people gives \(\frac13\) of the collection to each and sharing between \(5\) people gives \(\frac15\)  of the collection to each
 
-##### AC9M3N03
+##### AC9M3N03 {#ac9m3n03}
 
 add and subtract two- and three-digit numbers using place value to partition, rearrange and regroup numbers to assist in calculations without a calculator
 
@@ -56,7 +56,7 @@ add and subtract two- and three-digit numbers using place value to partition, re
 *  justifying choices about partitioning and regrouping numbers in terms of their usefulness for particular calculations when solving problems
 *  applying knowledge of place value to assist in calculations when solving problems involving larger numbers; for example, calculating the total crowd numbers for an agricultural show that lasts a week
 
-##### AC9M3N04
+##### AC9M3N04 {#ac9m3n04}
 
 multiply and divide one- and two-digit numbers, representing problems using number sentences, diagrams and arrays, and using a variety of calculation strategies
 
@@ -66,7 +66,7 @@ multiply and divide one- and two-digit numbers, representing problems using numb
 *  matching or creating a problem scenario or story that can be represented by a given number sentence involving multiplication and division; for example, using given number sentences to create worded problems for others to solve
 *  formulating connected multiplication and division expressions by representing situations from First Nations Australians’ cultural stories and dances about how they care for Country/Place such as turtle egg gathering using number sentences
 
-##### AC9M3N05
+##### AC9M3N05 {#ac9m3n05}
 
 estimate the quantity of objects in collections and make estimates when solving problems to determine the reasonableness of calculations
 
@@ -76,7 +76,7 @@ estimate the quantity of objects in collections and make estimates when solving 
 *  choosing which place value they would estimate to for different situations; for example, they would estimate to the nearest \(10\) when estimating how many dots on a ladybird or they would estimate to the nearest \(1000\) when estimating crowd sizes at a venue
 *  checking the reasonableness of an addition calculation by using two- and three-digit numbers to the nearest \(10\) or hundred to estimate; for example, using \(200 + 400 = 600\) to estimate and check the solution to the calculation \(219 + 385\)
 
-##### AC9M3N06
+##### AC9M3N06 {#ac9m3n06}
 
 use mathematical modelling to solve practical problems involving additive and multiplicative situations including financial contexts; formulate problems using number sentences and choose calculation strategies, using digital tools where appropriate; interpret and communicate solutions in terms of the situation
 
@@ -87,7 +87,7 @@ use mathematical modelling to solve practical problems involving additive and mu
 *  modelling and solving practical  division problems involving unknown numbers of groups or finding how much is in each group by representing the problem with both division and multiplication number sentences; explaining how the \(2\) number sentences are connected to the problem
 *  modelling the problem of deciding how to share an amount equally; for example, \(48\) horses into \(2, 4, 6\) or \(8\) paddocks, representing the shares with a division and a multiplication number sentence, and counting the number in each share to check the solutions
 
-##### AC9M3N07
+##### AC9M3N07 {#ac9m3n07}
 
 follow and create algorithms involving a sequence of steps and decisions to investigate numbers; describe any emerging patterns
 
@@ -97,9 +97,9 @@ follow and create algorithms involving a sequence of steps and decisions to inve
 *  creating an algorithm as a set of instructions that a classmate can follow to generate multiples of \(3\) using the rule “To multiply by \( 3\) you double the number and add on one more of the number”; for example, for \(3\) threes you double \(3\) and add on \(3\) to get \(9\), for \(3\) fours you double \(4\) and add one more \(4\) to get \(12\) ...
 *  creating a sorting algorithm that will sort a collection of \(5\) cent and \(10\) cent coins and providing the total value of the collection by applying knowledge of multiples of \(5\) and \(10\)
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9M3A01
+##### AC9M3A01 {#ac9m3a01}
 
 recognise and explain the connection between addition and subtraction as inverse operations, apply to partition numbers and find unknown values in number sentences
 
@@ -108,7 +108,7 @@ recognise and explain the connection between addition and subtraction as inverse
 *  using the inverse relationship between addition and subtraction to find unknown values with a calculator; for example, representing the problem, “Peter had some money and then spent \(\$375\), now he has \(\$158\) left. How much did Peter have to start with?” as \(\square – \$375 = \$158\) and solving the problem using \(\$375 + \$158 = \$533\); solving \(27 + \square = 63\) using subtraction, \(\square = 63\space – \space27\) or by counting on; \(27, 37, 47, 57, 60, 63,\) so add \(3\) tens and \(6\) ones, so \(\square = 36\)
 *  exploring First Nations Australians’ stories and dances that show the connection between addition and subtraction, representing this as a number sentence and discussing how this conveys important information about balance in processes on Country/Place
 
-##### AC9M3A02
+##### AC9M3A02 {#ac9m3a02}
 
 extend and apply knowledge of addition and subtraction facts to 20 to develop efficient mental strategies for computation with larger numbers without a calculator
 
@@ -117,7 +117,7 @@ extend and apply knowledge of addition and subtraction facts to 20 to develop ef
 *  using partitioning to develop and record facts systematically; for example, “How many ways can \(12\) monkeys be spread among \(2\) trees?”, \(12 = 12 + 0\), \(12 = 11 + 1\), \(12 = 10 + 2\), \(12 = 9 + 3\), …; explaining how they know they have found all possible partitions
 *  understanding basic addition and related subtraction facts and using extensions to these facts; for example, \(6 + 6 = 12, 16 + 6 = 22, 6 + 7 = 13, 16 + 7 = 23\), and \(60 + 60 = 120, 600 + 600 = 1200\)
 
-##### AC9M3A03
+##### AC9M3A03 {#ac9m3a03}
 
 recall and demonstrate proficiency with multiplication facts for \\(3, 4, 5\\) and \\(10\\); extend and apply facts to develop the related division facts
 
@@ -127,9 +127,9 @@ recall and demonstrate proficiency with multiplication facts for \\(3, 4, 5\\) a
 *  practising calculating and deriving multiplication facts for \(3, 4, 5\) and \(10\), explaining and recalling the patterns in them and using them to derive related division facts
 *  systematically exploring algorithms used for repeated addition, comparing and describing what is happening, and using them to establish the multiplication facts for \(3, 4, 5\) and \(10\); for example, following the sequence of steps, the decisions being made and the resulting solution, recognising and generalising any emerging patterns
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9M3M01
+##### AC9M3M01 {#ac9m3m01}
 
 identify which metric units are used to measure everyday items; use measurements of familiar items and known units to make estimates
 
@@ -139,7 +139,7 @@ identify which metric units are used to measure everyday items; use measurements
 *  estimating the height of a tree by comparing it to the height of their friend and quoting the result as “the tree is about \(3\) times as tall”; estimating the capacity of a fish tank by using a litre milk carton as a benchmark
 *  choosing and using metres to estimate the dimensions of the classroom
 
-##### AC9M3M02
+##### AC9M3M02 {#ac9m3m02}
 
 measure and compare objects using familiar metric units of length, mass and capacity, and instruments with labelled markings
 
@@ -150,7 +150,7 @@ measure and compare objects using familiar metric units of length, mass and capa
 *  measuring and comparing the mass of objects and capacity of containers, using measuring jugs and kitchen or other scales and standard metric units of millilitres, litres, grams and kilograms; interpreting and explaining what the lines on the measuring jug or scales mean
 *  comparing the capacity of different beakers used in science lessons and using the numbered graduations to measure out different capacities of liquid
 
-##### AC9M3M03
+##### AC9M3M03 {#ac9m3m03}
 
 recognise and use the relationship between formal units of time including days, hours, minutes and seconds to estimate and compare the duration of events
 
@@ -161,7 +161,7 @@ recognise and use the relationship between formal units of time including days, 
 *  using sand timers and digital timers to measure and check estimates of short durations of time, such as one minute, \(3\) minutes and \(5\) minutes
 *  exploring how cultural accounts of First Nations Australians explain cycles of time that involve the sun, moon and stars
 
-##### AC9M3M04
+##### AC9M3M04 {#ac9m3m04}
 
 describe the relationship between the hours and minutes on analog and digital clocks, and read the time to the nearest minute
 
@@ -170,7 +170,7 @@ describe the relationship between the hours and minutes on analog and digital cl
 *  reading and connecting analog and digital time, interpreting times, recognising and using the language of time; for example, \(12\):\(15\) as a quarter past \(12\), or \(15\) minutes past \(12, 12\):\(45\) as a quarter to one or \(15\) minutes before one o’clock and \(10\):\(05\) as \(5\) minutes past \(10\)
 *  reading analog clocks throughout the day, and noticing and connecting the position of the hour hand and the distance the minute hand has travelled during the current hour
 
-##### AC9M3M05
+##### AC9M3M05 {#ac9m3m05}
 
 identify angles as measures of turn and compare angles with right angles in everyday situations
 
@@ -180,7 +180,7 @@ identify angles as measures of turn and compare angles with right angles in ever
 *  identifying angles that are bigger than, smaller than and the same as a right angle in the environment; for example, opening doors partially and fully and comparing the angles created to a right angle
 *  exploring First Nations Australian children’s instructive games to investigate angles as measures of turn; for example, the game Waayin from the Datiwuy People in the northern part of the Northern Territory
 
-##### AC9M3M06
+##### AC9M3M06 {#ac9m3m06}
 
 recognise the relationships between dollars and cents and represent money values in different ways
 
@@ -189,9 +189,9 @@ recognise the relationships between dollars and cents and represent money values
 *  representing money amounts in different ways using knowledge of part-part-whole relationships; for example, knowing that \(\$1\) is equal to \(100\) cents; representing \(\$1.85\) as \(\$1 + 50\)c \(+ 20\)c\( + 10\)c \(+ 5\)c or \(50\)c \(+ 50\)c \(+ 50\)c \(+ 10\)c \(+ 10\)c \(+ 10\)c\( + 5\)c; when calculating change from buying an item for \(\$1.30\) from \(\$2\), starting from \(\$1.30\) add \(20\)c and \(50\)c which gives \(\$2\)
 *  representing money values in multiple ways when role-playing money transactions; for example, using play money to represent the coins and dollars you could use to pay for items
 
-### Space
+### Space {#space}
 
-##### AC9M3SP01
+##### AC9M3SP01 {#ac9m3sp01}
 
 make, compare and classify objects, identifying key features and explaining why these features make them suited to their uses
 
@@ -203,7 +203,7 @@ make, compare and classify objects, identifying key features and explaining why 
 *  identifying, classifying and comparing common objects found on Country/Place as cubes, rectangular prisms, cylinders, cones and spheres
 *  investigating and explaining how First Nations Australians’ dwellings are oriented in the environment to accommodate climatic conditions
 
-##### AC9M3SP02
+##### AC9M3SP02 {#ac9m3sp02}
 
 interpret and create two-dimensional representations of familiar environments, locating key landmarks and objects relative to each other
 
@@ -215,9 +215,9 @@ interpret and create two-dimensional representations of familiar environments, l
 *  creating a two-dimensional plan of the school on a floor mat, representing key buildings and landmarks, then programming a robot to move to different locations within the space
 *  exploring land maps or cultural maps used by First Nations Australians to locate, identify and position important landmarks such as waterholes
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9M3ST01
+##### AC9M3ST01 {#ac9m3st01}
 
 acquire data for categorical and discrete numerical variables to address a question of interest or purpose by observing, collecting and accessing data sets; record the data using appropriate methods including frequency tables and spreadsheets
 
@@ -228,7 +228,7 @@ acquire data for categorical and discrete numerical variables to address a quest
 *  using different online sources to access data; for example, using online query interfaces to select and retrieve data from an online database such as weather records, Google Trends or the World Health Organization
 *  using software to sort and calculate data when solving problems; for example, sorting discrete numerical and categorical data in ascending or descending order and automating simple arithmetic calculations using nearby cells and the Sum function in spreadsheets to calculate total frequencies of collected data
 
-##### AC9M3ST02
+##### AC9M3ST02 {#ac9m3st02}
 
 create and compare different graphical representations of data sets including using software where appropriate; interpret the data in terms of the context
 
@@ -238,7 +238,7 @@ create and compare different graphical representations of data sets including us
 *  selecting appropriate formats or layout styles to present data as information, depending on the type of data and the audience; for example, lists, tables, graphs and infographics
 *  using newspapers or magazines to find examples of different displays of data, interpreting and describing the information they present
 
-##### AC9M3ST03
+##### AC9M3ST03 {#ac9m3st03}
 
 conduct guided statistical investigations involving the collection, representation and interpretation of data for categorical and discrete numerical variables with respect to questions of interest
 
@@ -249,9 +249,9 @@ conduct guided statistical investigations involving the collection, representati
 *  conducting a whole class statistical investigation into the best day to hold an open day for parents by creating a simple survey; collecting the data by asking the parents, representing and interpreting the results, and deciding as a class which day would be best
 *  investigating seasonal calendars of First Nations Australians by collecting data and creating frequency tables and spreadsheets based on environmental indicators; creating one-to-one data displays about frequency of environmental indicators for the current season  
 
-### Probability
+### Probability {#probability}
 
-##### AC9M3P01
+##### AC9M3P01 {#ac9m3p01}
 
 identify practical activities and everyday events involving chance; describe possible outcomes and events as ‘likely’ or ‘unlikely’ and identify some events as ‘certain’ or ‘impossible’ explaining reasoning
 
@@ -261,7 +261,7 @@ identify practical activities and everyday events involving chance; describe pos
 *  making predictions and testing what would happen; for example, if \(10\) names were put in a box, and names were then drawn out one at a time and replaced after each selection, discussing how likely it would be after \(10\) selections that all \(10\) names were drawn from the box or that one name was drawn multiple times
 *  role-playing being a chatbot or virtual assistant responding to a user about the likelihood of events; for example, using preset questions on cards relating to the likelihood of events, role-playing in pairs responding as a virtual assistant, giving reasons for their response
 
-##### AC9M3P02
+##### AC9M3P02 {#ac9m3p02}
 
 conduct repeated chance experiments; identify and describe possible outcomes, record the results, recognise and discuss the variation
 
@@ -270,7 +270,7 @@ conduct repeated chance experiments; identify and describe possible outcomes, re
 *  conducting repeated trials of chance experiments such as tossing a coin, throwing a dice, drawing a coloured or numbered ball from a bag, using a coloured spinner with equal partitions, and identifying the variation in the number of heads/fives/reds between trials
 *  discussing how the process of conducting repeated chance experiments is crucial in the training of artificial intelligence applications like recommendation systems; for example, if they were building a recommendation system for an online shopping website, they could conduct repeated experiments by tracking user interactions over time
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Year 3, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/maths/year-4.md
+++ b/curriculum/maths/year-4.md
@@ -1,6 +1,6 @@
-# Mathematics - Year 4
+# Mathematics - Year 4 {#mathematics-year-4}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 4, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -16,11 +16,11 @@ Students further develop proficiency and positive dispositions towards mathemati
 *   draw on their reasoning skills to analyse, categorise and order chance events and identify independent and dependent events
 *   investigate variability by conducting repeated chance experiments and observing results.
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9M4N01
+##### AC9M4N01 {#ac9m4n01}
 
 recognise and extend the application of place value to tenths and hundredths and use the conventions of decimal notation to name and represent decimals
 
@@ -32,7 +32,7 @@ recognise and extend the application of place value to tenths and hundredths and
 *  counting large quantities of mixed notes and coins, writing the total using dollars and cents, and recognising the cents as parts of the next dollar
 *  comparing the way money and measures are read and said, and explaining how they are the same and different; for example, \(\$2.75\) is said, “two dollars seventy-five” and \(2.75\) metres is said “two point seven five metres”; recognising that the \(7\) means seven-tenths and the \(5\) means five-hundredths in both
 
-##### AC9M4N02
+##### AC9M4N02 {#ac9m4n02}
 
 explain and use the properties of odd and even numbers
 
@@ -42,7 +42,7 @@ explain and use the properties of odd and even numbers
 *  explaining the patterns involved in adding, subtracting and multiplying odd and even numbers; for example, even + even = even, odd + even = odd, odd + odd = even and using this to decide whether answers to addition, subtraction and multiplication calculations are correct or not
 *  following an algorithm consisting of a flow chart with a series of instructions and decisions to determine whether a number is even or odd; using the algorithm to identify which elements of a set of numbers are divisible by \(2\)
 
-##### AC9M4N03
+##### AC9M4N03 {#ac9m4n03}
 
 find equivalent representations of fractions using related denominators and make connections between fractions and decimal notation
 
@@ -53,7 +53,7 @@ find equivalent representations of fractions using related denominators and make
 *  identifying and using the connection between fractions of metres and decimals; for example, finding \(\frac14\) of a metre and connecting this to \(0.25\) metres or \(25\) centimetres, or finding \(\frac1{10}\) of a metre and connecting this with \(0.10\) metres or \(10\) centimetres
 *  using array diagrams to show the relationship between fractions and division and multiplication of natural numbers; for example, \(3 \times 4 = 12\), \(12 ÷ 4 = 3\), \(\frac14\) of \(12\) is \(3\), \(\frac13\) of \(12\) is \(4\)
 
-##### AC9M4N04
+##### AC9M4N04 {#ac9m4n04}
 
 count by fractions including mixed numerals; locate and represent these fractions as numbers on number lines
 
@@ -63,7 +63,7 @@ count by fractions including mixed numerals; locate and represent these fraction
 *  converting mixed numerals into improper fractions and vice versa and representing mixed numerals on a number line
 *  using a number line to represent and count in tenths, recognising that \(10\) tenths is equivalent to one
 
-##### AC9M4N05
+##### AC9M4N05 {#ac9m4n05}
 
 solve problems involving multiplying or dividing natural numbers by multiples and powers of 10 without a calculator, using the multiplicative relationship between the place value of digits
 
@@ -72,7 +72,7 @@ solve problems involving multiplying or dividing natural numbers by multiples an
 *  using materials such as place value charts, numeral expanders or sliders to recognise and explain why multiplying by \(10\) moves the digits one place to the left and dividing by \(10\) moves digits one place to the right
 *  using a calculator or other digital tools to recognise and develop an understanding of the effect of multiplying or dividing numbers by \(10\)s, \(100\)s and \(1000\)s, recording sequences in a place value chart, in a table or spreadsheet, generalising the patterns noticed and applying  them to solve multiplicative problems without a calculator
 
-##### AC9M4N06
+##### AC9M4N06 {#ac9m4n06}
 
 develop efficient strategies and use appropriate digital tools for solving problems involving addition and subtraction, and multiplication and division where there is no remainder
 
@@ -85,7 +85,7 @@ develop efficient strategies and use appropriate digital tools for solving probl
 *  using place value partitioning, basic facts and an area or region to represent and solve multiplication problems, such as \(16 \times 4\), thinking \(10 \times 4\) and \(6 \times 4\), \(40 + 24 = 64\) or a double, double strategy where double \(16\) is \(32\), double this is \(64\), so \(16 \times 4\) is \(64\)
 *  using materials or diagrams to develop and explain division strategies; for example, finding thirds, using the inverse relationship to turn division into a multiplication
 
-##### AC9M4N07
+##### AC9M4N07 {#ac9m4n07}
 
 choose and use estimation and rounding to check and explain the reasonableness of calculations including the results of financial transactions
 
@@ -94,7 +94,7 @@ choose and use estimation and rounding to check and explain the reasonableness o
 *  using rounded amounts to complete an estimated budget for a shopping trip or an excursion, explaining why overestimating the amounts is appropriate
 *  recognising the effect of rounding in addition and multiplication calculations; rounding both numbers up, both numbers down and one number up and one number down, and explaining which is the best approximation and why
 
-##### AC9M4N08
+##### AC9M4N08 {#ac9m4n08}
 
 use mathematical modelling to solve practical problems involving additive and multiplicative situations including financial contexts; formulate the problems using number sentences and choose efficient calculation strategies, using digital tools where appropriate; interpret and communicate solutions in terms of the situation
 
@@ -105,7 +105,7 @@ use mathematical modelling to solve practical problems involving additive and mu
 *  modelling and solving multiplication problems involving money, such as buying \(5\) toy scooters for \(\$96\) each, using efficient mental strategies and written jottings to keep track if needed; for example, rounding \(\$96\) up to \(\$100\) and subtracting \(5 \times\$4 = \$20\), so \(5 \times\$96\) is the same as \(5\times\$100\) less \(\$20\), giving the answer \(\$500 \space–\space \$20 = \$480\)
 *  modelling situations by formulating comparison problems using number sentences, comparison models and arrays; for example, “Ariana read \(16\) books for the readathon; Maryam read \(4\) times as many books. How many books did Maryam read?” using the expression \(4 \times 16\) and using place value partitioning, basic facts and an array, thinking \(4 \times 10 = 40\) and \(4 \times 6 = 24\), so \(4 \times 16\) can be written as \(40 + 24 = 64\)
 
-##### AC9M4N09
+##### AC9M4N09 {#ac9m4n09}
 
 follow and create algorithms involving a sequence of steps and decisions that use addition or multiplication to generate sets of numbers; identify and describe any emerging patterns
 
@@ -114,9 +114,9 @@ follow and create algorithms involving a sequence of steps and decisions that us
 *  creating a basic flow chart that represents an algorithm that will generate a sequence of numbers using multiplication by a constant term; using a calculator to model and follow the algorithm, and record the sequence of numbers generated; checking results and describing any emerging patterns
 *  using a multiplication formula in a spreadsheet and the “fill down” function to generate a sequence of numbers; for example, entering the number one in the cell A1, using “fill down” to cell A100, entering the formula “ = A1*4 “ in the cell B1 and using the “fill down” function to generate a sequence of 100 numbers; describing emerging patterns
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9M4A01
+##### AC9M4A01 {#ac9m4a01}
 
 find unknown values in numerical equations involving addition and subtraction, using the properties of numbers and operations
 
@@ -126,7 +126,7 @@ find unknown values in numerical equations involving addition and subtraction, u
 *  using relational thinking and knowledge of equivalent number sentences to explain whether equations involving addition or subtraction are true; for example, explaining that \(27 \space– \space 14 = 17\space – \space4\) is true and using a number line to show the common difference is \(13\)
 *  using part-part-whole diagrams or bar models to recognise and explain the inverse relationship between addition and subtraction, using this to make calculations easier; for example, solving \(27 + \square = 63\) using subtraction, \(\square = 63\space – \space27\)
 
-##### AC9M4A02
+##### AC9M4A02 {#ac9m4a02}
 
 recall and demonstrate proficiency with multiplication facts up to 10 x 10 and related division facts; extend and apply facts to develop efficient mental strategies for computation with larger numbers without a calculator
 
@@ -138,9 +138,9 @@ recall and demonstrate proficiency with multiplication facts up to 10 x 10 and r
 *  using known multiplication facts up to \(10 \times 10\) and the inverse relationship of multiplication and division to establish corresponding division facts
 *  designing, creating and playing instructive card games that involve the recall, recognition and explanation of the \(10 \times 10\) multiplication facts and related division facts
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9M4M01
+##### AC9M4M01 {#ac9m4m01}
 
 interpret unmarked and partial units when measuring and comparing attributes of length, mass, capacity, duration and temperature, using scaled and digital instruments and appropriate units
 
@@ -153,7 +153,7 @@ interpret unmarked and partial units when measuring and comparing attributes of 
 *  making a scaled measuring instrument such as a tape measure, ruler, sand timer, sun dial or measuring cup using scaled instruments and direct comparisons
 *  exploring the different types of scaled instruments used by First Nations Ranger Groups and other groups to make decisions about caring for Country/Place, and modelling these in local contexts
 
-##### AC9M4M02
+##### AC9M4M02 {#ac9m4m02}
 
 recognise ways of measuring and approximating the perimeter and area of shapes and enclosed spaces, using appropriate formal and informal units
 
@@ -164,7 +164,7 @@ recognise ways of measuring and approximating the perimeter and area of shapes a
 *  demonstrating how to use one unit repeatedly to measure the area of a shape; for example, using one paper square to measure and compare the area of a rectangle and a triangle; recording and explaining how they used part units to give a more accurate measure, and why they needed to ensure there were no gaps or overlaps
 *  investigating the ways First Nations Ranger Groups and other groups measure areas of land to make decisions about fire burns to care for Country/Place
 
-##### AC9M4M03
+##### AC9M4M03 {#ac9m4m03}
 
 solve problems involving the duration of time including situations involving “am” and “pm” and conversions between units of time
 
@@ -173,7 +173,7 @@ solve problems involving the duration of time including situations involving “
 *  converting units of time using relationships between units, such as \(60\) minutes in an hour and \(60\) seconds in a minute, to solve problems; for example, creating a daily timetable for an activity such as an athletics carnival or planning an exercise routine with activities and rests
 *  exploring First Nations Australians’ explanations of the passing of time through cultural accounts about cyclic phenomena involving sun, moon and stars
 
-##### AC9M4M04
+##### AC9M4M04 {#ac9m4m04}
 
 estimate and compare angles using angle names including acute, obtuse, straight angle, reflex and revolution, and recognise their relationship to a right angle
 
@@ -183,9 +183,9 @@ estimate and compare angles using angle names including acute, obtuse, straight 
 *  creating a right-angle template using cardboard or a double-folded piece of paper and using it to compare angles in the environment, commenting on whether they are smaller than or greater than a right angle
 *  using different measuring tools such as a spirit level or set squares to determine whether lines or objects are straight, square or perpendicular (at right angles)
 
-### Space
+### Space {#space}
 
-##### AC9M4SP01
+##### AC9M4SP01 {#ac9m4sp01}
 
 represent and approximate composite shapes and objects in the environment, using combinations of familiar shapes and objects
 
@@ -195,7 +195,7 @@ represent and approximate composite shapes and objects in the environment, using
 *  approximating complex shapes and objects in the environment with familiar shapes and objects; for example, drawing cartoon animals by combining familiar shapes
 *  recognising how familiar shapes and objects are used in logos and other graphics to represent more complex shapes and creating logos using graphic design software
 
-##### AC9M4SP02
+##### AC9M4SP02 {#ac9m4sp02}
 
 create and interpret grid reference systems using grid references and directions to locate and describe positions and pathways
 
@@ -206,7 +206,7 @@ create and interpret grid reference systems using grid references and directions
 *  using different sized grids as a tool to enlarge an image or artwork
 *  simulating the actions of autonomous or robotic vehicles moving to different positions within a grid, using grid references and directional language to describe positions and pathways; for example, imitating an autonomous mobile warehouse robot moving stock to different aisles, using grid reference systems to locate positions
 
-##### AC9M4SP03
+##### AC9M4SP03 {#ac9m4sp03}
 
 recognise line and rotational symmetry of shapes and create symmetrical patterns and pictures, using dynamic geometric software where appropriate
 
@@ -216,9 +216,9 @@ recognise line and rotational symmetry of shapes and create symmetrical patterns
 *  using stimulus materials such as the motifs in Central Asian textiles, Tibetan artefacts, Indian lotus designs and Islamic artwork to investigate and discuss line and rotational symmetry
 *  exploring the natural environment on Country/Place to investigate and discuss patterns and symmetry of shapes and objects such as in flowers, plants and landscapes
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9M4ST01
+##### AC9M4ST01 {#ac9m4st01}
 
 acquire data for categorical and discrete numerical variables to address a question of interest or purpose, using digital tools; represent data using many-to-one pictographs, column graphs and other displays or visualisations; interpret and discuss the information that has been created
 
@@ -230,7 +230,7 @@ acquire data for categorical and discrete numerical variables to address a quest
 *  acquiring samples of data using practical activities, observations or repeated chance experiments, recording data using tally charts, digital tables or spread sheets, graphing, discussing and comparing the results using a column graph
 *  using secondary data of fire burns to construct data displays that assist First Nations Ranger Groups and other groups to care for Country/Place
 
-##### AC9M4ST02
+##### AC9M4ST02 {#ac9m4st02}
 
 analyse the effectiveness of different displays or visualisations in illustrating and comparing data distributions, then discuss the shape of distributions and the variation in the data
 
@@ -240,7 +240,7 @@ analyse the effectiveness of different displays or visualisations in illustratin
 *  comparing different student generated diagrams, tables and graphs, describing their similarities and differences and commenting on the usefulness of each representation for interpreting the data
 *  discussing how analysing data distributions and visualising data is a fundamental step in data preparation for AI developers
 
-##### AC9M4ST03
+##### AC9M4ST03 {#ac9m4st03}
 
 conduct statistical investigations, collecting data through survey responses and other methods; record and display data using digital tools; interpret the data and communicate the results
 
@@ -249,9 +249,9 @@ conduct statistical investigations, collecting data through survey responses and
 *  conducting a statistical investigation and acquiring data from different online sources; for example, using online query interfaces to select and retrieve data from an online database such as weather records, Google Trends or the World Health Organization
 *  investigating different contexts in which statistical investigations can take place and the types of questions to ask to collect data relevant to the context; for example, investigating supermarket customer complaints that breakfast cereals with the most sugar are positioned at children’s eye level, discussing what questions they would need to ask and answer
 
-### Probability
+### Probability {#probability}
 
-##### AC9M4P01
+##### AC9M4P01 {#ac9m4p01}
 
 describe possible everyday events and the possible outcomes of chance experiments and order outcomes or events based on their likelihood of occurring; identify independent or dependent events
 
@@ -265,7 +265,7 @@ describe possible everyday events and the possible outcomes of chance experiment
 *  exploring how ordering outcomes based on their likelihood of occurring is an essential component of early warning systems that use artificial intelligence  to make decisions, such as natural disaster warning systems
 *  discussing how likelihood relates to the decisions an artificial intelligence  tool makes when generating predictive text; for example, discussing which word would most likely come next in a sentence, then refining the decision as the first letter is revealed
 
-##### AC9M4P02
+##### AC9M4P02 {#ac9m4p02}
 
 conduct repeated chance experiments to observe relationships between outcomes; identify and describe the variation in results
 
@@ -275,7 +275,7 @@ conduct repeated chance experiments to observe relationships between outcomes; i
 *  experimenting with tossing \(2\) coins at the same time, recording and commenting on the chance of outcomes after a number of tosses
 *  shuffling a set of cards, drawing a card at random, and recording whether it was a spade, club, diamond or heart, picture card or numbered; repeating the experiment a number of times and discussing the results
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Year 4, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/maths/year-5.md
+++ b/curriculum/maths/year-5.md
@@ -1,6 +1,6 @@
-# Mathematics - Year 5
+# Mathematics - Year 5 {#mathematics-year-5}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 5, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -17,11 +17,11 @@ Students further develop proficiency and positive dispositions towards mathemati
 *   plan, conduct and report findings from statistical investigations that involve an increasing range of types of data and means for representing data
 *   develop their reasoning skills when they consider relationships between events and connect long-term frequency over many trials to the likelihood of an event occurring.
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9M5N01
+##### AC9M5N01 {#ac9m5n01}
 
 interpret, compare and order numbers with more than 2 decimal places, including numbers greater than one, using place value understanding; represent these on a number line
 
@@ -32,7 +32,7 @@ interpret, compare and order numbers with more than 2 decimal places, including 
 *  interpreting and comparing the digits in decimal measures; for example, the length or mass of animals or plants, such as a baby echidna weighing \(1.78\) kilograms and a platypus weighing \(1.708\) kilograms
 *  interpreting plans or diagrams showing length measures as decimals, placing the numbers into a decimal place value chart to connect the digits to their value
 
-##### AC9M5N02
+##### AC9M5N02 {#ac9m5n02}
 
 express natural numbers as products of their factors, recognise multiples and determine if one number is divisible by another
 
@@ -42,7 +42,7 @@ express natural numbers as products of their factors, recognise multiples and de
 *  using divisibility tests to determine if larger numbers are multiples of one-digit numbers; for example, testing if \(89\) \(472\) is divisible by \(3\) using \(8 + 9 + 4 + 7 + 2=30\) as \(30\) is divisible by \(3\) then \(89\) \(472\) is a multiple of \(3\)
 *  demonstrating and reasoning that all multiples can be formed by combining or regrouping; for example, multiples of \(7\) can be formed by combining a multiple of \(2\) with the corresponding multiple of \(5\); \(3 \times 7 = 3 \times 2 + 3 \times 5\), and \(4 \times 7 = 4 \times 2 + 4 \times 5\)
 
-##### AC9M5N03
+##### AC9M5N03 {#ac9m5n03}
 
 compare and order fractions with the same and related denominators including mixed numerals, applying knowledge of factors and multiples; represent these fractions on a number line
 
@@ -53,7 +53,7 @@ compare and order fractions with the same and related denominators including mix
 *  using an understanding of factors and multiples as well as equivalence to recognise efficient methods for the location of fractions with related denominators on parallel number lines; for example, explaining on parallel number lines that \(\frac2{10}\) is located at the same position on a parallel number line as \(\frac15\) because \(\frac15\) is equivalent to \(\frac2{10}\)
 *  converting between mixed numerals and improper fractions to assist with locating them on a number line
 
-##### AC9M5N04
+##### AC9M5N04 {#ac9m5n04}
 
 recognise that 100% represents the complete whole and use percentages to describe, represent and compare relative size; connect familiar percentages to their decimal and fraction equivalents
 
@@ -63,7 +63,7 @@ recognise that 100% represents the complete whole and use percentages to describ
 *  creating a model by subdividing a collection of materials, such as blocks or money, to connect decimals and percentage equivalents of tenths and commonly used fractions \(\frac12\), \(\frac14\) and \(\frac34\); for example, one-tenth or \(0.1\) represents \(10\)% and one half or \(0.5\) represents \(50\)%; recognising that \(60\)% is \(10\)% more than \(50\)%
 *  using physical and virtual materials to represent the relationship between decimal notation and percentages; for example, \(0.3\) is \(3\) out of every \(10\), which is \(30\) out of every \(100\), which is \(30\)%)
 
-##### AC9M5N05
+##### AC9M5N05 {#ac9m5n05}
 
 solve problems involving addition and subtraction of fractions with the same or related denominators, using different strategies
 
@@ -72,7 +72,7 @@ solve problems involving addition and subtraction of fractions with the same or 
 *  representing and solving addition and subtraction problems involving fractions by using jumps on a number line, bar models or making diagrams of fractions as parts of shapes
 *  using materials, diagrams, number lines or arrays to show and explain that fraction number sentences can be rewritten in equivalent forms without changing the quantity; for example, \(\frac12\) + \(\frac14\)  is the same as \(\frac24\) + \(\frac14\)
 
-##### AC9M5N06
+##### AC9M5N06 {#ac9m5n06}
 
 solve problems involving multiplication of larger numbers by one- or two-digit numbers, choosing efficient calculation strategies and using digital tools where appropriate; check the reasonableness of answers
 
@@ -82,7 +82,7 @@ solve problems involving multiplication of larger numbers by one- or two-digit n
 *  using an array to show place value partitioning to solve multiplication, such as \(324 \times 8\), thinking \(300 \times 8 = 2400, 20 \times 8 = 160, 4 \times 8 = 32\) then adding the parts, \(2400 + 160 + 32 = 2592\) ; connecting the parts of the array to a standard written algorithm
 *  using different strategies used to multiply numbers, explaining how they work and if they have any limitations; for example, discussing how the Japanese visual method for multiplication is not effective for multiplying larger numbers
 
-##### AC9M5N07
+##### AC9M5N07 {#ac9m5n07}
 
 solve problems involving division, choosing efficient strategies and using digital tools where appropriate; interpret any remainder according to the context and express results as a whole number, decimal or fraction
 
@@ -91,7 +91,7 @@ solve problems involving division, choosing efficient strategies and using digit
 *  solving division problems mentally like \(72\) divided by \(9, 72 ÷ 9\), by thinking, “how many \(9\)s make \(72\)”, ? \(\times 9 = 72\) or “share \(72\) equally \(9\) ways”
 *  using the fact that equivalent division calculations result if both numbers are divided by the same factor
 
-##### AC9M5N08
+##### AC9M5N08 {#ac9m5n08}
 
 check and explain the reasonableness of solutions to problems including financial contexts using estimation strategies appropriate to the context
 
@@ -100,7 +100,7 @@ check and explain the reasonableness of solutions to problems including financia
 *  recognising the effect of rounding addition, subtraction, multiplication and division calculations, rounding both numbers up, both numbers down, and one number up and one number down; explaining which estimation is the best approximation and why
 *  considering the type of rounding that is appropriate when estimating the amount of money required; for example, rounding up or rounding down when buying one item from a store using cash, compared to rounding up the cost of every item when buying groceries to estimate the total cost and not rounding when the financial transactions are digital
 
-##### AC9M5N09
+##### AC9M5N09 {#ac9m5n09}
 
 use mathematical modelling to solve practical problems involving additive and multiplicative situations including financial contexts; formulate the problems, choosing operations and efficient calculation strategies, using digital tools where appropriate; interpret and communicate solutions in terms of the situation
 
@@ -110,7 +110,7 @@ use mathematical modelling to solve practical problems involving additive and mu
 *  modelling financial situations such as creating financial plans; for example, creating a budget for a class fundraising event, using a spreadsheet to tabulate data and perform calculations
 *  investigating how mathematical models involving combinations of operations can be used to represent songs, stories and/or dances of First Nations Australians
 
-##### AC9M5N010
+##### AC9M5N010 {#ac9m5n010}
 
 create and use algorithms involving a sequence of steps and decisions and digital tools to experiment with factors, multiples and divisibility; identify, interpret and describe emerging patterns
 
@@ -119,9 +119,9 @@ create and use algorithms involving a sequence of steps and decisions and digita
 *  identifying lowest common multiples and highest common factors of pairs or triples of natural numbers; for example, the lowest common multiple of {\(6, 9\)} is \(18\), and the highest common factor is \(3\); the lowest common multiple of {\(3, 4, 5\)} is \(60\) and the highest common factor is one
 *  using the “fill down” function of a spreadsheet and a multiplication formula to generate a sequence of numbers that represent the multiples of any number you enter into the cell; describing and explaining the emerging patterns
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9M5A01
+##### AC9M5A01 {#ac9m5a01}
 
 recognise and explain the connection between multiplication and division as inverse operations and use this to develop families of number facts
 
@@ -131,7 +131,7 @@ recognise and explain the connection between multiplication and division as inve
 *  demonstrating multiplicative partitioning using materials, diagrams or arrays and recording \(2\) multiplication and \(2\) division facts for each grouping; \(4 \times 6 = 24\), \(6 \times 4 = 24\), \(24 ÷ 4 = 6\) and \(24 ÷ 6 = 4\); explaining how each is different from and connected to groups in the materials, diagrams or arrays
 *  using materials, diagrams or arrays to recognise and explain the inverse relationship between multiplication and division; for example, solving \(240 ÷ 20 = \square\) by thinking \(20\times\square = 240\); using the inverse to make calculations easier; for example, solving \(17\times\square= 221\) using division, \(\square = 221 ÷ 17\)
 
-##### AC9M5A02
+##### AC9M5A02 {#ac9m5a02}
 
 find unknown values in numerical equations involving multiplication and division using the properties of numbers and operations
 
@@ -142,9 +142,9 @@ find unknown values in numerical equations involving multiplication and division
 *  using materials, diagrams or arrays to recognise and explain the distributive property; for example, where \(4 \times 13 = 4 \times 10 + 4 \times 3\)
 *  constructing equivalent number sentences involving multiplication to form a numerical equation, and applying knowledge of factors, multiples and the associative property to find unknown values in numerical equations; for example, considering \(3 \times 4 = 12\) and knowing \(2 \times 2 = 4\) then \(3 \times 4\) can be written as \(3\times\) (\(2 \times 2\)) and using the associative property (\(3 \times 2) \times 2\) so \(3 \times 4 = 6 \times 2\) and so \(6\) is the solution to \(3 \times 4 = \square\times 2\)
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9M5M01
+##### AC9M5M01 {#ac9m5m01}
 
 choose appropriate metric units when measuring the length, mass and capacity of objects; use smaller units or a combination of units to obtain a more accurate measure
 
@@ -155,7 +155,7 @@ choose appropriate metric units when measuring the length, mass and capacity of 
 *  measuring and comparing distances, such as jumps or throws using a metre length of string; for example, then measuring the part metre with centimetres and/or millimetres; explaining which unit of measure is most accurate
 *  researching how the base units are derived for the International System of Units (SI), commonly known as the metric system of units, recognising that the metric unit names for the attributes, length and mass are international standards for measurement
 
-##### AC9M5M02
+##### AC9M5M02 {#ac9m5m02}
 
 solve practical problems involving the perimeter and area of regular and irregular shapes using appropriate metric units
 
@@ -167,7 +167,7 @@ solve practical problems involving the perimeter and area of regular and irregul
 *  using a physical or a virtual “geoboard app” to recognise the relationship between area and perimeter and solve problems; for example, investigating what is the largest and what is the smallest area that has the same perimeter
 *  exploring the designs of fishing nets and dwellings of First Nations Australians, investigating the perimeter, area and purpose of the shapes within the designs
 
-##### AC9M5M03
+##### AC9M5M03 {#ac9m5m03}
 
 compare 12- and 24-hour time systems and solve practical problems involving the conversion between them
 
@@ -175,7 +175,7 @@ compare 12- and 24-hour time systems and solve practical problems involving the 
 *  using timetables written in \(24\)-hour time, such as flight schedules, to plan an overseas or interstate trip, converting between \(24\)- and \(12\)-hour time
 *  converting between the digital and analog representation of \(24\)-hour time, matching the same times represented in both systems; setting the time on an analog watch using a digital alarm clock
 
-##### AC9M5M04
+##### AC9M5M04 {#ac9m5m04}
 
 estimate, construct and measure angles in degrees, using appropriate tools including a protractor, and relate these measures to angle names
 
@@ -186,9 +186,9 @@ estimate, construct and measure angles in degrees, using appropriate tools inclu
 *  using a protractor to measure angles when creating a pattern or string design within a circle
 *  recognising the size of angles within shapes that do and do not tesselate, measuring the angles and using the sum of angles to explain why some shapes will tesselate and other shapes do not
 
-### Space
+### Space {#space}
 
-##### AC9M5SP01
+##### AC9M5SP01 {#ac9m5sp01}
 
 connect objects to their nets and build objects from their nets using spatial and geometric reasoning
 
@@ -198,7 +198,7 @@ connect objects to their nets and build objects from their nets using spatial an
 *  sketching nets for a range of prisms and pyramids considering the number, shape and placement of the faces, and test by cutting and folding
 *  investigating objects designed and developed by First Nations Australians, such as those used in fish traps and instructive toys, identifying the shape and relative position of each face to determine the net of the object
 
-##### AC9M5SP02
+##### AC9M5SP02 {#ac9m5sp02}
 
 construct a grid coordinate system that uses coordinates to locate positions within a space; use coordinates and directional language to describe position and movement
 
@@ -209,7 +209,7 @@ construct a grid coordinate system that uses coordinates to locate positions wit
 *  placing a coordinate grid over a contour line, drawing and listing the coordinates of each point in the picture, asking a peer to re-create the drawing using only the list of coordinates, and discussing the reasons for the potential similarities and differences between the \(2\) drawings
 *  investigating how autonomous vehicles use mapping, GPS systems, communication systems and path planning to navigate within a space
 
-##### AC9M5SP03
+##### AC9M5SP03 {#ac9m5sp03}
 
 describe and perform translations, reflections and rotations of shapes, using dynamic geometric software where appropriate; recognise what changes and what remains the same, and identify any symmetries
 
@@ -220,9 +220,9 @@ describe and perform translations, reflections and rotations of shapes, using dy
 *  challenging classmates to select a combination of transformations to move from an original image to the final image, noting the different combinations by using different colours to trace images
 *  investigating how animal tracks can be interpreted by First Nations Australians using the transformation of their shapes to help determine and understand animal behaviour
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9M5ST01
+##### AC9M5ST01 {#ac9m5st01}
 
 acquire, validate and represent data for nominal and ordinal categorical and discrete numerical variables, to address a question of interest or purpose using software including spreadsheets; discuss and report on data distributions in terms of highest frequency (mode) and shape, in the context of the data
 
@@ -235,7 +235,7 @@ acquire, validate and represent data for nominal and ordinal categorical and dis
 *  exploring how travel and online shopping websites and apps collect ordinal data from users to provide customer satisfaction and popularity ratings, and how they use recommendation algorithms to assist customers in travel planning or retail purchasing
 *  investigating data relating to Australia’s reconciliation process with First Nations Australians, posing questions, discussing and reporting on findings
 
-##### AC9M5ST02
+##### AC9M5ST02 {#ac9m5st02}
 
 interpret line graphs representing change over time; discuss the relationships that are represented and conclusions that can be made
 
@@ -246,7 +246,7 @@ interpret line graphs representing change over time; discuss the relationships t
 *  interpreting the data represented in a line graph making inferences; for example, reading line graphs that show the varying temperatures or UV rates over a period of a day and discussing when would be the best time to hold an outdoor assembly
 *  exploring how line graphs can be used to train AI systems to make predictions by providing historical data and showing trends
 
-##### AC9M5ST03
+##### AC9M5ST03 {#ac9m5st03}
 
 plan and conduct statistical investigations by posing questions or identifying a problem and collecting relevant data; choose appropriate displays and interpret the data; communicate findings within the context of the investigation
 
@@ -256,9 +256,9 @@ plan and conduct statistical investigations by posing questions or identifying a
 *  developing survey questions that are objective, without opinion and have a balanced set of answer choices without bias
 *  exploring First Nations Ranger Groups’ and other groups’ biodiversity detection techniques to care for Country/Place, posing investigative questions, collecting and interpreting related data to represent and communicate findings
 
-### Probability
+### Probability {#probability}
 
-##### AC9M5P01
+##### AC9M5P01 {#ac9m5p01}
 
 list the possible outcomes of chance experiments involving equally likely outcomes and compare to those which are not equally likely
 
@@ -271,7 +271,7 @@ list the possible outcomes of chance experiments involving equally likely outcom
 *  comparing the chance of a head or a tail when a coin is tossed, whether some numbers on a dice are more likely to be facing up when the dice is rolled, or the chance of getting a \(1, 2\) or \(3\) on a spinner with uneven regions for the numbers
 *  discussing supermarket promotions such as collecting stickers or objects and whether there is an equal chance of getting each of them
 
-##### AC9M5P02
+##### AC9M5P02 {#ac9m5p02}
 
 conduct repeated chance experiments including those with and without equally likely outcomes, observe and record the results; use frequency to compare outcomes and estimate their likelihoods
 
@@ -283,7 +283,7 @@ conduct repeated chance experiments including those with and without equally lik
 *  using spreadsheets to record the outcomes of an activity and calculate the total frequencies of different outcomes, representing these as a fraction; for example, using coloured balls in a bag, drawing one out at a time and recording the colour, replacing them in the bag after each draw
 *  investigating First Nations Australian children’s instructive games; for example, Diyari koolchee from the Diyari Peoples near Lake Eyre in South Australia, to conduct repeated trials and explore predictable patterns, using digital tools where appropriate
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Year 5, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/maths/year-6.md
+++ b/curriculum/maths/year-6.md
@@ -1,6 +1,6 @@
-# Mathematics - Year 6
+# Mathematics - Year 6 {#mathematics-year-6}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 6, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -18,11 +18,11 @@ Students further develop proficiency and positive dispositions towards mathemati
 *   determine the mode and range and discuss the shape of distributions in their reports of findings from their statistical investigations
 *   observe and compare long-run frequencies in repeated chance experiments and simulations
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9M6N01
+##### AC9M6N01 {#ac9m6n01}
 
 recognise situations, including financial contexts, that use integers; locate and represent integers on a number line and as coordinates on the Cartesian plane
 
@@ -33,7 +33,7 @@ recognise situations, including financial contexts, that use integers; locate an
 *  recognising that the sign (positive or negative) indicates a direction in relation to zero; for example, \(30\) metres left of the admin block is (-\(30\)) and \(20\) metres right of the admin block is (+\(20\)); programming robots to move along a number line which is either horizontal or vertical but not both at the same time
 *  representing the temperatures of the different planets in the solar system, using a diagram of a thermometer that models a vertical number line 
 
-##### AC9M6N02
+##### AC9M6N02 {#ac9m6n02}
 
 identify and describe the properties of prime, composite and square numbers and use these properties to solve problems and simplify calculations
 
@@ -44,7 +44,7 @@ identify and describe the properties of prime, composite and square numbers and 
 *  identifying and describing the product of a number with itself as square; for example, \(3 \times 3\) is the same as \(3^2\)
 *  using spreadsheets to list all the numbers that have up to \(3\) factors, using combinations of only the first \(3\) prime numbers, recognise any emerging patterns, making conjectures and experimenting with other combinations
 
-##### AC9M6N03
+##### AC9M6N03 {#ac9m6n03}
 
 apply knowledge of equivalence to compare, order and represent common fractions including halves, thirds and quarters on the same number line and justify their order
 
@@ -54,7 +54,7 @@ apply knowledge of equivalence to compare, order and represent common fractions 
 *  explaining equivalence and order between fractions using number lines, drawings and models
 *  comparing and ordering fractions by placing cards on a string line across the room and referring to benchmark fractions to justify their position; for example, \(\frac58\) is greater than \(\frac12\) can be written as \(\frac58>\frac12\), because half of \(8\) is \(4\); \(\frac16\) is less than \(\frac14\), because \(6 > 4\) and can be written \(\frac16\) < \(\frac14\)
 
-##### AC9M6N04
+##### AC9M6N04 {#ac9m6n04}
 
 apply knowledge of place value to add and subtract decimals, using digital tools where appropriate; use estimation and rounding to check the reasonableness of answers
 
@@ -64,7 +64,7 @@ apply knowledge of place value to add and subtract decimals, using digital tools
 *  working additively with linear measurements expressed as decimals up to \(2\) and \(3\) decimal places; for example, calculating how far off the world record the athletes were at the last Olympic games in the women’s long jump or shot-put and comparing school records to the Olympic records
 *  deciding to use a calculator as a calculation strategy for solving additive problems involving decimals that vary in their number of decimal places beyond hundredths; for example, \(1.0 - 0.0035\) or \(2.345 + 1.4999\)
 
-##### AC9M6N05
+##### AC9M6N05 {#ac9m6n05}
 
 solve problems involving addition and subtraction of fractions using knowledge of equivalent fractions
 
@@ -74,7 +74,7 @@ solve problems involving addition and subtraction of fractions using knowledge o
 *  calculating the addition or subtraction of fractions in the context of realistic problems; for example, using part cups or spoons in a recipe; using the understanding of equivalent fractions
 *  understanding the processes for adding and subtracting fractions with related denominators and fractions as an operator, in preparation for calculating with all fractions; for example, using fraction overlays and number lines to give meaning to adding and subtracting fractions with related and unrelated denominators
 
-##### AC9M6N06
+##### AC9M6N06 {#ac9m6n06}
 
 multiply and divide decimals by multiples of powers of 10 without a calculator, applying knowledge of place value and proficiency with multiplication facts; using estimation and rounding to check the reasonableness of answers
 
@@ -83,7 +83,7 @@ multiply and divide decimals by multiples of powers of 10 without a calculator, 
 *  applying and explaining estimation strategies in multiplicative situations involving a decimal greater than one that is multiplied by a two- or three-digit number, using a multiple of \(10\) or \(100\) when the situation requires just an estimation
 *  explaining the effect of multiplying or dividing a decimal by \(10, 100, 1000\) … in terms of place value and not the decimal point shifting
 
-##### AC9M6N07
+##### AC9M6N07 {#ac9m6n07}
 
 solve problems that require finding a familiar fraction, decimal or percentage of a quantity, including percentage discounts, choosing efficient calculation strategies and using digital tools where appropriate
 
@@ -94,7 +94,7 @@ solve problems that require finding a familiar fraction, decimal or percentage o
 *  explaining the equivalence between percentages and fractions; for example, \(33\frac13\)% and \(\frac13\); keeping to percentages that are equivalent to fractions with small denominators such as \(66\frac23\)% and \(12.5\)%
 *  representing a situation with a mathematical expression; for example, numbers and symbols such as \(\frac14\times24\), that involve finding a familiar fraction or percentage of a quantity; using mental strategies or a calculator and explaining the result in terms of the situation in question
 
-##### AC9M6N08
+##### AC9M6N08 {#ac9m6n08}
 
 approximate numerical solutions to problems involving rational numbers and percentages, including financial contexts, using appropriate estimation strategies
 
@@ -106,7 +106,7 @@ approximate numerical solutions to problems involving rational numbers and perce
 *  verifying solutions by estimating percentages in suitable contexts such as discounts using common percentages of \(10\)%, \(25\)%, \(30\)%, \(50\)% and \(1\)%
 *  investigating estimation strategies to make decisions about steam cooking in ground ovens by First Nations Australians, including catering for different numbers of people and resources needed for cooking
 
-##### AC9M6N09
+##### AC9M6N09 {#ac9m6n09}
 
 use mathematical modelling to solve practical problems involving natural and rational numbers and percentages, including in financial contexts; formulate the problems, choosing operations and efficient calculation strategies, and using digital tools where appropriate; interpret and communicate solutions in terms of the situation, justifying the choices made
 
@@ -115,9 +115,9 @@ use mathematical modelling to solve practical problems involving natural and rat
 *  modelling situations involving earning money and budgeting, asking questions such as, “Can I afford it?”, “Do I need it?”, “How much do I need to save for it?”, and developing a savings plan or budget for an upcoming event or personal purchase
 *  modelling and solving the problem of creating a budget for a class excursion or family holiday, using the internet to research costs and expenses, and representing the budget in a spreadsheet, creating and using formulas to calculate totals
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9M6A01
+##### AC9M6A01 {#ac9m6a01}
 
 recognise and use rules that generate visually growing patterns and number patterns involving rational numbers
 
@@ -128,7 +128,7 @@ recognise and use rules that generate visually growing patterns and number patte
 *  investigating the number of regions created by successive folds of a sheet of paper: one fold, \(2\) regions; \(2\) folds, \(4\) regions; \(3\) folds, \(8\) regions, and describing the pattern using everyday language
 *  creating a pattern sequence with materials, writing the associated number sequence and then describing the sequence with a rule so someone else can replicate it with different materials; for example, using matchsticks or toothpicks to create a growing pattern of triangles using \(3\) for one triangle, \(5\) for \(2\) triangles, \(7\) for \(3\) triangles and describing the pattern as, “Multiply the number of triangles by \(2\) and then add one for the extra toothpick in the first triangle”
 
-##### AC9M6A02
+##### AC9M6A02 {#ac9m6a02}
 
 find unknown values in numerical equations involving brackets and combinations of arithmetic operations, using the properties of numbers and operations
 
@@ -138,7 +138,7 @@ find unknown values in numerical equations involving brackets and combinations o
 *  finding pairs of unknown values in numerical equations that make the equation hold true; for example, listing possible combinations of natural numbers that make this statement true: \(6+4\times8\;=\;6\times\bigtriangleup+\square\)
 *  applying knowledge of inverse operations and number properties to create equivalent number sentences; removing one of the numbers and replacing it with a symbol, then swapping with a classmate to find the unknown values
 
-##### AC9M6A03
+##### AC9M6A03 {#ac9m6a03}
 
 create and use algorithms involving a sequence of steps and decisions that use rules to generate sets of numbers; identify, interpret and explain emerging patterns
 
@@ -147,9 +147,9 @@ create and use algorithms involving a sequence of steps and decisions that use r
 *  designing an algorithm to model operations, using the concept of input and output, describing and explaining relationships and any emerging patterns; for example, using function machines to model operations and recognising and comparing additive and multiplicative relationships
 *  designing an algorithm or writing a simple program to generate a sequence of numbers based on the user’s input and a chosen operation, discussing any emerging patterns; for example, generating a sequence of numbers and comparing how quickly the sequences are growing in comparison to each other using the rule adding \(2\) to the input number compared to multiplying the input number by \(2\)
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9M6M01
+##### AC9M6M01 {#ac9m6m01}
 
 convert between common metric units of length, mass and capacity; choose and use decimal representations of metric measurements relevant to the context of a problem
 
@@ -158,7 +158,7 @@ convert between common metric units of length, mass and capacity; choose and use
 *  identifying and using the correct operations when converting between units including millimetres, centimetres, metres, kilometres, milligrams, grams, kilograms, tonnes, millilitres, litres, kilolitres and megalitres
 *  recognising the equivalence of measurements, such as \(1.25\) metres is the same as \(125\) centimetres
 
-##### AC9M6M02
+##### AC9M6M02 {#ac9m6m02}
 
 establish the formula for the area of a rectangle and use it to solve practical problems
 
@@ -168,7 +168,7 @@ establish the formula for the area of a rectangle and use it to solve practical 
 *  solving problems involving the comparison of lengths and areas using appropriate units
 *  investigating the connection between the perimeters of different rectangles with the same area and between the areas of rectangles with the same perimeter
 
-##### AC9M6M03
+##### AC9M6M03 {#ac9m6m03}
 
 interpret and use timetables and itineraries to plan activities and determine the duration of events and journeys
 
@@ -177,7 +177,7 @@ interpret and use timetables and itineraries to plan activities and determine th
 *  developing a timetable of daily activities for a planned event; for example, a sports carnival
 *  investigating different ways duration is represented in timetables and using different timetables to plan a journey
 
-##### AC9M6M04
+##### AC9M6M04 {#ac9m6m04}
 
 identify the relationships between angles on a straight line, angles at a point and vertically opposite angles; use these to determine unknown angles, communicating reasoning
 
@@ -186,9 +186,9 @@ identify the relationships between angles on a straight line, angles at a point 
 *  demonstrating the meaning of language associated with properties of angles, including right, complementary, complement, straight, supplement, vertically opposite, and angles at a point
 *  using the properties of supplementary and complementary angles to represent spatial situations with number sentences and solving to find the size of unknown angles
 
-### Space
+### Space {#space}
 
-##### AC9M6SP01
+##### AC9M6SP01 {#ac9m6sp01}
 
 compare the parallel cross-sections of objects and recognise their relationships to right prisms
 
@@ -200,7 +200,7 @@ compare the parallel cross-sections of objects and recognise their relationships
 *  connecting different right prisms to the shape of their parallel cross-sections, such as a triangular prism which can be described as a stack of the same sized triangles, and a cube or square prism, which can be described as a stack of the same sized squares
 *  investigating the design of First Nations Australians’ dwellings, exploring the relationship between the cross-sections and the dwellings’ construction
 
-##### AC9M6SP02
+##### AC9M6SP02 {#ac9m6sp02}
 
 locate points in the 4 quadrants of a Cartesian plane; describe changes to the coordinates when a point is moved to a different position in the plane
 
@@ -212,7 +212,7 @@ locate points in the 4 quadrants of a Cartesian plane; describe changes to the c
 *  exploring how coordinates can be used to input positional data for artificial intelligence  systems to locate positions in an image or other two-dimensional space
 *  investigating and connecting land or star maps used by First Nations Australians with the Cartesian plane through a graphical or visual way of describing location
 
-##### AC9M6SP03
+##### AC9M6SP03 {#ac9m6sp03}
 
 recognise and use combinations of transformations to create tessellations and other geometric patterns, using dynamic geometric software where appropriate
 
@@ -223,9 +223,9 @@ recognise and use combinations of transformations to create tessellations and ot
 *  designing an algorithm as a set of instructions to transform a shape, including getting back to where you started from; for example, programming a robot to move around the plane using instructions for movements, such as 2 down, 3 to the right, and combinations of these to transform shapes
 *  investigating symmetry, transformation and tessellation in different shapes on Country/Place, including rock formations, insects, and land and sea animals, discussing the purpose or role symmetry plays in their physical structure
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9M6ST01
+##### AC9M6ST01 {#ac9m6st01}
 
 interpret and compare data sets for ordinal and nominal categorical, discrete and continuous numerical variables using comparative displays or visualisations and digital tools; compare distributions in terms of mode, range and shape
 
@@ -235,7 +235,7 @@ interpret and compare data sets for ordinal and nominal categorical, discrete an
 *  representing ordinal data collected through surveys, using visualisation tools including dot plots and bar charts, and discussing the distribution of data in terms of shape
 *  using technology to access data sets and graphing software to construct side-by-side column graphs or stacked line graphs; comparing data sets that are grouped by gender, year level, age group or other variables and discussing findings
 
-##### AC9M6ST02
+##### AC9M6ST02 {#ac9m6st02}
 
 identify statistically informed arguments presented in traditional and digital media; discuss and critique methods, data representations and conclusions
 
@@ -245,7 +245,7 @@ identify statistically informed arguments presented in traditional and digital m
 *  identifying potentially misleading data representations in the media; for example, graphs with broken axes or non-linear scales, graphics not drawn to scale, data not related to the population about which the claims are made and pie charts in which the whole pie does not represent the entire population about which the claims are made
 *  investigating both traditional and digital media relating to First Nations Australians, identifying and critiquing statistically informed arguments
 
-##### AC9M6ST03
+##### AC9M6ST03 {#ac9m6st03}
 
 plan and conduct statistical investigations by posing and refining questions or identifying a problem and collecting relevant data; analyse and interpret the data and communicate findings within the context of the investigation
 
@@ -257,9 +257,9 @@ plan and conduct statistical investigations by posing and refining questions or 
 *  collecting ordinal categorical data through the use of a survey; for example, surveying each member of the class where they are asked to indicate their preference on a five-point scale for a particular graphic and colour combination of a proposed school logo
 *  collecting ordinal data for ranking nominees for school captain with respect to several criteria, contrasting the use of a five-point scale compared with using a four-point scale
 
-### Probability
+### Probability {#probability}
 
-##### AC9M6P01
+##### AC9M6P01 {#ac9m6p01}
 
 recognise that probabilities lie on numerical scales of 0 – 1 or 0% – 100% and use estimation to assign probabilities that events occur in a given context, using common fractions, percentages and decimals
 
@@ -271,7 +271,7 @@ recognise that probabilities lie on numerical scales of 0 – 1 or 0% – 100% a
 *  exploring how probabilities are used in artificial intelligence  for machine learning and decision-making; for example, when choosing a video on a streaming service or travelling in a self-driving autonomous car, where artificial intelligence  algorithms estimate the probability of a pedestrian crossing the road, which helps the autonomous car make decisions about when to stop or slow down
 *  exploring First Nations Australian children’s instructive games, such as Weme from the Warlpiri Peoples of Central Australia, to investigate and assign probabilities that events will occur, indicating their estimated likelihood
 
-##### AC9M6P02
+##### AC9M6P02 {#ac9m6p02}
 
 conduct repeated chance experiments and run simulations with an increasing number of trials using digital tools; compare observations with expected results and discuss the effect on variation of increasing the number of trials
 
@@ -281,7 +281,7 @@ conduct repeated chance experiments and run simulations with an increasing n
 *  investigating the relative frequencies of all outcomes for a chance experiment and verifying that their sum equals one
 *  systematically recording the outcome of large numbers of spins on a spinner and analysing the relative frequencies of outcomes, representing these as percentages
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Year 6, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/maths/year-7.md
+++ b/curriculum/maths/year-7.md
@@ -1,6 +1,6 @@
-# Mathematics - Year 7
+# Mathematics - Year 7 {#mathematics-year-7}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 7, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -17,11 +17,11 @@ Students further develop proficiency and positive dispositions towards mathemati
 *   apply the statistical investigation process to obtain numerical data related to questions of interest, choose displays for the distributions of data and interpret summary statistics for determining the centre and spread of the data in context
 *   conduct probability simulations and experiments involving chance events, construct corresponding sample spaces and observe related frequencies, comparing expected, simulated and experimental results.
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9M7N01
+##### AC9M7N01 {#ac9m7n01}
 
 describe the relationship between perfect square numbers and square roots, and use squares of numbers and square roots of perfect square numbers to solve problems
 
@@ -32,7 +32,7 @@ describe the relationship between perfect square numbers and square roots, and u
 *  generating a list of perfect square numbers and describing any emerging patterns; for example, the last digit of perfect square numbers, or the difference between consecutive square numbers, and recognising the constant second difference
 *  using the relationship between perfect square numbers and their square roots to determine the perimeter of a square tiled floor using square tiles; for example, an area of floor with \(144\) square tiles has a perimeter of \(48\) tile lengths
 
-##### AC9M7N02
+##### AC9M7N02 {#ac9m7n02}
 
 represent natural numbers as products of powers of prime numbers using exponent notation
 
@@ -41,7 +41,7 @@ represent natural numbers as products of powers of prime numbers using exponent 
 *  developing familiarity with the sequence \(1, 2, 4, 8, 16, 32, 64, 128, 256, 512\) and powers of \(2\); the sequence \(1, 3, 9, 27, 81, 243, 729\) and powers of \(3\); and the sequence \(1, 5, 25, 125, 625\) and powers of \(5\)
 *  solving problems involving lowest common multiples and greatest common divisors (highest common factors) for pairs of natural numbers by comparing their prime factorisation
 
-##### AC9M7N03
+##### AC9M7N03 {#ac9m7n03}
 
 represent natural numbers in expanded notation using place value and powers of 10
 
@@ -50,7 +50,7 @@ represent natural numbers in expanded notation using place value and powers of 1
 *  relating the sequences \(10, 100, 1000, 10 000\) … and \(10^1\), \(10^2\), \(10^3\), \(10^4\) ...
 *  applying and explaining the connections between place value and expanded notations; for example, \(7000=7×10^3\) and \(3750=3×10^3+7×10^2+5×10^1\)
 
-##### AC9M7N04
+##### AC9M7N04 {#ac9m7n04}
 
 find equivalent representations of rational numbers and represent rational numbers on a number line
 
@@ -60,7 +60,7 @@ find equivalent representations of rational numbers and represent rational numbe
 *  applying and explaining the equivalence between fraction, decimal and percentage representations of rational numbers; for example, \(16\%\), \(0.16\), \(\frac{16}{100}\) and \(\frac4{25}\), using manipulatives, number lines or diagrams
 *  representing positive and negative fractions and mixed numerals on various intervals of the real number line, including intervals that are not symmetrical about zero
 
-##### AC9M7N05
+##### AC9M7N05 {#ac9m7n05}
 
 round decimals to a given accuracy appropriate to the context and use appropriate rounding and estimation to check the reasonableness of solutions
 
@@ -69,7 +69,7 @@ round decimals to a given accuracy appropriate to the context and use appropriat
 *  choosing and applying conventions for rounding correct to a specified number of decimal places based upon the context
 *  checking that the accuracy of rounding is suitable for context and purpose, such as the amount of paint required and cost estimate for renovating a house; for example, purchasing \(2\) litres of paint to paint the bedroom even though \(1.89\) litres is the exact answer or estimating a renovation budget to the nearest \(\$100\)
 
-##### AC9M7N06
+##### AC9M7N06 {#ac9m7n06}
 
 use the 4 operations with positive rational numbers including fractions, decimals and percentages to solve problems using efficient calculation strategies
 
@@ -81,7 +81,7 @@ use the 4 operations with positive rational numbers including fractions, decimal
 *  developing efficient strategies with appropriate use of the commutative and associative properties, regrouping or partitioning to solve additive problems involving fractions and decimals
 *  carry out calculations to solve problems using the representation that makes computations efficient such as \(12.5\)% of \(96\) is more efficiently calculated as \(\frac18\) of \(96\), including contexts such as comparing land-use by calculating the total local municipal area set aside for parkland or manufacturing and retail, the amount of protein in daily food intake across several days, or increases/decreases in energy accounts each account cycle
 
-##### AC9M7N07
+##### AC9M7N07 {#ac9m7n07}
 
 compare, order and solve problems involving addition and subtraction of integers
 
@@ -90,7 +90,7 @@ compare, order and solve problems involving addition and subtraction of integers
 *  discussing language such as “addition”, “subtraction”, “magnitude”, “difference”, “sign” and synonyms of these terms
 *  ordering, adding and subtracting integers using a number line
 
-##### AC9M7N08
+##### AC9M7N08 {#ac9m7n08}
 
 recognise, represent and solve problems involving ratios
 
@@ -100,7 +100,7 @@ recognise, represent and solve problems involving ratios
 *  sharing quantities in a given ratio; for example, sharing an amount of money in a given ratio, such as sharing \(\$20\) in the ratio \(2:3\)
 *  applying ratios to realistic and meaningful contexts; for example, mixing \(500\) millilitres of a liquid with a concentration of \(1:4\) means \(\frac15\) concentrate and \(\frac45\) water so, \(0.2\) of \(500\) millilitres is concentrate and \(0.8\) of \(500\) millilitres is water; interpreting results in context
 
-##### AC9M7N09
+##### AC9M7N09 {#ac9m7n09}
 
 use mathematical modelling to solve practical problems, involving rational numbers and percentages, including financial contexts; formulate problems, choosing representations and efficient calculation strategies, using digital tools as appropriate; interpret and communicate solutions in terms of the situation, justifying choices made about the representation
 
@@ -110,9 +110,9 @@ use mathematical modelling to solve practical problems, involving rational numbe
 *  modelling financial problems involving profit and loss, credits and debits, gains and losses; for example, holding a fundraising sausage sizzle and determining whether the event made a percentage profit or loss
 *  using mathematical modelling to investigate the proportion of land mass/area of Australian First Nations Peoples’ traditional grain belt compared with Australia’s current grain belt
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9M7A01
+##### AC9M7A01 {#ac9m7a01}
 
 recognise and use variables to represent everyday formulas algebraically and substitute values into formulas to determine an unknown
 
@@ -122,7 +122,7 @@ recognise and use variables to represent everyday formulas algebraically and sub
 *  substituting numerical values for variables when using formulas and calculating the value of an unknown in practical situations; for example, calculating weekly wage \(W\) given base wage \(b\) and overtime hours \(h\) at \(1.5\) times rate \(r\), \(W\;=\;b+1.5\times h\times r\), using values for mass \(m\) and volume \(v\) to determine density \(d\) of a substance where \(d\;=\;\frac mv\)
 *  using everyday formulas and their application to contexts on Country/Place, investigating the relationships between variables
 
-##### AC9M7A02
+##### AC9M7A02 {#ac9m7a02}
 
 formulate algebraic expressions using constants, variables, operations and brackets
 
@@ -131,7 +131,7 @@ formulate algebraic expressions using constants, variables, operations and brack
 *  formulating algebraic expressions that represent mathematical relationships; for example, translating from words to symbols, “think of a number” type of activities
 *  recognising and applying the concept of variable as something that can change in value, investigating the relationships between variables, and the application to processes on Country/Place, including how cultural expressions of First Nations Australians, such as storytelling, communicate mathematical relationships that can be represented as mathematical expressions
 
-##### AC9M7A03
+##### AC9M7A03 {#ac9m7a03}
 
 solve one-variable linear equations with natural number solutions; verify the solution by substitution
 
@@ -140,7 +140,7 @@ solve one-variable linear equations with natural number solutions; verify the so
 *  solving equations using concrete materials, the balance model, and backtracking, explaining the process
 *  solving linear equations such as \(3x+7=19\) algebraically, and verifying the solution by substitution
 
-##### AC9M7A04
+##### AC9M7A04 {#ac9m7a04}
 
 describe relationships between variables represented in graphs of functions from authentic data
 
@@ -151,7 +151,7 @@ describe relationships between variables represented in graphs of functions from
 *  exploring how functions are used in machine learning to model relationships; for example, in linear regression models, a linear function is used to map input features to predictions
 *  using graphs of evaporation rates to explore and discuss First Nations Australians’ methods of water resource management
 
-##### AC9M7A05
+##### AC9M7A05 {#ac9m7a05}
 
 generate tables of values from visually growing patterns or the rule of a function; describe and plot these relationships on the Cartesian plane
 
@@ -162,7 +162,7 @@ generate tables of values from visually growing patterns or the rule of a functi
 *  using diagrams and manipulatives to form linear growth patterns, representing these patterns in tables and describing the relationship in terms of the way the pattern is growing and in the context of the situation
 *  using a simple general-purpose programming language to create and use algorithms that generate growing patterns and graphing the relationships on a Cartesian plane
 
-##### AC9M7A06
+##### AC9M7A06 {#ac9m7a06}
 
 manipulate formulas involving several variables using digital tools, and describe the effect of systematic variation in the values of the variables
 
@@ -173,9 +173,9 @@ manipulate formulas involving several variables using digital tools, and describ
 *  exploring how deep learning models used for training artificial intelligence agents can involve the manipulation of mathematical functions with multiple variables; for example, conducting a sensitivity analysis to understand the artificial intelligence  model's behaviour
 *  understanding that the relationship between variables in an artificial intelligence  model assists with explainability and interpretability; for example, manipulating and analysing formulas allows researchers to gain insights into how and why a model makes certain predictions
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9M7M01
+##### AC9M7M01 {#ac9m7m01}
 
 solve problems involving the area of triangles and parallelograms using established formulas and appropriate units
 
@@ -184,7 +184,7 @@ solve problems involving the area of triangles and parallelograms using establis
 *  using dynamic geometry software to demonstrate how the sliding of the vertex of a triangle at a fixed altitude opposite a side leaves the area of the triangle unchanged
 *  using established formulas to solve practical problems involving the area of triangles, parallelograms and rectangles; for example, estimating the cost of materials needed to make shade sails based on a price per metre or determining different combinations of dimensions that lead to a given area
 
-##### AC9M7M02
+##### AC9M7M02 {#ac9m7m02}
 
 solve problems involving the volume of right prisms including rectangular and triangular prisms, using established formulas and appropriate units
 
@@ -194,7 +194,7 @@ solve problems involving the volume of right prisms including rectangular and tr
 *  connecting the area of the floor space and the number of floors of a high-rise building to calculate the volume of a building
 *  using dynamic geometry software, spatial reasoning and prediction to derive the formula for the volume of prisms
 
-##### AC9M7M03
+##### AC9M7M03 {#ac9m7m03}
 
 describe the relationship between \\(π\\) and the features of circles including the circumference, radius and diameter
 
@@ -204,7 +204,7 @@ describe the relationship between \\(π\\) and the features of circles including
 *  investigating \(π\) as the constant in the proportional relationship between the circumference of a circle and its diameter, and historical approximations from different civilisations, including Egypt, Babylon, Greece, India and China
 *  investigating the applications and significance of circles in everyday life of First Nations Australians such as in basketry, symbols and architecture, recognising the relationships between the centre, radius, diameter and circumference
 
-##### AC9M7M04
+##### AC9M7M04 {#ac9m7m04}
 
 identify corresponding, alternate and co-interior relationships between angles formed when parallel lines are crossed by a transversal; use them to solve problems and explain reasons
 
@@ -214,7 +214,7 @@ identify corresponding, alternate and co-interior relationships between angles f
 *  using dynamic geometry software to demonstrate how angles and their properties are involved in the design and construction of scissor lifts, folding umbrellas, toolboxes and cherry pickers
 *  using geometric reasoning of angle properties to generalise the angle relationships of parallel lines and transversals, and related properties such as the size of an exterior angle of a triangle is equal to the sum of the sizes of opposite and non-adjacent interior angles, and the sum of the sizes of interior angles in a triangle in the plane is equal to the size of \(2\) right angles or \(180\)°
 
-##### AC9M7M05
+##### AC9M7M05 {#ac9m7m05}
 
 demonstrate that the interior angle sum of a triangle in the plane is 180° and apply this to determine the interior angle sum of other shapes and the size of unknown angles
 
@@ -222,7 +222,7 @@ demonstrate that the interior angle sum of a triangle in the plane is 180° and 
 *  using concrete materials to demonstrate that the sum of the interior angles of a triangle is 180°; for example, using paper triangles and tearing to demonstrate that the interior angles when combined form 180°
 *  using decomposition and the angle sum of a triangle to generalise the interior angle sum of an \(n\)-sided polygon, as \(180(n-2)\;=\;180n-360\)
 
-##### AC9M7M06
+##### AC9M7M06 {#ac9m7m06}
 
 use mathematical modelling to solve practical problems involving ratios; formulate problems, interpret and communicate solutions in terms of the situation, justifying choices made about the representation
 
@@ -232,9 +232,9 @@ use mathematical modelling to solve practical problems involving ratios; formula
 *  modelling the situation using manipulatives, diagrams and/or mathematical discussion; for example, mixing primary colours in a variety of ratios to investigate how new colours are created and the strength of those colours
 *  investigating commercialised substances founded on First Nations Australians’ knowledges of substances including pharmaceuticals and toxins, understanding how ratios are used in their development
 
-### Space
+### Space {#space}
 
-##### AC9M7SP01
+##### AC9M7SP01 {#ac9m7sp01}
 
 represent objects in 2 dimensions; discuss and reason about the advantages and disadvantages of different representations
 
@@ -246,7 +246,7 @@ represent objects in 2 dimensions; discuss and reason about the advantages and d
 *  using isometric and square grid paper to draw views of front, back, side, top and bottom of objects
 *  exploring different two-dimensional representations of objects in First Nations Australians’ artworks or cultural maps of Country/Place
 
-##### AC9M7SP02
+##### AC9M7SP02 {#ac9m7sp02}
 
 classify triangles, quadrilaterals and other polygons according to their side and angle properties; identify and reason about relationships
 
@@ -256,7 +256,7 @@ classify triangles, quadrilaterals and other polygons according to their side an
 *  identifying and communicating about side and angle properties of scalene, isosceles, equilateral, right-angled, acute and obtuse triangles using geometric conventions
 *  describing, comparing and contrasting squares, rectangles, rhombuses, parallelograms, kites and trapeziums, explaining the relationships between these shapes
 
-##### AC9M7SP03
+##### AC9M7SP03 {#ac9m7sp03}
 
 describe transformations of a set of points using coordinates in the Cartesian plane, translations and reflections on an axis, and rotations about a given point
 
@@ -265,7 +265,7 @@ describe transformations of a set of points using coordinates in the Cartesian p
 *  describing patterns and investigating different ways to produce the same transformation, such as using \(2\) successive reflections to provide the same result as a translation
 *  experimenting with, creating and re-creating patterns using combinations of translations, reflections and rotations, using digital tools
 
-##### AC9M7SP04
+##### AC9M7SP04 {#ac9m7sp04}
 
 design and create algorithms involving a sequence of steps and decisions that will sort and classify sets of shapes according to their attributes, and describe how the algorithms work
 
@@ -274,9 +274,9 @@ design and create algorithms involving a sequence of steps and decisions that wi
 *  creating a flow chart or hierarchy for quadrilaterals that shows the relationships between trapeziums, parallelograms, rhombuses, rectangles, squares and kites
 *  creating a classification scheme for regular, irregular, concave or convex polygons that are sorted according to the number of sides
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9M7ST01
+##### AC9M7ST01 {#ac9m7st01}
 
 acquire data sets for discrete and continuous numerical variables and calculate the range, median, mean and mode; make and justify decisions about which measures of central tendency provide useful insights into the nature of the distribution of data
 
@@ -287,7 +287,7 @@ acquire data sets for discrete and continuous numerical variables and calculate 
 *  acquire continuous numerical data by taking measurement samples during a science experiment, observation or field study, comparing measures of central tendency and identifying any anomalies in the distribution of data
 *  exploring how descriptive statistics are used by artificial intelligence  developers to summarise and analyse data, assist the artificial intelligence  in making informed decisions, and gain insights from the processed data; for example, descriptive statistics in recommendation systems can help analyse user behaviour and preferences
 
-##### AC9M7ST02
+##### AC9M7ST02 {#ac9m7st02}
 
 create different types of numerical data displays including stem-and-leaf plots using software where appropriate; describe and compare the distribution of data, commenting on the shape, centre and spread including outliers and determining the range, median, mean and mode
 
@@ -299,7 +299,7 @@ create different types of numerical data displays including stem-and-leaf plots 
 *  comparing the mean and median of data with and without extremes; for example, estimation of standard measures for length or mass, informally considering for a given set of data what might constitute an unexpected, unusual or extreme data value
 *  exploring how artificial intelligence systems can also use descriptive statistics to identify outliers or anomalies in data; for example, fraud detection and quality control
 
-##### AC9M7ST03
+##### AC9M7ST03 {#ac9m7st03}
 
 plan and conduct statistical investigations involving data for discrete and continuous numerical variables; analyse and interpret distributions of data and report findings in terms of shape and summary statistics
 
@@ -308,9 +308,9 @@ plan and conduct statistical investigations involving data for discrete and cont
 *  conducting an investigation to support claims that a modification of a Science, Technology, Engineering and Mathematics (STEM) related design has improved performance
 *  using secondary data from the Reconciliation Barometer to conduct and report on statistical investigations relating to First Nations Australians
 
-### Probability
+### Probability {#probability}
 
-##### AC9M7P01
+##### AC9M7P01 {#ac9m7p01}
 
 identify the sample space for single-stage events; assign probabilities to the outcomes of these events and predict relative frequencies for related events
 
@@ -320,7 +320,7 @@ identify the sample space for single-stage events; assign probabilities to the o
 *  exploring how relative frequencies can be used to make predictions by estimating the probability of an event; for example, in natural language processing (NLP), predictive text algorithms use the relative frequency of words in a set of texts to predict the next word in a sentence
 *  assigning the probability for throwing a \(6\) on a dice and using this to predict the number of times a \(6\) will occur when a dice is thrown multiple times
 
-##### AC9M7P02
+##### AC9M7P02 {#ac9m7p02}
 
 conduct repeated chance experiments and run simulations with a large number of trials using digital tools; compare predictions about outcomes with observed results, explaining the differences
 
@@ -329,7 +329,7 @@ conduct repeated chance experiments and run simulations with a large numbe
 *  conducting simulations using online simulation tools and comparing the combined results of a large number of trials to predicted results
 *  exploring and observing First Nations Australian children’s instructive games; for example, Koara from the Jawi and Bardi Peoples of Sunday Island in Western Australia, to investigate probability, predicting outcomes for an event and comparing with increasingly larger numbers of trials, and between observed and expected results
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Year 7, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/maths/year-8.md
+++ b/curriculum/maths/year-8.md
@@ -1,6 +1,6 @@
-# Mathematics - Year 8
+# Mathematics - Year 8 {#mathematics-year-8}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 8, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -17,11 +17,11 @@ Students further develop proficiency and positive dispositions towards mathemati
 *   consider a variety of situations involving complementary and mutually exclusive events, combinations of 2 events; represent these using tables and diagrams, conducting simulations and calculating corresponding probabilities
 *   examine experimental and observational data and identify populations and samples with respect to context; investigate variation in summary statistics across samples of varying size and discuss their findings.
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9M8N01
+##### AC9M8N01 {#ac9m8n01}
 
 recognise irrational numbers in applied contexts, including square roots and \\(π\\)
 
@@ -31,7 +31,7 @@ recognise irrational numbers in applied contexts, including square roots and \\(
 *  investigating the golden ratio in art and design, and historical approximations to \(π\) in different societies
 *  connecting the ratio between the circumference and diameter of any circle to the irrational value of \(π\) using circular objects and string or dynamic drawing software
 
-##### AC9M8N02
+##### AC9M8N02 {#ac9m8n02}
 
 establish and apply the exponent laws with positive integer exponents and the zero-exponent, using exponent notation with numbers
 
@@ -41,7 +41,7 @@ establish and apply the exponent laws with positive integer exponents and the ze
 *  using digital tools to systematically explore the application of the exponent laws; observing that the bases need to be the same
 *  using examples such as \(\frac{3^4}{3^4}\;=\;1\), and \(3^{4-4}\;=\;3^0\) to illustrate the necessity that for any non-zero natural number \(n,\;n^0\;=\;1\)
 
-##### AC9M8N03
+##### AC9M8N03 {#ac9m8n03}
 
 recognise terminating and recurring decimals, using digital tools as appropriate
 
@@ -49,7 +49,7 @@ recognise terminating and recurring decimals, using digital tools as appropriate
 *  identifying when a fraction has a terminating decimal expansion from the prime factorisation of its denominator; for example, \(\frac7{24}\;=\;0.291\overset\_6\) does not have a terminating decimal expansion, while \(\frac7{25}\;=\;0.28\) does
 *  identifying terminating, recurring and non-terminating decimals and choosing their appropriate representations such as \(\frac13\) is represented as \(0.\overset\_3\)
 
-##### AC9M8N04
+##### AC9M8N04 {#ac9m8n04}
 
 use the 4 operations with integers and with rational numbers, choosing and using efficient strategies and digital tools where appropriate
 
@@ -58,7 +58,7 @@ use the 4 operations with integers and with rational numbers, choosing and using
 *  applying and explaining efficient strategies such as using the commutative or associative property for regrouping, partitioning, place value, patterning, multiplication or division facts to solve problems involving positive and negative integers, fractions and decimals
 *  recognising the effect of sign in the multiplication of integers; for example, (-\(1)^4\;=\;1\) and (-\(1)^5\;=\) -\(1\)
 
-##### AC9M8N05
+##### AC9M8N05 {#ac9m8n05}
 
 use mathematical modelling to solve practical problems involving rational numbers and percentages, including financial contexts; formulate problems, choosing efficient calculation strategies and using digital tools where appropriate; interpret and communicate solutions in terms of the situation, reviewing the appropriateness of the model
 
@@ -68,9 +68,9 @@ use mathematical modelling to solve practical problems involving rational number
 *  modelling situations involving personal income tax, interpreting tax tables to determine income tax at various levels of income, including overall percentage of income allocated to tax
 *  modelling situations involving percentage increase or decrease such as market trends, effects on population, or effects on the environment over extended time periods
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9M8A01
+##### AC9M8A01 {#ac9m8a01}
 
 create, expand, factorise, rearrange and simplify linear expressions, applying the associative, commutative, identity, distributive and inverse properties
 
@@ -79,7 +79,7 @@ create, expand, factorise, rearrange and simplify linear expressions, applying t
 *  demonstrating the relationship between factorising and expanding linear expressions using manipulatives, such as algebra tiles or area models, and describing with mathematical language
 *  using the distributive, associative, commutative, identity and inverse properties to expand and factorise algebraic expressions using strategies such as the area model
 
-##### AC9M8A02
+##### AC9M8A02 {#ac9m8a02}
 
 graph linear relations on the Cartesian plane using digital tools where appropriate; solve linear equations and one-variable inequalities using graphical and algebraic techniques; verify solutions by substitution
 
@@ -91,7 +91,7 @@ graph linear relations on the Cartesian plane using digital tools where appropri
 *  solving linear equations of the form \(ax+b\;=\;c\) and one-variable inequalities of the form \(ax+b\;<\;c\) or \(ax+b\;>\;c\) where \(a>0\) using inverse operations and digital tools, and checking solutions by substitution
 *  solving linear equations such as \(3x+7\;=\;6x-9\), representing these graphically, and verifying solutions by substitution
 
-##### AC9M8A03
+##### AC9M8A03 {#ac9m8a03}
 
 use mathematical modelling to solve applied problems involving linear relations, including financial contexts; formulate problems with linear functions, choosing a representation; interpret and communicate solutions in terms of the situation, reviewing the appropriateness of the model
 
@@ -101,7 +101,7 @@ use mathematical modelling to solve applied problems involving linear relations,
 *  modelling financial problems involving pay rates, using a table of values to represent the pay amounts and hours worked using an hourly rate of pay, and graphing the relationship to make inferences
 *  modelling patterns on Country/Place and exploring their connections and meaning to linear equations, using the model as a predictive tool and critiquing results by connecting back to Country/Place
 
-##### AC9M8A04
+##### AC9M8A04 {#ac9m8a04}
 
 experiment with linear functions and relations using digital tools, making and testing conjectures and generalising emerging patterns
 
@@ -111,9 +111,9 @@ experiment with linear functions and relations using digital tools, making and t
 *  using digital tools to investigate integer solutions to equations such as \(2x+3y\;=\;48\)
 *  exploring how linear functions are used in linear regression models as a statistical technique in machine learning of artificial intelligence agents; for example, linear functions are used to model the relationship between input variables and a target variable, to predict stock or house prices in the financial and real-estate sectors
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9M8M01
+##### AC9M8M01 {#ac9m8m01}
 
 solve problems involving the area and perimeter of irregular and composite shapes using appropriate units
 
@@ -122,7 +122,7 @@ solve problems involving the area and perimeter of irregular and composite shape
 *  using arrays and rectangles to approximate the area of irregular shapes in situations such as a council needing to work out how much mosquito spray to use for a swamp area or a farmer needing to work out how much seed, fertilizer and herbicide are required to cover a paddock
 *  determining the perimeter and area of irregular shapes by sums of increasingly accurate covering measurements, such as line segments and grids; for example, using millimetres or square millimetres as opposed to centimetres or square centimetres
 
-##### AC9M8M02
+##### AC9M8M02 {#ac9m8m02}
 
 solve problems involving the volume and capacity of right prisms using appropriate units
 
@@ -132,7 +132,7 @@ solve problems involving the volume and capacity of right prisms using appropria
 *  choosing which measurements are useful to consider when solving practical problems in context; for example, when purchasing a new washing machine, the dimensions are useful when determining whether it will fit in the available space in the laundry and its capacity is useful when considering the maximum washing load it can carry
 *  investigating, reasoning and finding solutions to measurement problems involving dimensions, rates, volume and capacity of objects; for example, given the dimensions of a pool and the rate of flow from a tap, determining how long it will take to fill the pool to its normal capacity
 
-##### AC9M8M03
+##### AC9M8M03 {#ac9m8m03}
 
 solve problems involving the circumference and area of a circle using formulas and appropriate units
 
@@ -142,7 +142,7 @@ solve problems involving the circumference and area of a circle using formulas a
 *  applying the formulas for the area and circumference of a circle to solve practical problems, and using one of the measures of radius, diameter, circumference or area to deduce the value of the other measures; for example, determining the length of material needed to edge a round table, given its dimensions as the area of the tabletop
 *  exploring traditional weaving designs by First Nations Australians and investigating the significance and use of circles
 
-##### AC9M8M04
+##### AC9M8M04 {#ac9m8m04}
 
 solve problems involving duration, including using 12- and 24-hour time across multiple time zones
 
@@ -151,7 +151,7 @@ solve problems involving duration, including using 12- and 24-hour time across m
 *  recognising the challenges of planning regular virtual meeting times for a company that has both international staff and staff within different states and territories, and the impact daylight savings has due to multiple time zones, explaining the mathematical language used to communicate current time such as Coordinated Universal Time (UTC)+\(8\), AEST, ACST and AWST
 *  planning an international travel itinerary that covers destinations in different time zones across Asia
 
-##### AC9M8M05
+##### AC9M8M05 {#ac9m8m05}
 
 recognise and use rates to solve problems involving the comparison of 2 related quantities of different units of measure
 
@@ -162,7 +162,7 @@ recognise and use rates to solve problems involving the comparison of 2 related 
 *  using taxation tables to calculate an individual's annual income tax
 *  investigating the application of rates in First Nation Australians’ land management practices, including the rate of fire spread under different environmental conditions such as fuel types, wind speed, temperature and relative humidity; the conservation of water by First Nations Australians by estimating rates of water evaporation based on surface area and climatic conditions
 
-##### AC9M8M06
+##### AC9M8M06 {#ac9m8m06}
 
 use Pythagoras’ theorem to solve problems involving the side lengths of right-angled triangles
 
@@ -173,7 +173,7 @@ use Pythagoras’ theorem to solve problems involving the side lengths of right-
 *  identifying Pythagorean triples, such as (\(3,4,5\)), (\(5,12,13\)), (\(7, 24, 25\)) and (\(8,15, 17\))
 *  investigating how Pythagoras' theorem can be applied to determine the distance between two points in the plane, and how this can be used by predictive algorithms to navigate autonomous vehicles
 
-##### AC9M8M07
+##### AC9M8M07 {#ac9m8m07}
 
 use mathematical modelling to solve practical problems involving ratios and rates, including financial contexts; formulate problems; interpret and communicate solutions in terms of the situation, reviewing the appropriateness of the model
 
@@ -184,9 +184,9 @@ use mathematical modelling to solve practical problems involving ratios and rate
 *  modelling situations involving the use of ratios in radiocarbon dating methods, including the ratio of carbon-\(14\) to carbon-\(12\) isotopes in organisms, to measure dates of First Peoples of Australia’s habitation on the Australian continent
 *  modelling situations involving ratio and its application in the making of string and cordage by First Nations Australians, including the ratio of length to the mass of a rope, the strength of the ply in proportion to a rope’s pulling force, and the proportion of fibre for the length of string required
 
-### Space
+### Space {#space}
 
-##### AC9M8SP01
+##### AC9M8SP01 {#ac9m8sp01}
 
 identify the conditions for congruence and similarity of triangles and explain the conditions for other sets of common shapes to be congruent or similar, including those formed by transformations
 
@@ -198,7 +198,7 @@ identify the conditions for congruence and similarity of triangles and explain t
 *  comparing angle and side measurements of shapes under transformation to answer questions such as “What changes?” and “What stays the same?”
 *  establishing that \(2\) shapes are congruent if one lies exactly on top of the other after one or more transformations including translations, reflections and rotations, and recognising that the matching sides and the matching angles are equal
 
-##### AC9M8SP02
+##### AC9M8SP02 {#ac9m8sp02}
 
 establish properties of quadrilaterals using congruent triangles and angle properties, and solve related problems explaining reasoning
 
@@ -207,7 +207,7 @@ establish properties of quadrilaterals using congruent triangles and angle prope
 *  identifying properties of quadrilaterals related to side lengths, parallel sides, angles, diagonals and symmetry
 *  applying the properties of triangles and quadrilaterals to construction designs such as car jacks, scissor lifts, folding umbrellas, toolboxes and cherry pickers
 
-##### AC9M8SP03
+##### AC9M8SP03 {#ac9m8sp03}
 
 describe the position and location of objects in 3 dimensions in different ways, including using a three-dimensional coordinate system with the use of dynamic geometric software and other digital tools
 
@@ -219,7 +219,7 @@ describe the position and location of objects in 3 dimensions in different ways,
 *  interpreting  three-dimensional coordinate locations for objects in multi-storey car parks; playing games based on  three-dimensional coordinate systems such as  three-dimensional Noughts and Crosses (Tic-Tac-Toe)
 *  exploring position and transformation through geospatial technologies used by First Nations Australians’ communities
 
-##### AC9M8SP04
+##### AC9M8SP04 {#ac9m8sp04}
 
 design, create and test algorithms involving a sequence of steps and decisions that identify congruency or similarity of shapes, and describe how the algorithm works
 
@@ -228,9 +228,9 @@ design, create and test algorithms involving a sequence of steps and decisions t
 *  using the conditions for congruence of triangles and similarity of triangles to develop a sorting algorithm; for example, creating a flow chart
 *  evaluating algorithms for accuracy in classifying and distinguishing between similar and congruent triangles
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9M8ST01
+##### AC9M8ST01 {#ac9m8st01}
 
 investigate techniques for data collection including census, sampling, experiment and observation, and explain the practicalities and implications of obtaining data through these techniques
 
@@ -241,7 +241,7 @@ investigate techniques for data collection including census, sampling, experimen
 *  using digital tools such as simulations and digital measuring devices to observe, measure and record qualitative and quantitative data, discussing precision and the implications of error
 *  investigating how decisions concerning sampling relate to the training of artificial intelligence  systems, recognising the need to mitigate any potential bias that may lead to the development of biased models
 
-##### AC9M8ST02
+##### AC9M8ST02 {#ac9m8st02}
 
 analyse and report on the distribution of data from primary and secondary sources using random and non-random sampling techniques to select and study samples
 
@@ -251,7 +251,7 @@ analyse and report on the distribution of data from primary and secondary source
 *  defining and distinguishing between probabilistic terms such as random, sample space, sample and sample distribution
 *  investigating primary and secondary data sources relating to reconciliation between First Nations Australians and non-Indigenous Australians, analysing and reporting on findings
 
-##### AC9M8ST03
+##### AC9M8ST03 {#ac9m8st03}
 
 compare variations in distributions and proportions obtained from random samples of the same size drawn from a population and recognise the effect of sample size on this variation
 
@@ -263,7 +263,7 @@ compare variations in distributions and proportions obtained from random samples
 *  investigating First Nations Ranger Groups and other groups’ use of sampling techniques to track biodiversity of species
 *  exploring how the comparison of variations in distributions and proportions from the same population applies to data-driven decision-making and how this relates to training of artificial intelligence systems
 
-##### AC9M8ST04
+##### AC9M8ST04 {#ac9m8st04}
 
 plan and conduct statistical investigations involving samples of a population; use ethical and fair methods to make inferences about the population and report findings, acknowledging uncertainty
 
@@ -272,9 +272,9 @@ plan and conduct statistical investigations involving samples of a population; u
 *  identifying situations where the collection of data from a sample is necessary due to efficiency, cost or restricted time for collection of data, and sufficiently reliable for making inferences about a population
 *  exploring progress in reconciliation between First Nations Australians and non-Indigenous Australians, investigating and evaluating sampling techniques and methods to gather relevant data to measure progress
 
-### Probability
+### Probability {#probability}
 
-##### AC9M8P01
+##### AC9M8P01 {#ac9m8p01}
 
 recognise that complementary events have a combined probability of one; use this relationship to calculate probabilities in applied contexts
 
@@ -284,7 +284,7 @@ recognise that complementary events have a combined probability of one; use this
 *  using the sum of probabilities to solve problems, such as the probability of starting a game by throwing a \(5\) or \(6\) on a dice is \(\frac13\) and probability of not throwing a \(5\) or \(6\) is \(\frac23\)
 *  investigating how various applications of artificial intelligence  use the probability of complementary events when assessing the likelihood of favourable and unfavourable outcomes and making informed decisions based on these probabilities; for example, in binary classification problems where data is classified into one of two categories, such as spam or not spam, fraud or not fraud
 
-##### AC9M8P02
+##### AC9M8P02 {#ac9m8p02}
 
 determine all possible combinations for 2 events, using two-way tables, tree diagrams and Venn diagrams, and use these to determine probabilities of specific outcomes in practical situations
 
@@ -294,7 +294,7 @@ determine all possible combinations for 2 events, using two-way tables, tree dia
 *  using Venn diagrams or two-way tables to demonstrate the difference between events that are mutually exclusive, such as whether a coin toss will land on a head or a tail, or those that are not mutually exclusive, such as people who have blonde hair and people who have blue eyes
 *  exploring First Nations Australian children’s instructive games; for example, Battendi from the Ngarrindjeri Peoples of Lake Murray and Lake Albert in southern Australia, applying possible combinations and relationships and calculating probabilities using two-way tables and Venn diagrams
 
-##### AC9M8P03
+##### AC9M8P03 {#ac9m8p03}
 
 conduct repeated chance experiments and simulations, using digital tools to determine probabilities for compound events, and describe results
 
@@ -303,7 +303,7 @@ conduct repeated chance experiments and simulations, using digital tools to dete
 *  using a random number generator and digital tools, including generative artificial intelligence, to simulate rolling \(2\) dice and calculating the difference between them, investigating what difference is likely to occur more often
 *  using online simulation software to conduct probability simulations to determine in the long run if events are complementary
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Year 8, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/maths/year-9.md
+++ b/curriculum/maths/year-9.md
@@ -1,6 +1,6 @@
-# Mathematics - Year 9
+# Mathematics - Year 9 {#mathematics-year-9}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 9, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 
@@ -16,11 +16,11 @@ Students further develop proficiency and positive dispositions towards mathemati
 *   investigate probabilities of compound events from two-step experiments and solve related problems; use a variety of representations such as Venn diagrams, tree diagrams, two-way tables and grids to assist in determining the probabilities for these events; design experiments to gather empirical data about relative frequencies and use these to check their reasoning
 *   compare multiple numerical data subsets in context and analyse their distributions with consideration of symmetry and skew; justify their choice of data representation with respect to data types and context, and critically review the statistical presentation of data and related arguments of others.
 
-## Strands
+## Strands {#strands}
 
-### Number
+### Number {#number}
 
-##### AC9M9N01
+##### AC9M9N01 {#ac9m9n01}
 
 recognise that the real number system includes the rational numbers and the irrational numbers, and solve problems involving real numbers using digital tools
 
@@ -31,9 +31,9 @@ recognise that the real number system includes the rational numbers and the irra
 *  solving problems involving the substitution of real numbers into formulas, understanding that solutions can be represented in exact form or as a decimal approximation, such as calculating the area of a circle using the formula \(A=\mathrm{π}r^2\) and specifying the answer in terms of \(π\) as an exact real number; for example, the circumference of a circle with diameter \(5\) units is \(5\mathrm\pi\) units, and the exact area is \(\mathrm\pi(\frac52)^2=\frac{25}4\mathrm\pi\) square units which rounds to \(19.63\) square units, correct to \(2\) decimal places
 *  investigating the position of rational and irrational numbers on the real number line, using geometric constructions to locate rational numbers and square roots on a number line; for example, \(\sqrt2\) is located at the intersection of an arc and the number line, where the radius of the arc is the length of the diagonal of a one-unit square
 
-### Algebra
+### Algebra {#algebra}
 
-##### AC9M9A01
+##### AC9M9A01 {#ac9m9a01}
 
 apply the exponent laws to numerical expressions with integer exponents and extend to variables
 
@@ -46,7 +46,7 @@ apply the exponent laws to numerical expressions with integer exponents and exte
 *  applying the exponent laws to simplifying expressions involving products, quotients, and powers of constants and variables; for example, \(\frac{(2xy)^3}{xy^4}\;=\;\frac{8x^3y^3}{xy^4}\;=\;8x^2y^{-1}\)
 *  relating the prefixes for SI units from pico- (trillionth) to tera- (trillion) to the corresponding powers of \(10\); for example, one pico-gram = \(10^{-12}\) gram and one terabyte = \(10^{12}\) bytes
 
-##### AC9M9A02
+##### AC9M9A02 {#ac9m9a02}
 
 simplify algebraic expressions, expand binomial products and factorise monic quadratic expressions
 
@@ -55,7 +55,7 @@ simplify algebraic expressions, expand binomial products and factorise monic qua
 *  using manipulatives such as algebra tiles or area models to expand or factorise algebraic expressions with readily identifiable binomial factors; for example, \((x+1)(x+3)\;=\;x^2+4x+3,\;(x-5)^2\;=\;x^2-10x+25\) or \((x-3)^2+4\;=\;x^2-6x+9+4\;=\;x^2-6x+13\)
 *  recognising the relationship between expansion and factorisation, and using digital tools to systematically explore the factorisation of \(x^2+mx+n\) where \(m\) and \(n\) are integers
 
-##### AC9M9A03
+##### AC9M9A03 {#ac9m9a03}
 
 find the gradient of a line segment, the midpoint of the line interval and the distance between 2 distinct points on the Cartesian plane
 
@@ -67,7 +67,7 @@ find the gradient of a line segment, the midpoint of the line interval and the d
 *  using dynamic graphing software and superimposed images; for example, playground equipment, ramps and escalators, to investigate gradients in context and their relationship to rule of a linear function, and interpret gradient as a constant rate of change in linear modelling contexts
 *  investigating how coordinate geometry and aspects of linear algebra play a fundamental role in machine learning and predictive algorithms; for example, object detection and navigation by autonomous vehicles
 
-##### AC9M9A04
+##### AC9M9A04 {#ac9m9a04}
 
 identify and graph quadratic functions, solve quadratic equations graphically and numerically, and solve monic quadratic equations with integer roots algebraically, using graphing software and digital tools as appropriate
 
@@ -80,7 +80,7 @@ identify and graph quadratic functions, solve quadratic equations graphically an
 *  recognising that the equation \(x^2=a\), where \(a>0\), has \(2\) solutions, \(x=\sqrt a\) and \(x=\)-\(\sqrt a\); for example, if \(x^2=39\) then \(x=\sqrt{39}=6.245\) correct to \(3\) decimal places, or \(x=\)-\(\sqrt{39}=\)-\(6.245\) correct to \(3\) decimal places, and representing these graphically
 *  graphing percentages of illumination of moon phases in relation to First Nations Australians’ understandings that describe the different phases of the moon
 
-##### AC9M9A05
+##### AC9M9A05 {#ac9m9a05}
 
 use mathematical modelling to solve applied problems involving change including financial contexts; formulate problems, choosing to use either linear or quadratic functions; interpret solutions in terms of the situation; evaluate the model and report methods and findings
 
@@ -92,7 +92,7 @@ use mathematical modelling to solve applied problems involving change including 
 *  modelling situations involving change; for example, change in daily temperature during the ski season, fluctuation of speed above and below the speed limit, acceleration and deceleration of a car coming to and moving off from a set of traffic lights
 *  modelling the hunting techniques of First Nations Australians using quadratic functions and exploring the effect of increasing the number of hunters to catch more prey
 
-##### AC9M9A06
+##### AC9M9A06 {#ac9m9a06}
 
 experiment with the effects of the variation of parameters on graphs of related functions, using digital tools, making connections between graphical and algebraic representations, and generalising emerging patterns
 
@@ -102,9 +102,9 @@ experiment with the effects of the variation of parameters on graphs of related 
 *  experimenting with digital tools by applying transformations to the graphs of functions, such as reciprocal \(y=\frac1x\), square root \(y=\sqrt x\), cube \(y=x^3\) and exponential functions, \(y=2^x\), \(y=(\frac12)^x\), identifying patterns
 *  investigating how experimenting with the effects of the variation of parameters of related functions can provide artificial intelligence researchers insights into the predictive behaviour of artificial intelligence models
 
-### Measurement
+### Measurement {#measurement}
 
-##### AC9M9M01
+##### AC9M9M01 {#ac9m9m01}
 
 solve problems involving the volume and surface area of right prisms and cylinders using appropriate units
 
@@ -114,7 +114,7 @@ solve problems involving the volume and surface area of right prisms and cylinde
 *  finding different prisms that have the same volume but different surface areas, making conjectures as to what type of prism would have the smallest or largest surface area
 *  investigating objects and technologies of First Nations Australians, analysing and connecting surface area and volume, and exploring their relationship to their capacity
 
-##### AC9M9M02
+##### AC9M9M02 {#ac9m9m02}
 
 solve problems involving very small and very large measurements, time scales and intervals expressed in scientific notation
 
@@ -123,7 +123,7 @@ solve problems involving very small and very large measurements, time scales and
 *  using knowledge of place value and applying exponent laws to operate with numbers expressed in scientific notation in applied contexts; for example, performing calculations involving extremely small numbers in scientific and other contexts
 *  examining the degree of accuracy that different measurement instruments provide in a science laboratory, such as a measuring cylinder compared with a pipette, and recording data values to the correct degree of accuracy using appropriate scientific notation
 
-##### AC9M9M03
+##### AC9M9M03 {#ac9m9m03}
 
 solve spatial problems, applying angle properties, scale, similarity, Pythagoras’ theorem and trigonometry in right-angled triangles
 
@@ -136,7 +136,7 @@ solve spatial problems, applying angle properties, scale, similarity, Pythagoras
 *  using knowledge of similar triangles, Pythagoras’ theorem, rates and algebra to design and construct a Biltmore stick used to measure the diameter and height of a tree, and calculating the density and dry mass to predict how much paper could be manufactured from the tree
 *  investigating how autonomous vehicles solve spatial problems using algorithms based on geometric properties relating to angles, distances and scale
 
-##### AC9M9M04
+##### AC9M9M04 {#ac9m9m04}
 
 calculate and interpret absolute, relative and percentage errors in measurements, recognising that all measurements are estimates
 
@@ -147,7 +147,7 @@ calculate and interpret absolute, relative and percentage errors in measurements
 *  estimating the accuracy of measurements in practical contexts and giving suitable lower and upper bounds for measurement values
 *  investigating how calculating and interpreting absolute, relative and percentage errors in measurements relates to artificial intelligence systems such as regression models, estimating uncertainty and recommendation systems
 
-##### AC9M9M05
+##### AC9M9M05 {#ac9m9m05}
 
 use mathematical modelling to solve practical problems involving direct proportion, rates, ratio and scale, including financial contexts; formulate the problems and interpret solutions in terms of the situation; evaluate the model and report methods and findings
 
@@ -158,9 +158,9 @@ use mathematical modelling to solve practical problems involving direct proporti
 *  modelling situations involving the application of rates in practical contexts; for example, density, birth, flow or heartbeats
 *  exploring fire techniques in land management practices used by First Nations Australians that use proportion relationships, including the rate of fire spread in different fuel types to wind speed, temperature and relative humidity
 
-### Space
+### Space {#space}
 
-##### AC9M9SP01
+##### AC9M9SP01 {#ac9m9sp01}
 
 recognise the constancy of the sine, cosine and tangent ratios for a given angle in right-angled triangles using properties of similarity
 
@@ -170,7 +170,7 @@ recognise the constancy of the sine, cosine and tangent ratios for a given angle
 *  establishing an understanding that the sine of an angle can be considered as the length of the altitude of a right-angled triangle with a hypotenuse of length one unit and similarly the cosine as the length of the base of the same triangle, and relating this to enlargement and similar triangles
 *  relating the tangent of an angle to the altitude and base of nested similar right-angled triangles, and connecting the tangent of the angle at which the graph of a straight line meets the positive direction of the horizontal coordinate axis to the gradient of the straight line
 
-##### AC9M9SP02
+##### AC9M9SP02 {#ac9m9sp02}
 
 apply the enlargement transformation to shapes and objects using dynamic geometry software as appropriate; identify and explain aspects that remain the same and those that change
 
@@ -179,7 +179,7 @@ apply the enlargement transformation to shapes and objects using dynamic geometr
 *  using the properties of similarity to solve problems involving enlargement
 *  investigating and generalising patterns in length, angle, area and volume when side lengths of shapes and objects are enlarged or dilated by whole and rational numbers; for example, comparing an enlargement of a square and a cube of side length \(2\) units by a factor of \(3\) increases the area of the square, \(2^2\), to \((3\times2)^2 = 9\times 2^2=9\) times the original area and the volume of the cube, \(2^3\), to \((3\times2)^3=27\times 2^3=27\) times the volume
 
-##### AC9M9SP03
+##### AC9M9SP03 {#ac9m9sp03}
 
 design, test and refine algorithms involving a sequence of steps and decisions based on geometric constructions and theorems; discuss and evaluate refinements
 
@@ -188,9 +188,9 @@ design, test and refine algorithms involving a sequence of steps and decisions b
 *  creating and testing algorithms designed to construct or bisect angles, using pseudocode or flow charts
 *  developing an algorithm for an animation of a geometric construction, or a visual proof, evaluating the algorithm using test cases
 
-### Statistics
+### Statistics {#statistics}
 
-##### AC9M9ST01
+##### AC9M9ST01 {#ac9m9st01}
 
 analyse reports of surveys in digital media and elsewhere for information on how data was obtained to estimate population means and medians
 
@@ -201,7 +201,7 @@ analyse reports of surveys in digital media and elsewhere for information on how
 *  investigating a range of data and its sources; for example, the age of residents in Australia, Cambodia and Tonga; the number of subjects studied at school in a year by \(14\)-year-old students in Australia, Singapore, Japan, South Korea and Timor-Leste
 *  analysing reports of public opinion surveys on environmental issues, such as land clearing, wind farms or single use plastics; discussing methods of data collection and the reasonableness of any inferences made
 
-##### AC9M9ST02
+##### AC9M9ST02 {#ac9m9st02}
 
 analyse how different sampling methods can affect the results of surveys and how choice of representation can be used to support a particular point of view
 
@@ -210,7 +210,7 @@ analyse how different sampling methods can affect the results of surveys and how
 *  discussing the impact of decreased landline usage or an increased aversion to answering calls from unknown numbers on survey data
 *  exploring potential cultural bias relating to First Nations Australians by critically analysing sampling techniques in statistical reports
 
-##### AC9M9ST03
+##### AC9M9ST03 {#ac9m9st03}
 
 represent the distribution of multiple data sets for numerical variables using comparative representations; compare data distributions with consideration of centre, spread and shape, and the effect of outliers on these measures
 
@@ -220,7 +220,7 @@ represent the distribution of multiple data sets for numerical variables using c
 *  constructing grouped histograms that show trends in health issues such as lung cancer, leukemia, stroke and diabetes, and using the graph to justify, verify or invalidate claims
 *  exploring comparative data presented in reports by National Indigenous Australians Agency in regard to “Closing the Gap”, discussing the comparative distributions within the context of the data; for example, comparative data presented in the “Closing the Gap – Prime Minister’s Report”
 
-##### AC9M9ST04
+##### AC9M9ST04 {#ac9m9st04}
 
 choose appropriate forms of display or visualisation for a given type of data; justify selections and interpret displays for a given context
 
@@ -231,7 +231,7 @@ choose appropriate forms of display or visualisation for a given type of data; j
 *  comparing and interpreting stacked bar charts, area charts and line graphs, discussing how they represent larger categories that can be subdivided into smaller categories and how information that can be obtained from these displays can be used for comparison
 *  using digital tools, including generative artificial intelligence, to generate different data displays and visualisations using existing data sets, and discussing which form is more appropriate for the given context
 
-##### AC9M9ST05
+##### AC9M9ST05 {#ac9m9st05}
 
 plan and conduct statistical investigations involving the collection and analysis of different kinds of data; report findings and discuss the strength of evidence to support any conclusions
 
@@ -241,9 +241,9 @@ plan and conduct statistical investigations involving the collection and analysi
 *  investigating where would be the best location for a tropical fruit plantation by conducting a statistical investigation comparing different variables such as the annual rainfall in various parts of Australia, Indonesia, New Guinea and Malaysia, land prices and associated farming costs
 *  posing statistical questions, collecting, representing and interpreting data from different sources in relation to reconciliation, considering the relationships between variables
 
-### Probability
+### Probability {#probability}
 
-##### AC9M9P01
+##### AC9M9P01 {#ac9m9p01}
 
 list all outcomes for compound events both with and without replacement, using lists, tree diagrams, tables or arrays; assign probabilities to outcomes
 
@@ -253,7 +253,7 @@ list all outcomes for compound events both with and without replacement, using l
 *  using a tree diagram to represent a three-stage event and assigning probabilities to these events; for example, selecting \(3\) cards from a deck, assigning the probability of drawing an ace, then a king, then a queen of the same suit, with and without replacing the cards after every draw
 *  assigning probabilities to compound events involving the random selection of people from a given population; for example, selecting \(2\) names at random from all of the students at a high school and assigning the probability that they are both in Year 9
 
-##### AC9M9P02
+##### AC9M9P02 {#ac9m9p02}
 
 calculate relative frequencies from given or collected data to estimate probabilities of events involving “and”, inclusive “or” and exclusive “or”
 
@@ -262,7 +262,7 @@ calculate relative frequencies from given or collected data to estimate probabil
 *  using Venn diagrams or two-way tables to estimate frequencies of events involving “and”, “or” questions
 *  designing, testing and refining an algorithm used to determine relative frequencies from a generated data set, to estimate different probabilities
 
-##### AC9M9P03
+##### AC9M9P03 {#ac9m9p03}
 
 design and conduct repeated chance experiments and simulations, using digital tools to compare probabilities of simple events to related compound events, and describe results
 
@@ -272,7 +272,7 @@ design and conduct repeated chance experiments and simulations, using digital to
 *  conducting two-step chance experiments using systematic methods to list outcomes of experiments and to list outcomes favourable to an event
 *  using repeated trials of First Nations Australian children’s instructive games; for example, Gorri from all parts of Australia, to calculate the probabilities of winning and not winning
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 In Year 9, learning in Mathematics builds on each student’s prior learning and experiences. Students engage in a range of approaches to learning and doing mathematics that develop their understanding of and fluency with concepts, procedures and processes by making connections, reasoning, problem-solving and practice. Proficiency in mathematics enables students to respond to familiar and unfamiliar situations by employing mathematical strategies to make informed decisions and solve problems efficiently.
 

--- a/curriculum/science/foundation-year.md
+++ b/curriculum/science/foundation-year.md
@@ -1,6 +1,6 @@
-# Science - Foundation Year
+# Science - Foundation Year {#science-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 In Foundation, learning in Science builds on the Early Years Learning Framework and each student’s prior learning and experiences. Science encourages students to explore their environment and be curious about their surroundings.
 
@@ -8,21 +8,19 @@ Students build wonder and their natural curiosity by observing everyday objects,
 
 Inquiry questions can help excite students’ curiosity and challenge their thinking. Following are examples of inquiry questions that could be used to prompt discussion and exploration:
 
- 
-
 *   Why do we have different senses? How do we use them?
 *   Why is sorting important?
 *   How are a spider and a fly alike and different?
 *   Are wheels the only way to get around?
 *   Why do people describe things differently?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Biological sciences
+#### Biological sciences {#biological-sciences}
 
-##### AC9SFU01
+##### AC9SFU01 {#ac9sfu01}
 
 observe external features of plants and animals and describe ways they can be grouped based on these features
 
@@ -34,9 +32,9 @@ observe external features of plants and animals and describe ways they can be gr
 *  recognising First Nations Australians’ use of observable features to group living things
 *  exploring how First Nations Australians’ observations of external features of living things are replicated in traditional dance
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9SFU02
+##### AC9SFU02 {#ac9sfu02}
 
 describe how objects move and how factors including their size, shape or material influence their movement
 
@@ -47,9 +45,9 @@ describe how objects move and how factors including their size, shape or materia
 *  exploring how the material a ball is made from affects the way it moves, such as plastic, foam, cloth or rubber balls on a surface
 *  exploring how the size and shape of traditional instructive toys used by First Nations Australians influence their movement
 
-#### Chemical sciences
+#### Chemical sciences {#chemical-sciences}
 
-##### AC9SFU03
+##### AC9SFU03 {#ac9sfu03}
 
 recognise that objects can be composed of different materials and describe the observable properties of those materials
 
@@ -62,11 +60,11 @@ recognise that objects can be composed of different materials and describe the o
 *  suggesting why different parts of everyday objects, such as saucepans and clothing, are made from different materials
 *  investigating the ways in which First Nations Australians make utensils for different purposes by combining different materials
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9SFH01
+##### AC9SFH01 {#ac9sfh01}
 
 explore the ways people make and use observations and questions to learn about the natural world
 
@@ -77,11 +75,11 @@ explore the ways people make and use observations and questions to learn about t
 *  interacting with stories or documentaries about scientists such as Dame Jane Goodall or Sir Joseph Banks and noticing the ways they make their observations such as through drawings, collections, sound recordings and photography and how they ask questions about what they think they will observe and find
 *  watching an age-appropriate documentary; noticing how people including scientists, engineers, naturalists or citizen scientists ask questions; and posing their own questions
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9SFI01
+##### AC9SFI01 {#ac9sfi01}
 
 pose questions and make predictions based on experiences
 
@@ -91,9 +89,9 @@ pose questions and make predictions based on experiences
 *  making predictions before field work, such as which plants and animals they may observe in the school grounds
 *  making predictions about how an unusually shaped object such as an egg or a hexagonal block might move down a slope
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9SFI02
+##### AC9SFI02 {#ac9sfi02}
 
 engage in investigations safely and make observations using their senses
 
@@ -103,9 +101,9 @@ engage in investigations safely and make observations using their senses
 *  using provided tools such as binoculars, magnifying glasses, digital photography or video to enhance their observations of plants and animals
 *  recording observations using numbers, dots, drawings, voice recordings, digital photography or video
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9SFI03
+##### AC9SFI03 {#ac9sfi03}
 
 represent observations in provided templates and identify patterns with guidance
 
@@ -116,9 +114,9 @@ represent observations in provided templates and identify patterns with guidance
 *  identifying patterns of movement of objects, with guidance, such as that balls roll easily in a straight line when pushed, or toy cars move in certain ways because of their wheels
 *  identifying patterns in uses of everyday objects made of similar materials, such as wood, plastic, metal or glass
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9SFI04
+##### AC9SFI04 {#ac9sfi04}
 
 compare observations with predictions with guidance
 
@@ -127,9 +125,9 @@ compare observations with predictions with guidance
 *  comparing, with guidance, observations of plants or animals made during field work with their predictions
 *  using a provided table to draw or dictate their prediction and their observation and identifying whether they are the same or different
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9SFI05
+##### AC9SFI05 {#ac9sfi05}
 
 share questions, predictions, observations and ideas with others
 
@@ -142,7 +140,7 @@ share questions, predictions, observations and ideas with others
 *  representing external features of animals and plants using a range of materials such as blocks, modelling clay, craft materials or paper
 *  communicating questions, predictions and observations using posters, collages, digital displays, drawings or storyboards
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Foundation students group plants and animals based on external features. They identify factors that influence the movement of objects. They describe the observable properties of the materials that make up objects. They identify examples of people using observation and questioning to learn about the natural world.
 

--- a/curriculum/science/year-1.md
+++ b/curriculum/science/year-1.md
@@ -1,6 +1,6 @@
-# Science - Year 1
+# Science - Year 1 {#science-year-1}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 1 students extend their understanding of patterns by exploring patterns in daily and seasonal events, recognising that all living things share the same basic needs, and that objects can behave in predictable ways. They infer relationships from their observations and experiences and begin to link function with observable properties.
 
@@ -14,13 +14,13 @@ Inquiry questions can help excite students’ curiosity and challenge their thin
 *   How can we tell if something has changed?
 *   How does science help us care for ourselves and other living things?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Biological sciences
+#### Biological sciences {#biological-sciences}
 
-##### AC9S1U01
+##### AC9S1U01 {#ac9s1u01}
 
 identify the basic needs of plants and animals, including air, water, food or shelter, and describe how the places they live meet those needs
 
@@ -32,9 +32,9 @@ identify the basic needs of plants and animals, including air, water, food or sh
 *  recognising how First Nations Australians care for living things
 *  exploring why caring for plants and animals is important including as sources of food and fibre
 
-#### Earth and space sciences
+#### Earth and space sciences {#earth-and-space-sciences}
 
-##### AC9S1U02
+##### AC9S1U02 {#ac9s1u02}
 
 describe daily and seasonal changes in the environment and explore how these changes affect everyday life
 
@@ -47,9 +47,9 @@ describe daily and seasonal changes in the environment and explore how these cha
 *  recognising the extensive knowledges of daily and seasonal changes in weather patterns and landscape held by First Nations Australians
 *  exploring how First Nations Australians’ concepts of time and weather patterns explain how things happen in the world around them
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9S1U03
+##### AC9S1U03 {#ac9s1u03}
 
 describe pushes and pulls in terms of strength and direction and predict the effect of these forces on objects’ motion and shape
 
@@ -62,11 +62,11 @@ describe pushes and pulls in terms of strength and direction and predict the eff
 *  investigating the push and pull movements of traditional First Nations Australians children’s instructive toys
 *  exploring how traditional Asian toys and games such as a kendama, Daruma Otoshi or shuttlecock are played using a push or pull
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9S1H01
+##### AC9S1H01 {#ac9s1h01}
 
 describe how people use science in their daily lives, including using patterns to make scientific predictions
 
@@ -80,11 +80,11 @@ describe how people use science in their daily lives, including using patterns t
 *  identifying how we use pushes and pulls when preparing meals, and the tools that help us push or pull objects
 *  exploring how engineers use knowledge of forces to create new playground equipment or toys
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9S1I01
+##### AC9S1I01 {#ac9s1i01}
 
 pose questions to explore observed simple patterns and relationships and make predictions based on experiences
 
@@ -95,9 +95,9 @@ pose questions to explore observed simple patterns and relationships and make pr
 *  making predictions about types of animals and plants they might observe in a particular place, such as a garden or pond
 *  making predictions about patterns of observable phenomena such as seasonal changes of plants or changes in temperatures across the seasons
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9S1I02
+##### AC9S1I02 {#ac9s1i02}
 
 suggest and follow safe procedures to investigate questions and test predictions
 
@@ -107,7 +107,7 @@ suggest and follow safe procedures to investigate questions and test predictions
 *  exploring different ways of investigating science questions through guided discussion
 *  suggesting steps for setting up and packing away equipment
 
-##### AC9S1I03
+##### AC9S1I03 {#ac9s1i03}
 
 make and record observations, including informal measurements, using digital tools as appropriate
 
@@ -117,9 +117,9 @@ make and record observations, including informal measurements, using digital too
 *  making suggestions about types of measurements that may be made during an investigation, including using blocks to measure plant growth or paces to measure how far an object has moved
 *  recording observations through text, drawing, counts, informal measurements, digital photography or video
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9S1I04
+##### AC9S1I04 {#ac9s1i04}
 
 sort and order data and information and represent patterns, including with provided tables and visual or physical models
 
@@ -130,9 +130,9 @@ sort and order data and information and represent patterns, including with provi
 *  ordering images of seasonal changes across the year
 *  using graphic organisers to sort data into groups, such as plants and animals, or objects around the home that need a push or pull force to work
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9S1I05
+##### AC9S1I05 {#ac9s1i05}
 
 compare observations with predictions and others’ observations, consider if investigations are fair and identify further questions with guidance
 
@@ -143,9 +143,9 @@ compare observations with predictions and others’ observations, consider if in
 *  comparing observations of movement with predictions, such as how far an object travels
 *  exploring if all ‘big’ pushes are the same by comparing how far an object travels with different students doing the pushing, and discussing how they could have made the investigation fairer
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9S1I06
+##### AC9S1I06 {#ac9s1i06}
 
 write and create texts to communicate observations, findings and ideas, using everyday and scientific vocabulary
 
@@ -157,7 +157,7 @@ write and create texts to communicate observations, findings and ideas, using ev
 *  representing push and pull forces using role-play, labels, arrows or time lapse drawings and describing their representation using everyday and scientific vocabulary
 *  role-playing or recounting how people they know or have observed identify and use patterns to make predictions at work or in their daily lives
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 1 students identify how living things meet their needs in the places they live. They identify daily and seasonal changes and describe ways these changes affect their everyday life. They describe how different pushes and pulls change the motion and shape of objects. They describe situations where they use science in their daily lives and identify examples of people making scientific predictions.
 

--- a/curriculum/science/year-10.md
+++ b/curriculum/science/year-10.md
@@ -1,6 +1,6 @@
-# Science - Year 10
+# Science - Year 10 {#science-year-10}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 10 students explore the biological, chemical, geological and astronomical evidence for different theories, such as the theory of natural selection and the big bang theory. Through investigating natural selection and processes of heredity they come to understand the evolutionary feedback mechanisms that ensure the continuity of life. They appreciate how energy drives the Earth system and how climate models simulate the flow of energy and matter within and between Earth’s spheres. Students develop a more sophisticated understanding of atomic theory to understand patterns and relationships within the periodic table. They understand that motion and forces are related by applying physical laws and can be modelled mathematically. Students analyse and synthesise data from systems at multiple scales to develop evidence-based explanations for phenomena. They learn that all models involve assumptions and approximations, and that this can limit the reliability of predictions based on those models.
 
@@ -12,13 +12,13 @@ Inquiry questions can help excite students’ curiosity and challenge their thin
 *   Just because we can, should we?
 *   How have advanced computing and big data changed science?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Biological sciences
+#### Biological sciences {#biological-sciences}
 
-##### AC9S10U01
+##### AC9S10U01 {#ac9s10u01}
 
 explain the role of meiosis and mitosis and the function of chromosomes, DNA and genes in heredity and predict patterns of Mendelian inheritance
 
@@ -31,7 +31,7 @@ explain the role of meiosis and mitosis and the function of chromosomes, DNA and
 *  exploring environmental and other factors that cause mutations and identifying changes in DNA or chromosomes
 *  exploring the role of DNA in cancer or genetic disorders such as haemochromatosis, sickle cell anaemia, cystic fibrosis or Klinefelter syndrome
 
-##### AC9S10U02
+##### AC9S10U02 {#ac9s10u02}
 
 use the theory of evolution by natural selection to explain past and present diversity and analyse the scientific evidence supporting the theory
 
@@ -43,9 +43,9 @@ use the theory of evolution by natural selection to explain past and present div
 *  relating genetic characteristics to survival and reproductive rates
 *  investigating some of the structural and physiological adaptations of First Nations Australians to the Australian environment
 
-#### Earth and space sciences
+#### Earth and space sciences {#earth-and-space-sciences}
 
-##### AC9S10U03
+##### AC9S10U03 {#ac9s10u03}
 
 describe how the big bang theory models the origin and evolution of the universe and analyse the supporting evidence for the theory
 
@@ -58,7 +58,7 @@ describe how the big bang theory models the origin and evolution of the universe
 *  identifying the different technologies used to collect astronomical data and the types of data collected
 *  exploring recent advances in astronomy, including the Australian Square Kilometre Array Pathfinder, and astrophysics, such as the discovery of gravitational waves, dark matter and dark energy; and identifying new knowledge which has emerged
 
-##### AC9S10U04
+##### AC9S10U04 {#ac9s10u04}
 
 use models of energy flow between the geosphere, biosphere, hydrosphere and atmosphere to explain patterns of global climate change
 
@@ -70,9 +70,9 @@ use models of energy flow between the geosphere, biosphere, hydrosphere and atmo
 *  investigating how quantum computers enhance modelling of complex weather and climate systems
 *  predicting changes to the Earth system and identifying strategies designed to reduce climate change or mitigate its effects
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9S10U05
+##### AC9S10U05 {#ac9s10u05}
 
 investigate Newton’s laws of motion and quantitatively analyse the relationship between force, mass and acceleration of objects
 
@@ -85,9 +85,9 @@ investigate Newton’s laws of motion and quantitatively analyse the relationshi
 *  constructing an argument, supported by data, to support lower speed limits near schools or for trucks in urban environments
 *  investigating how driverless vehicles apply Newton’s laws of motion to brake in time
 
-#### Chemical sciences
+#### Chemical sciences {#chemical-sciences}
 
-##### AC9S10U06
+##### AC9S10U06 {#ac9s10u06}
 
 explain how the structure and properties of atoms relate to the organisation of the elements in the periodic table
 
@@ -99,7 +99,7 @@ explain how the structure and properties of atoms relate to the organisation of 
 *  conducting flame tests for a selection of elements and examining emission spectra
 *  examining how the development of the spectroscope led to further development of the model of the atom
 
-##### AC9S10U07
+##### AC9S10U07 {#ac9s10u07}
 
 identify patterns in synthesis, decomposition and displacement reactions and investigate the factors that affect reaction rates
 
@@ -112,11 +112,11 @@ identify patterns in synthesis, decomposition and displacement reactions and inv
 *  investigating some of the chemical reactions and methods employed by First Nations Australians to convert toxic plants into edible food products
 *  examining reactions that are used to produce a range of useful products
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Nature and development of science
+#### Nature and development of science {#nature-and-development-of-science}
 
-##### AC9S10H01
+##### AC9S10H01 {#ac9s10h01}
 
 explain how scientific knowledge is validated and refined, including the role of publication and peer review
 
@@ -128,7 +128,7 @@ explain how scientific knowledge is validated and refined, including the role 
 *  examining how the discovery of gravity waves validated Einstein’s theory of general relativity and why this discovery did not occur until 100 years after the theory was proposed
 *  investigating how the development of the periodic table has been disputed and refined as science has progressed and new elements have been discovered
 
-##### AC9S10H02
+##### AC9S10H02 {#ac9s10h02}
 
 investigate how advances in technologies enable advances in science, and how science has contributed to developments in technologies and engineering
 
@@ -142,9 +142,9 @@ investigate how advances in technologies enable advances in science, and how sci
 *  exploring how the development of new materials and thin films has led to better computer chips and solar cells
 *  investigating how the development of superstrong, lighter alloys has enabled engineers to improve structural components in building, transportation and industry and to design products such as improved protective armour for police and soldiers
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9S10H03
+##### AC9S10H03 {#ac9s10h03}
 
 analyse the key factors that contribute to science knowledge and practices being adopted more broadly by society
 
@@ -156,7 +156,7 @@ analyse the key factors that contribute to science knowledge and practices being
 *  discussing citizen science projects such as the GLOBE Project or others of local relevance and examining why people would choose to be involved
 *  considering how the traditional ecological knowledges of First Nations Australians are being reaffirmed by modern science and how these practices are being used by Traditional Owners in carbon farming initiatives
 
-##### AC9S10H04
+##### AC9S10H04 {#ac9s10h04}
 
 examine how the values and needs of society influence the focus of scientific research
 
@@ -166,11 +166,11 @@ examine how the values and needs of society influence the focus of scientific re
 *  recognising that financial backing from governments or commercial organisations is needed for scientific developments and that this can determine what research is carried out
 *  examining the link between scientific research and real-world applications such as space research and new material development
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9S10I01
+##### AC9S10I01 {#ac9s10i01}
 
 develop investigable questions, reasoned predictions and hypotheses to test relationships and develop explanatory models
 
@@ -181,9 +181,9 @@ develop investigable questions, reasoned predictions and hypotheses to test rela
 *  asking questions about the relationship between crash impact force and speed and developing a hypothesis which can then be tested
 *  observing how changing the surface area, concentration and temperature affects the rate of a chemical reaction and developing reasoned predictions
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9S10I02
+##### AC9S10I02 {#ac9s10i02}
 
 plan and conduct valid, reproducible investigations to answer questions and test hypotheses, including identifying and controlling for possible sources of error and, as appropriate, developing and following risk assessments, considering ethical issues, and addressing key considerations regarding heritage sites and artefacts on Country/Place
 
@@ -196,7 +196,7 @@ plan and conduct valid, reproducible investigations to answer questions and test
 *  modelling how to report the discovery of unregistered First Nations Australians artefacts and heritage or any unauthorised disturbance
 *  considering the ethical and social issues and legal responsibilities involved in the care and use of animals for scientific purposes before starting an investigation involving animals
 
-##### AC9S10I03
+##### AC9S10I03 {#ac9s10i03}
 
 select and use equipment to generate and record data with precision to obtain useful sample sizes and replicable data, using digital tools as appropriate
 
@@ -206,9 +206,9 @@ select and use equipment to generate and record data with precision to obtain us
 *  identifying how human error can affect replicability and reproducibility
 *  deciding how much data is needed to produce valid conclusions
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9S10I04
+##### AC9S10I04 {#ac9s10i04}
 
 select and construct appropriate representations, including tables, graphs, descriptive statistics, models and mathematical relationships, to organise and process data and information
 
@@ -220,7 +220,7 @@ select and construct appropriate representations, including tables, graphs, desc
 *  evaluating the merits and limitations of time-lapse visual representations of changes in polar ice coverage with a mathematical representation
 *  comparing merits and limitations of patterns as represented by the periodic table with graphical representations of patterns such as melting point or boiling point, and with consideration of anomalies
 
-##### AC9S10I05
+##### AC9S10I05 {#ac9s10i05}
 
 analyse and connect a variety of data and information to identify and explain patterns, trends, relationships and anomalies
 
@@ -231,9 +231,9 @@ analyse and connect a variety of data and information to identify and explain pa
 *  representing speed and acceleration data from investigations or simulations in tables and graphs and comparing how these facilitate the identification of relationships
 *  exploring how different interpretations can be made from data that is organised or processed in different ways, and the implications of this for data analysis
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9S10I06
+##### AC9S10I06 {#ac9s10i06}
 
 assess the validity and reproducibility of methods and evaluate the validity of conclusions and claims, including by identifying assumptions, conflicting evidence and areas of uncertainty
 
@@ -245,7 +245,7 @@ assess the validity and reproducibility of methods and evaluate the validity of 
 *  considering how data variation can indicate uncertainty and might affect confidence in conclusions reached and claims made
 *  analysing conclusions and claims to identify facts or premises that are taken for granted to be true, and evaluating the reasonableness of those assumptions
 
-##### AC9S10I07
+##### AC9S10I07 {#ac9s10i07}
 
 construct arguments based on analysis of a variety of evidence to support conclusions or evaluate claims, and consider any ethical issues and cultural protocols associated with accessing, using or citing secondary data or information
 
@@ -259,9 +259,9 @@ construct arguments based on analysis of a variety of evidence to support conclu
 *  using primary or secondary scientific evidence to support or oppose a local action that may impact on global climate change
 *  preparing an argument for increased funding for a particular scientific research focus
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9S10I08
+##### AC9S10I08 {#ac9s10i08}
 
 write and create texts to communicate ideas, findings and arguments effectively for identified purposes and audiences, including selection of appropriate content, language and text features, using digital tools as appropriate
 
@@ -273,7 +273,7 @@ write and create texts to communicate ideas, findings and arguments effectively 
 *  using animation or comic strip software to create an explanation of the Big Bang for an audience of their peers
 *  creating a campaign to lower speed limits in specific areas of the local community
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 10 students explain the processes that underpin heredity and genetic diversity and describe the evidence supporting the theory of evolution by natural selection. They sequence key events in the origin and evolution of the universe and describe the supporting evidence for the big bang theory. They describe trends in patterns of global climate change and identify causal factors. They explain how Newton’s laws describe motion and apply them to predict motion of objects in a system. They explain patterns and trends in the periodic table and predict the products of reactions and the effect of changing reactant and reaction conditions. Students analyse the importance of publication and peer review in the development of scientific knowledge and analyse the relationship between science, technologies and engineering. They analyse the key factors that influence interactions between science and society.
 

--- a/curriculum/science/year-2.md
+++ b/curriculum/science/year-2.md
@@ -1,6 +1,6 @@
-# Science - Year 2
+# Science - Year 2 {#science-year-2}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 2 students build on their experiences of the natural and physical world to identify the components of simple systems. They appreciate that Earth is a planet in space and identify other celestial objects. They explore the ways components in a system interact, such as by using their bodies or combining and manipulating objects to make sounds. They build on their understanding of properties of materials to recognise that those properties stay the same when the material is changed physically. They continue to build their understanding of patterns by observing that some patterns, such as the changing positions of the sun, moon and stars, can only be observed over certain timescales. As they explore patterns and relationships, they use counting and informal measurements to make and compare observations and recognise that organising these observations in tables makes it easier to identify and represent patterns. They appreciate that science involves making and organising observations to identify patterns and relationships, and that these patterns and relationships are the basis of scientific predictions.
 
@@ -12,13 +12,13 @@ Inquiry questions can help excite students’ curiosity and challenge their thin
 *   What’s the best material? Why?
 *   How does the sky change over time?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Earth and space sciences
+#### Earth and space sciences {#earth-and-space-sciences}
 
-##### AC9S2U01
+##### AC9S2U01 {#ac9s2u01}
 
 recognise Earth is a planet in the solar system and identify patterns in the changing position of the sun, moon, planets and stars in the sky
 
@@ -34,9 +34,9 @@ recognise Earth is a planet in the solar system and identify patterns in the cha
 *  distinguishing between regular events that occur in the sky, such as the appearance of a full moon, and irregular events such as ‘blue’, ‘blood’ or ‘super’ moons
 *  exploring how cultural stories of First Nations Peoples of Australia describe the patterns in the changing positions of the sun, moon and stars
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9S2U02
+##### AC9S2U02 {#ac9s2u02}
 
 explore different actions to make sounds and how to make a variety of sounds, and recognise that sound energy causes objects to vibrate
 
@@ -51,9 +51,9 @@ explore different actions to make sounds and how to make a variety of sounds, an
 *  designing and making instruments that produce different sounds, such as drums, rain makers, thongophones or box guitars
 *  discussing situations in which they have heard echoes and exploring how humans with vision impairment and other animals such as dolphins and bats use echolocation to locate objects in their environments
 
-#### Chemical sciences
+#### Chemical sciences {#chemical-sciences}
 
-##### AC9S2U03
+##### AC9S2U03 {#ac9s2u03}
 
 recognise that materials can be changed physically without changing their material composition and explore the effect of different actions on materials including bending, twisting, stretching and breaking into smaller pieces
 
@@ -64,11 +64,11 @@ recognise that materials can be changed physically without changing their materi
 *  exploring how First Nations Australians make physical changes to natural materials to produce objects such as bowls, baskets and various fibre crafts
 *  creating an ‘odd one out’ game by providing samples of the same material that has been physically changed in different ways, and one sample of a different material, and challenging other students to identify the odd one out
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9S2H01
+##### AC9S2H01 {#ac9s2h01}
 
 describe how people use science in their daily lives, including using patterns to make scientific predictions
 
@@ -83,11 +83,11 @@ describe how people use science in their daily lives, including using patterns t
 *  exploring how physically changing materials helps us to re-use them in a variety of ways, and decrease waste
 *  considering how First Nations Australians use scientific practices such as sorting, classification and estimation to make predictions
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9S2I01
+##### AC9S2I01 {#ac9s2i01}
 
 pose questions to explore observed simple patterns and relationships and make predictions based on experiences
 
@@ -98,9 +98,9 @@ pose questions to explore observed simple patterns and relationships and make pr
 *  making predictions about the relationship between vibration and sound, such as: ‘I think that if a ruler is twanged harder, it will make a louder sound’
 *  making predictions about future appearances of phenomena in the sky at certain times of the week, month or year, such as the moon or satellites
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9S2I02
+##### AC9S2I02 {#ac9s2i02}
 
 suggest and follow safe procedures to investigate questions and test predictions
 
@@ -110,7 +110,7 @@ suggest and follow safe procedures to investigate questions and test predictions
 *  following visual or verbal steps to construct a musical instrument or manipulate a material
 *  suggesting ways they could manipulate materials and tools they could use
 
-##### AC9S2I03
+##### AC9S2I03 {#ac9s2i03}
 
 make and record observations, including informal measurements, using digital tools as appropriate
 
@@ -121,9 +121,9 @@ make and record observations, including informal measurements, using digital too
 *  representing informal measurements with concrete objects, such as drawing chalk lines and using lengths of string to measure shadows
 *  exploring how digital tools can be used to make observations, such as simple clap-o-meter apps that measure sound volume, time lapse digital photography for observing apparent movement of celestial objects or slow-motion videos for observing a vibrating ruler
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9S2I04
+##### AC9S2I04 {#ac9s2i04}
 
 sort and order data and information and represent patterns, including with provided tables and visual or physical models
 
@@ -134,9 +134,9 @@ sort and order data and information and represent patterns, including with provi
 *  constructing simple column graphs and picture graphs with guidance to represent class investigations, such as recording objects that produce or do not produce sound
 *  completing a table to record the number of ways different materials can be changed physically
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9S2I05
+##### AC9S2I05 {#ac9s2i05}
 
 compare observations with predictions and others’ observations, consider if investigations are fair and identify further questions with guidance
 
@@ -146,9 +146,9 @@ compare observations with predictions and others’ observations, consider if in
 *  proposing ways to ensure that the same sound is produced in an investigation in order to keep the investigation fair
 *  comparing findings from investigations about physically changing a material, such as cutting and folding, and exploring questions that investigate similar changes to different materials
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9S2I06
+##### AC9S2I06 {#ac9s2i06}
 
 write and create texts to communicate observations, findings and ideas, using everyday and scientific vocabulary
 
@@ -161,7 +161,7 @@ write and create texts to communicate observations, findings and ideas, using ev
 *  presenting findings of investigations using charts, read-alouds, slideshows or displays using everyday and scientific vocabulary
 *  acknowledging and learning about First Nations Australians’ ways of sharing astronomical knowledge across generations through oral traditions that include cultural accounts, stories, song and dance
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 2 students identify celestial objects and describe patterns they observe in the sky. They demonstrate how different sounds can be produced and describe the effect of sound energy on objects. They identify ways to change materials without changing their material composition. They describe how people use science in their daily lives and how people use patterns to make scientific predictions.
 

--- a/curriculum/science/year-3.md
+++ b/curriculum/science/year-3.md
@@ -1,6 +1,6 @@
-# Science - Year 3
+# Science - Year 3 {#science-year-3}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 3 students explore the value of grouping and classifying objects and events based on similarities and differences. In classifying things as living or non-living they begin to recognise that classifications are not always easy to define or apply. Students contrast patterns of growth and change in living things; compare characteristics of soils, rocks and minerals; and classify states of matter. They learn that key processes such as heat transfer can cause predictable change in simple systems. They recognise that change is described and measured in terms of differences over time and begin to quantify their observations to enable comparison. They learn more-sophisticated ways of identifying and representing relationships, including the use of tables and graphs to identify patterns and relationships. They appreciate that science involves conducting fair tests to answer questions or test predictions, and that scientific explanations are based on data.
 
@@ -12,13 +12,13 @@ Inquiry questions can help excite students’ curiosity and challenge their thin
 *   Why is a spoon hot in soup and cold in ice cream?
 *   Can you do science without a fair test?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Biological sciences
+#### Biological sciences {#biological-sciences}
 
-##### AC9S3U01
+##### AC9S3U01 {#ac9s3u01}
 
 compare characteristics of living and non-living things and examine the differences between the life cycles of plants and animals
 
@@ -29,9 +29,9 @@ compare characteristics of living and non-living things and examine the differen
 *  representing stages of a plant or animal’s life cycle using drawings, digital photographs, graphic organisers or concrete materials
 *  investigating how First Nations Australians understand and utilise the life cycles of certain species
 
-#### Earth and space sciences
+#### Earth and space sciences {#earth-and-space-sciences}
 
-##### AC9S3U02
+##### AC9S3U02 {#ac9s3u02}
 
 compare the observable properties of soils, rocks and minerals and investigate why they are important Earth resources
 
@@ -45,9 +45,9 @@ compare the observable properties of soils, rocks and minerals and investigate w
 *  examining information on plant tags and exploring the vocabulary used to describe soils and different plant soil requirements
 *  investigating which rocks or minerals are quarried or mined locally or regionally and how those resources are used
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9S3U03
+##### AC9S3U03 {#ac9s3u03}
 
 identify sources of heat energy and examine how temperature changes when heat energy is transferred from one object to another
 
@@ -59,9 +59,9 @@ identify sources of heat energy and examine how temperature changes when heat en
 *  investigating how well heat is transferred by different types of materials such as metals, plastics and ceramics and identifying how materials are used to keep things hot and cold
 *  exploring how First Nations Australians developed clothing from animal skins such as possum furs and kangaroo skin cloaks that trap heat close to the body to stay warm
 
-#### Chemical sciences
+#### Chemical sciences {#chemical-sciences}
 
-##### AC9S3U04
+##### AC9S3U04 {#ac9s3u04}
 
 investigate the observable properties of solids and liquids and how adding or removing heat energy leads to a change of state
 
@@ -72,11 +72,11 @@ investigate the observable properties of solids and liquids and how adding or re
 *  investigating how changes of state in materials used by First Nations Australians such as beeswax or resins are important for their use
 *  exploring how changes from solid to liquid and liquid to solid can help us recycle materials such as glass or plastics
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Nature and development of science
+#### Nature and development of science {#nature-and-development-of-science}
 
-##### AC9S3H01
+##### AC9S3H01 {#ac9s3h01}
 
 examine how people use data to develop scientific explanations
 
@@ -87,9 +87,9 @@ examine how people use data to develop scientific explanations
 *  exploring age-appropriate science reports and journal articles and identifying where in the text the author has included data, findings or explanations
 *  viewing a documentary or webinar and observing how scientists and researchers share their data and explanations
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9S3H02
+##### AC9S3H02 {#ac9s3h02}
 
 consider how people use scientific explanations to meet a need or solve a problem
 
@@ -101,11 +101,11 @@ consider how people use scientific explanations to meet a need or solve a proble
 *  exploring how science knowledge of heat transfer has helped people develop different ways to cook food, such as by boiling, frying or roasting
 *  investigating how engineers test the insulation properties of materials, and how this information is used to design food and beverage packaging, building insulation or clothing
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9S3I01
+##### AC9S3I01 {#ac9s3i01}
 
 pose questions to explore observed patterns and relationships and make predictions based on observations
 
@@ -118,9 +118,9 @@ pose questions to explore observed patterns and relationships and make predictio
 *  predicting which material will be the most effective insulator of heat
 *  predicting how quickly ice will melt at different ambient temperatures based on previous observations
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9S3I02
+##### AC9S3I02 {#ac9s3i02}
 
 use provided scaffolds to plan and conduct investigations to answer questions or test predictions, including identifying the elements of fair tests, and considering the safe use of materials and equipment
 
@@ -132,7 +132,7 @@ use provided scaffolds to plan and conduct investigations to answer questions or
 *  discussing safety rules to follow when conducting investigations, such as following teacher instructions, manipulating equipment and materials with care and wearing appropriate personal safety gear, such as gloves, safety goggles and face masks when handling soils
 *  consulting with First Nations Australians to guide the planning of scientific investigations, including safety considerations for field investigations
 
-##### AC9S3I03
+##### AC9S3I03 {#ac9s3i03}
 
 follow procedures to make and record observations, including making formal measurements using familiar scaled instruments and using digital tools as appropriate
 
@@ -142,9 +142,9 @@ follow procedures to make and record observations, including making formal measu
 *  collaboratively designing a table to collect observations in the form of numerical data, written descriptions, drawings or photos
 *  identifying and taking on roles in group work, such as setting up the equipment, making observations, recording observations and ensuring safe behaviours
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9S3I04
+##### AC9S3I04 {#ac9s3i04}
 
 construct and use representations, including tables, simple column graphs and visual or physical models, to organise data and information, show simple relationships and identify patterns
 
@@ -155,9 +155,9 @@ construct and use representations, including tables, simple column graphs and vi
 *  using graphic organisers to compare properties of solids and liquids
 *  using column graphs to show melting time for ice in containers with different insulating layers
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9S3I05
+##### AC9S3I05 {#ac9s3i05}
 
 compare findings with those of others, consider if investigations were fair, identify questions for further investigation and draw conclusions
 
@@ -167,9 +167,9 @@ compare findings with those of others, consider if investigations were fair, ide
 *  drawing conclusions based on consideration of their own and others’ findings
 *  identifying further questions for investigation based on observations, differences in findings or new ideas
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9S3I06
+##### AC9S3I06 {#ac9s3i06}
 
 write and create texts to communicate findings and ideas for identified purposes and audiences, using scientific vocabulary and digital tools as appropriate
 
@@ -182,7 +182,7 @@ write and create texts to communicate findings and ideas for identified purposes
 *  creating an advertisement to promote a new insulated container design to parents of primary-school-aged children
 *  representing heat transfer using diagrams, digital drawings, arrows or labels using scientific vocabulary
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 3 students classify and compare living and non-living things and different life cycles. They describe the observable properties of soils, rocks and minerals and describe their importance as resources. They identify sources of heat energy and examples of heat transfer and explain changes in the temperature of objects. They classify solids and liquids based on observable properties and describe how to cause a change of state. They describe how people use data to develop explanations. They identify solutions that use scientific explanations.
 

--- a/curriculum/science/year-4.md
+++ b/curriculum/science/year-4.md
@@ -1,6 +1,6 @@
-# Science - Year 4
+# Science - Year 4 {#science-year-4}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 4 students extend their understanding of systems as interactions between related components and analyse patterns to identify that these interactions can occur in predictable ways. They classify system components and create simple models of system interactions, such as food chains and representations of the water cycle. They learn that these models can be used to predict the effect of missing or malfunctioning components. They explore the relationship between form and function by investigating different materials and their properties and learn that classification can enable prediction. They investigate forces that operate from a distance and learn that some interactions result from phenomena that cannot be seen with the naked eye. Students use fair testing to explore relationships between system components. They appreciate the value of using standard units of measurement to measure and compare attributes of systems and the importance of fair methods for drawing conclusions.
 
@@ -12,13 +12,13 @@ Inquiry questions can help excite students’ curiosity and challenge their thin
 *   How does friction help or hinder motion?
 *   What’s the big deal about the water cycle?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Biological sciences
+#### Biological sciences {#biological-sciences}
 
-##### AC9S4U01
+##### AC9S4U01 {#ac9s4u01}
 
 explain the roles and interactions of consumers, producers and decomposers within a habitat and how food chains represent feeding relationships
 
@@ -31,9 +31,9 @@ explain the roles and interactions of consumers, producers and decomposers withi
 *  investigating the impact of introduced predators such as foxes on small mammal species in Australia
 *  researching how the removal of a food source from within a habitat, such as through an insect or rodent infestation, affected other living things within that habitat
 
-#### Earth and space sciences
+#### Earth and space sciences {#earth-and-space-sciences}
 
-##### AC9S4U02
+##### AC9S4U02 {#ac9s4u02}
 
 identify sources of water and describe key processes in the water cycle, including movement of water through the sky, landscape and ocean; precipitation; evaporation; and condensation
 
@@ -47,9 +47,9 @@ identify sources of water and describe key processes in the water cycle, includi
 *  recognising First Nations Australians’ knowledges and understandings of evaporation and how the effect of evaporation can be reduced to conserve water, such as by covering surfaces
 *  considering why we are encouraged to save and recycle water, and actions people can take to reduce water consumption and waste
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9S4U03
+##### AC9S4U03 {#ac9s4u03}
 
 identify how forces can be exerted by one object on another and investigate the effect of frictional, gravitational and magnetic forces on the motion of objects
 
@@ -63,9 +63,9 @@ identify how forces can be exerted by one object on another and investigate the 
 *  watching a video of astronauts walking on the moon or dropping objects on its surface, and discussing the force they are observing
 *  exploring how force arrows can be used to represent the direction and magnitude of forces acting on an object
 
-#### Chemical sciences
+#### Chemical sciences {#chemical-sciences}
 
-##### AC9S4U04
+##### AC9S4U04 {#ac9s4u04}
 
 examine the properties of natural and made materials including fibres, metals, glass and plastics and consider how these properties influence their use
 
@@ -77,11 +77,11 @@ examine the properties of natural and made materials including fibres, metals, g
 *  designing, building and testing an object or structure for a specific purpose, such as a tent, lunchbox or bird feeder
 *  investigating which materials can be recycled and researching alternatives for materials such as single use plastics
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Nature and development of science
+#### Nature and development of science {#nature-and-development-of-science}
 
-##### AC9S4H01
+##### AC9S4H01 {#ac9s4h01}
 
 examine how people use data to develop scientific explanations
 
@@ -92,9 +92,9 @@ examine how people use data to develop scientific explanations
 *  explore how hydrologists use rainfall and water use data to explain the amount of water flowing in rivers and why this changes over time
 *  investigating how First Nations Australians test predictions and gather data in the development of technologies and processes
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9S4H02
+##### AC9S4H02 {#ac9s4h02}
 
 consider how people use scientific explanations to meet a need or solve a problem
 
@@ -106,11 +106,11 @@ consider how people use scientific explanations to meet a need or solve a proble
 *  examining how people use knowledge of friction to improve car or bicycle safety on slippery surfaces such as wet or icy roads
 *  investigating how knowledge of magnetic force is used to sort metals in recycling, mining and food processing
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9S4I01
+##### AC9S4I01 {#ac9s4i01}
 
 pose questions to explore observed patterns and relationships and make predictions based on observations
 
@@ -120,9 +120,9 @@ pose questions to explore observed patterns and relationships and make predictio
 *  consulting with First Nations Australians about how to predict the location of water sources from observation of landscape features
 *  making predictions about the distances over which magnets will attract or repel each other
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9S4I02
+##### AC9S4I02 {#ac9s4i02}
 
 use provided scaffolds to plan and conduct investigations to answer questions or test predictions, including identifying the elements of fair tests, and considering the safe use of materials and equipment
 
@@ -132,7 +132,7 @@ use provided scaffolds to plan and conduct investigations to answer questions or
 *  predicting effects of changing numbers of producers or consumers, and using a virtual or roleplay food chain simulation to explore possible outcomes by running the simulation multiple times
 *  following safety rules when conducting investigations, such as wearing personal safety gear correctly, using equipment according to guidelines and demonstrating safe behaviours in field sites or when interacting with biological specimens
 
-##### AC9S4I03
+##### AC9S4I03 {#ac9s4i03}
 
 follow procedures to make and record observations, including making formal measurements using familiar scaled instruments and using digital tools as appropriate
 
@@ -142,9 +142,9 @@ follow procedures to make and record observations, including making formal measu
 *  describing how to use rounding up or down when reading scaled instruments, and the effect of the scale size on the accuracy of the measurement
 *  constructing tables or graphic organisers to record observations
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9S4I04
+##### AC9S4I04 {#ac9s4i04}
 
 construct and use representations, including tables, simple column graphs and visual or physical models, to organise data and information, show simple relationships and identify patterns
 
@@ -154,9 +154,9 @@ construct and use representations, including tables, simple column graphs and vi
 *  constructing column graphs to compare numbers of objects made of particular materials or distances moved by objects experiencing frictional forces
 *  using force arrows to show forces operating on objects
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9S4I05
+##### AC9S4I05 {#ac9s4i05}
 
 compare findings with those of others, consider if investigations were fair, identify questions for further investigation and draw conclusions
 
@@ -168,9 +168,9 @@ compare findings with those of others, consider if investigations were fair, ide
 *  identifying unexpected findings and posing questions for further investigation
 *  drawing conclusions that reflect their data and information
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9S4I06
+##### AC9S4I06 {#ac9s4i06}
 
 write and create texts to communicate findings and ideas for identified purposes and audiences, using scientific vocabulary and digital tools as appropriate
 
@@ -182,7 +182,7 @@ write and create texts to communicate findings and ideas for identified purposes
 *  constructing a report using scientific vocabulary to explain which materials are best suited to be used for making particular products, such as nylon for tents, rubber for shoes or wool for warm clothing
 *  creating posters, a song, slideshow or performance to encourage the school community to save water
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 4 students identify the roles of organisms in a habitat and construct food chains. They identify key processes in the water cycle and describe how water cycles through the environment. They identify forces acting on objects and describe their effect. They relate the uses of materials to their properties. They explain the role of data in science inquiry. They identify solutions based on scientific explanations and describe the needs these meet.
 

--- a/curriculum/science/year-5.md
+++ b/curriculum/science/year-5.md
@@ -1,6 +1,6 @@
-# Science - Year 5
+# Science - Year 5 {#science-year-5}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 5 students continue to explore the relationship between form and function by investigating how features of living things enable them to survive in their habitat. They identify stable and dynamic aspects of systems and appreciate that current systems, such as Earth’s surface, have characteristics that have resulted from past changes. They recognise that models are useful for investigating relationships between system components and can be used to predict the effects of changes. They explore observable phenomena associated with light and analyse patterns to identify that these phenomena have sets of characteristic behaviours. They begin to explain how matter structures the world around them. They develop explanations for the patterns they observe and recognise the importance of reflecting on their methods to identify potential sources of error before drawing conclusions.
 
@@ -12,13 +12,13 @@ Inquiry questions can help excite students’ curiosity and challenge their thin
 *   How has science shaped our community?
 *   What if emus could fly?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Biological sciences
+#### Biological sciences {#biological-sciences}
 
-##### AC9S5U01
+##### AC9S5U01 {#ac9s5u01}
 
 examine how particular structural features and behaviours of living things enable their survival in specific habitats
 
@@ -29,9 +29,9 @@ examine how particular structural features and behaviours of living things enabl
 *  using physical or digital simulations to explore how the shape of animals’ body parts, such as the beak of a particular bird species, influence their ability to find food and survive in a given environment
 *  investigating First Nations Australians’ knowledges of the structural features of certain species and how those features can be exploited
 
-#### Earth and space sciences
+#### Earth and space sciences {#earth-and-space-sciences}
 
-##### AC9S5U02
+##### AC9S5U02 {#ac9s5u02}
 
 describe how weathering, erosion, transportation and deposition cause slow or rapid change to Earth’s surface
 
@@ -44,9 +44,9 @@ describe how weathering, erosion, transportation and deposition cause slow or ra
 *  considering how First Nations Australians are impacted by the rapid erosion of sand dunes and the resulting effect of saltwater on culturally significant freshwater swamps
 *  considering the effects of significant rainfall, such as a monsoon, on the transportation and deposition of river sediments in the Asia-Pacific region
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9S5U03
+##### AC9S5U03 {#ac9s5u03}
 
 identify sources of light, recognise that light travels in a straight path and describe how shadows are formed and light can be reflected and refracted
 
@@ -59,9 +59,9 @@ identify sources of light, recognise that light travels in a straight path and d
 *  exploring the use of reflection of light by mirrors such as in periscopes and mirror mazes
 *  recognising First Nations Australians’ understanding of refraction as experienced in spearfishing and in shimmering body paint, and reflection as evidenced by materials selected for construction of housing
 
-#### Chemical sciences
+#### Chemical sciences {#chemical-sciences}
 
-##### AC9S5U04
+##### AC9S5U04 {#ac9s5u04}
 
 explain observable properties of solids, liquids and gases by modelling the motion and arrangement of particles
 
@@ -73,11 +73,11 @@ explain observable properties of solids, liquids and gases by modelling the moti
 *  exploring, through guided discussion, ideas about what is between particles
 *  recognising First Nations Australians’ knowledges and understandings of solids, liquids and gases and how these knowledges are applied in a range of processes and practices, including the extraction of oils, medical therapies and cooking
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Nature and development of science
+#### Nature and development of science {#nature-and-development-of-science}
 
-##### AC9S5H01
+##### AC9S5H01 {#ac9s5h01}
 
 examine why advances in science are often the result of collaboration or build on the work of others
 
@@ -88,9 +88,9 @@ examine why advances in science are often the result of collaboration or build o
 *  exploring why developing new erosion mitigation techniques such as contour banks and strip cropping requires geologists, hydrologists and farmers to collaborate
 *  exploring how understanding of light and optics has developed by comparing the ideas of Plato, Euclid, Ptolemy, Ibn al-Haytham and Roger Bacon
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9S5H02
+##### AC9S5H02 {#ac9s5h02}
 
 investigate how scientific knowledge is used by individuals and communities to identify problems, consider responses and make decisions
 
@@ -101,11 +101,11 @@ investigate how scientific knowledge is used by individuals and communities to i
 *  researching the impacts of light pollution and exploring how communities have used scientific knowledge to reduce light pollution, such as through the use of covered bulbs facing downwards in streetlights, automated systems to turn off streetlights and motion sensors on outdoor lights at home and in public places
 *  investigating how and why people used properties of light to design signal lamps to communicate via Morse code and where they continue to be used
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9S5I01
+##### AC9S5I01 {#ac9s5i01}
 
 pose investigable questions to identify patterns and test relationships and make reasoned predictions
 
@@ -116,9 +116,9 @@ pose investigable questions to identify patterns and test relationships and make
 *  asking questions and making predictions to test relationships, such as: ‘Will there be more erosion of steeper slopes? Will this organisation of mirrors enable me to see around corners? Are animals that camouflage well more likely to survive predation?’
 *  making reasoned predictions about the habitat a plant or animal lives in or the observable effect of light interacting with an object
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9S5I02
+##### AC9S5I02 {#ac9s5i02}
 
 plan and conduct repeatable investigations to answer questions, including, as appropriate, deciding the variables to be changed, measured and controlled in fair tests; describing potential risks; planning for the safe use of equipment and materials; and identifying required permissions to conduct investigations on Country/Place
 
@@ -131,7 +131,7 @@ plan and conduct repeatable investigations to answer questions, including, as ap
 *  consulting with First Nations Australians to identify local areas that require permission before accessing
 *  consulting with First Nations Australians to guide the planning of scientific investigations, considering potential risks for field investigations
 
-##### AC9S5I03
+##### AC9S5I03 {#ac9s5i03}
 
 use equipment to observe, measure and record data with reasonable precision, using digital tools as appropriate
 
@@ -141,9 +141,9 @@ use equipment to observe, measure and record data with reasonable precision, usi
 *  recording data using standard units, such as grams, second and metre, and developing the use of standard prefixes for metric units such as kilo- and milli-
 *  recording data in tables and diagrams or electronically as digital images and spreadsheets
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9S5I04
+##### AC9S5I04 {#ac9s5i04}
 
 construct and use appropriate representations, including tables, graphs and visual or physical models, to organise and process data and information and describe patterns, trends and relationships
 
@@ -154,9 +154,9 @@ construct and use appropriate representations, including tables, graphs and visu
 *  constructing labelled ray diagrams to represent observations and compare how light interacts with different objects
 *  using maps to identify patterns in erosion site locations or aerial photographs to show effects of erosion over time
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9S5I05
+##### AC9S5I05 {#ac9s5i05}
 
 compare methods and findings with those of others, recognise possible sources of error, pose questions for further investigation and select evidence to draw reasoned conclusions
 
@@ -167,9 +167,9 @@ compare methods and findings with those of others, recognise possible sources of
 *  discussing the difference between data and evidence and examining how evidence is selected
 *  reflecting on inferences made from observations and analysis of the data to draw a reasoned conclusion
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9S5I06
+##### AC9S5I06 {#ac9s5i06}
 
 write and create texts to communicate ideas and findings for specific purposes and audiences, including selection of language features, using digital tools as appropriate
 
@@ -181,7 +181,7 @@ write and create texts to communicate ideas and findings for specific purposes a
 *  co-authoring a scientific report on an investigation into the behaviours of light using appropriate vocabulary, data representations and sentence structures
 *  exploring whether there is a ‘correct’ way of representing particles and creating an animation to teach other students about the particulate nature of matter
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 5 students explain how the form and behaviour of living things enables survival. They describe key processes that change Earth’s surface. They identify sources of light and model the transfer of light to explain observed phenomena. They relate the particulate arrangement of solids, liquids and gases to their observable properties. They describe examples of collaboration leading to advances in science, and scientific knowledge that has changed over time. They identify examples where scientific knowledge informs the actions of individuals and communities.
 

--- a/curriculum/science/year-6.md
+++ b/curriculum/science/year-6.md
@@ -1,6 +1,6 @@
-# Science - Year 6
+# Science - Year 6 {#science-year-6}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 6 students develop an understanding of interdependencies between systems as they explore the relationship between physical conditions of habitats and the growth and survival of living things and investigate the effect of the relative positions of Earth and the sun on phenomena such as day length. They identify and classify components in electrical circuits and learn to describe energy flows in terms of transfer and transformation. They are introduced to ways to classify changes to substances. Students begin to appreciate the role of controlling variables in fair testing and the value of accuracy in measurements. They generalise about relationships between events, phenomena and systems and use identified patterns, trends and relationships to develop scientific explanations and draw reasoned conclusions.
 
@@ -12,13 +12,13 @@ Inquiry questions can help excite students’ curiosity and challenge their thin
 *   Why is it important for a test to be ‘fair’?
 *   How does the weather affect local habitats?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Biological sciences
+#### Biological sciences {#biological-sciences}
 
-##### AC9S6U01
+##### AC9S6U01 {#ac9s6u01}
 
 investigate the physical conditions of a habitat and analyse how the growth and survival of living things is affected by changing physical conditions
 
@@ -31,9 +31,9 @@ investigate the physical conditions of a habitat and analyse how the growth and 
 *  recognising that environmental conditions can affect stages of life, such as ponds drying up, seeds requiring water to germinate, or temperatures being too hot or cold for eggs to hatch
 *  investigating First Nations Australians’ knowledges and understandings of the physical conditions necessary for the survival of certain plants and animals
 
-#### Earth and space sciences
+#### Earth and space sciences {#earth-and-space-sciences}
 
-##### AC9S6U02
+##### AC9S6U02 {#ac9s6u02}
 
 describe the movement of Earth and other planets relative to the sun and model how Earth’s tilt, rotation on its axis and revolution around the sun relate to cyclic observable phenomena, including variable day and night length
 
@@ -45,9 +45,9 @@ describe the movement of Earth and other planets relative to the sun and model h
 *  using 3-dimensional models to explore how the tilt of Earth points one hemisphere towards the sun and the other away at different times of the year, and predicting how this affects the amount of sunlight on the surface of different regions on Earth
 *  researching First Nations Australians’ understandings of the night sky and its use for timekeeping purposes as evidenced in oral cultural records, rock paintings, paintings and stone arrangements
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9S6U03
+##### AC9S6U03 {#ac9s6u03}
 
 investigate the transfer and transformation of energy in electrical circuits, including the role of circuit components, insulators and conductors
 
@@ -59,9 +59,9 @@ investigate the transfer and transformation of energy in electrical circuits, in
 *  investigating different electrical conductors and insulators and examining why they may be used
 *  exploring how electricity is used in the home and identifying electrical hazards and safety measures used to mitigate these hazards
 
-#### Chemical sciences
+#### Chemical sciences {#chemical-sciences}
 
-##### AC9S6U04
+##### AC9S6U04 {#ac9s6u04}
 
 compare reversible changes, including dissolving and changes of state, and irreversible changes, including cooking and rusting that produce new substances
 
@@ -73,11 +73,11 @@ compare reversible changes, including dissolving and changes of state, and irrev
 *  exploring how reversible changes can be used to recycle materials
 *  investigating First Nations Australians’ knowledges of reversible processes such as the application of adhesives and of irreversible processes such as the use of fuels for torches
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Nature and development of science
+#### Nature and development of science {#nature-and-development-of-science}
 
-##### AC9S6H01
+##### AC9S6H01 {#ac9s6h01}
 
 examine why advances in science are often the result of collaboration or build on the work of others
 
@@ -89,9 +89,9 @@ examine why advances in science are often the result of collaboration or build o
 *  investigating how astronauts and scientists from many different countries have collaborated in the International Space Station program
 *  investigating why scientists changed the phosphate levels in detergents to prevent algal blooms
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9S6H02
+##### AC9S6H02 {#ac9s6h02}
 
 investigate how scientific knowledge is used by individuals and communities to identify problems, consider responses and make decisions
 
@@ -101,11 +101,11 @@ investigate how scientific knowledge is used by individuals and communities to i
 *  considering how people use electrical device guidelines to help ensure safety of children
 *  investigating why underground power cables were developed and how local government authorities use scientific knowledge about power safety when considering converting to underground power
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9S6I01
+##### AC9S6I01 {#ac9s6i01}
 
 pose investigable questions to identify patterns and test relationships and make reasoned predictions
 
@@ -116,9 +116,9 @@ pose investigable questions to identify patterns and test relationships and make
 *  making reasoned predictions about the physical conditions that will result in the largest mould colonies growing on bread
 *  making reasoned predictions about electrical circuit function based on a picture or diagram of a circuit
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9S6I02
+##### AC9S6I02 {#ac9s6i02}
 
 plan and conduct repeatable investigations to answer questions including, as appropriate, deciding the variables to be changed, measured and controlled in fair tests; describing potential risks; planning for the safe use of equipment and materials; and identifying required permissions to conduct investigations on Country/Place
 
@@ -128,7 +128,7 @@ plan and conduct repeatable investigations to answer questions including, as app
 *  identifying potential risks to themselves or others when conducting an investigation and explaining rules for safe processes and use of equipment and materials
 *  consulting with First Nations Australians land councils in seeking permissions to conduct scientific investigations on traditional Lands and seeking guidance regarding culturally sensitive locations during field work
 
-##### AC9S6I03
+##### AC9S6I03 {#ac9s6i03}
 
 use equipment to observe, measure and record data with reasonable precision, using digital tools as appropriate
 
@@ -139,9 +139,9 @@ use equipment to observe, measure and record data with reasonable precision, usi
 *  recording data using standard units, such as volt, ampere, gram, second and metre, and developing the use of standard prefixes for metric units such as kilo- and milli-
 *  using digital tools such as digital thermometers or soil moisture probes to collect data over time and record data in spreadsheets
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9S6I04
+##### AC9S6I04 {#ac9s6i04}
 
 construct and use appropriate representations, including tables, graphs and visual or physical models, to organise and process data and information and describe patterns, trends and relationships
 
@@ -152,9 +152,9 @@ construct and use appropriate representations, including tables, graphs and visu
 *  developing a physical model of the sun and Earth using objects or role-play to describe their relative positions when a place on Earth is in day or night
 *  organising information in graphic organisers to describe patterns and trends
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9S6I05
+##### AC9S6I05 {#ac9s6i05}
 
 compare methods and findings with those of others, recognise possible sources of error, pose questions for further investigation and select evidence to draw reasoned conclusions
 
@@ -165,9 +165,9 @@ compare methods and findings with those of others, recognise possible sources of
 *  comparing and contrasting evidence selected by different individuals or groups from similar data
 *  evaluating the inferences made from observations and analysis of the data to draw a reasoned conclusion
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9S6I06
+##### AC9S6I06 {#ac9s6i06}
 
 write and create texts to communicate ideas and findings for specific purposes and audiences, including selection of language features, using digital tools as appropriate
 
@@ -178,7 +178,7 @@ write and create texts to communicate ideas and findings for specific purposes a
 *  designing a product that uses electrical circuits and performing a sales pitch to have the product mass produced
 *  constructing a poster or slideshow comparing everyday examples of reversible and irreversible change
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 6 students explain how changes in physical conditions affect living things. They model the relationship between the sun and planets of the solar system and explain how the relative positions of Earth and the sun relate to observed phenomena on Earth. They identify the role of circuit components in the transfer and transformation of electrical energy. They classify and compare reversible and irreversible changes to substances. They explain why science is often collaborative and describe different individuals’ contributions to scientific knowledge. They describe how individuals and communities use scientific knowledge.
 

--- a/curriculum/science/year-7.md
+++ b/curriculum/science/year-7.md
@@ -1,6 +1,6 @@
-# Science - Year 7
+# Science - Year 7 {#science-year-7}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 7 students explore the diversity of life on Earth and continue to develop their understanding of the role of classification in ordering and organising information. They use and develop models to represent and analyse the flow of energy and matter through ecosystems and explore the impact of changing components within these systems. They investigate relationships in the Earth-sun-moon system and use models to predict and explain events. They extend their understanding of the particulate nature of matter and explore how interactions of matter and energy at the sub-microscopic scale determine macroscopic properties. They consider the effects of multiple forces when explaining changes in an object’s motion. Students make accurate measurements and analyse relationships between system components. They construct and use models to test hypotheses about phenomena at scales that are difficult to study directly and use these observations and other evidence to draw conclusions. They begin to understand the relationship between science and society and appreciate the need for ethical and cultural considerations when acquiring data.
 
@@ -12,13 +12,13 @@ Inquiry questions can help excite students’ curiosity and challenge their thin
 *   Why is being able to separate mixtures important?
 *   How have systems of classification changed over time? How do they differ across cultures?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Biological sciences
+#### Biological sciences {#biological-sciences}
 
-##### AC9S7U01
+##### AC9S7U01 {#ac9s7u01}
 
 investigate the role of classification in ordering and organising the diversity of life on Earth and use and develop classification tools including dichotomous keys
 
@@ -31,7 +31,7 @@ investigate the role of classification in ordering and organising the diversity 
 *  using provided dichotomous keys to identify organisms surveyed on a field trip
 *  investigating First Nations Australians’ systems of classifying living things and how these systems differ from those used by contemporary science
 
-##### AC9S7U02
+##### AC9S7U02 {#ac9s7u02}
 
 use models, including food webs, to represent matter and energy flow in ecosystems and predict the impact of changing abiotic and biotic factors on populations
 
@@ -43,9 +43,9 @@ use models, including food webs, to represent matter and energy flow in ecosyste
 *  investigating First Nations Australians’ responses to invasive species and their effect on food webs that many communities are a part of, and depend on, for produce and medicine
 *  considering how First Nations Australians’ fire management practices over tens of thousands of years have changed the distribution of flora and fauna in most regions of Australia
 
-#### Earth and space sciences
+#### Earth and space sciences {#earth-and-space-sciences}
 
-##### AC9S7U03
+##### AC9S7U03 {#ac9s7u03}
 
 model cyclic changes in the relative positions of the Earth, sun and moon and explain how these cycles cause eclipses and influence predictable phenomena on Earth, including seasons and tides
 
@@ -57,9 +57,9 @@ model cyclic changes in the relative positions of the Earth, sun and moon and ex
 *  investigating First Nations Australians’ calendars and how they are used to predict seasonal changes
 *  researching First Nations Australians’ oral traditions and cultural recordings of solar and lunar eclipses and investigating similarities and differences with contemporary understandings of such phenomena
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9S7U04
+##### AC9S7U04 {#ac9s7u04}
 
 investigate and represent balanced and unbalanced forces, including gravitational force, acting on objects, and relate changes in an object’s motion to its mass and the magnitude and direction of forces acting on it
 
@@ -73,9 +73,9 @@ investigate and represent balanced and unbalanced forces, including gravitationa
 *  analysing the forces acting on boomerangs and how early First Peoples of Australia designed an air foil profile which allowed for multiple variations and applications
 *  investigating the effect of forces through the application of simple machines, such as the bow and arrows used by Torres Strait Islander Peoples or the spearthrowers used by First Peoples of Australia
 
-#### Chemical sciences
+#### Chemical sciences {#chemical-sciences}
 
-##### AC9S7U05
+##### AC9S7U05 {#ac9s7u05}
 
 use particle theory to describe the arrangement of particles in a substance, including the motion of and attraction between particles, and relate this to the properties of the substance
 
@@ -88,7 +88,7 @@ use particle theory to describe the arrangement of particles in a substance, inc
 *  investigating properties of materials such as density, melting point and compressibility and explaining these in terms of particle arrangement
 *  explaining the process of diffusion in a liquid and a gas in terms of particles
 
-##### AC9S7U06
+##### AC9S7U06 {#ac9s7u06}
 
 use a particle model to describe differences between pure substances and mixtures and apply understanding of properties of substances to separate mixtures
 
@@ -100,11 +100,11 @@ use a particle model to describe differences between pure substances and mixture
 *  analysing how the physical properties of substances in mixtures, such as particle size, density or volatility, determine the separation technique used
 *  investigating separation techniques used by First Nations Australians, such as hand-picking, sieving, winnowing, yandying, filtering, cold-pressing and steam distilling
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Nature and development of science
+#### Nature and development of science {#nature-and-development-of-science}
 
-##### AC9S7H01
+##### AC9S7H01 {#ac9s7h01}
 
 explain how new evidence or different perspectives can lead to changes in scientific knowledge
 
@@ -115,7 +115,7 @@ explain how new evidence or different perspectives can lead to changes in scient
 *  researching developments in the understanding of astronomy, such as the predictions of eclipses and the calculation of the length of the solar year by Abu Abdallah Mohammad ibn Jabir ibn Sinan al-Raqqi al-Harrani al-Sabi al-Battani in the 10th century
 *  investigating how aeronautical engineers’ understanding of the nature of the forces acting in flight have led to changes in the design of aircraft
 
-##### AC9S7H02
+##### AC9S7H02 {#ac9s7h02}
 
 investigate how cultural perspectives and world views influence the development of scientific knowledge
 
@@ -127,9 +127,9 @@ investigate how cultural perspectives and world views influence the development 
 *  exploring the work of Wang Zhenyi, an acclaimed female scholar of 18th-century China, including her experiments in studying lunar eclipses
 *  exploring how David Unaipon, a Ngarrindjeri man from Coorong region of South Australia, used his cultural knowledge and understanding of the aerodynamic properties of boomerangs to conceptualise a ‘vertical lift flying machine’ in 1914
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9S7H03
+##### AC9S7H03 {#ac9s7h03}
 
 examine how proposed scientific responses to contemporary issues may impact on society and explore ethical, environmental, social and economic considerations
 
@@ -142,7 +142,7 @@ examine how proposed scientific responses to contemporary issues may impact on s
 *  discussing how scientific knowledge of the forces involved in flight has led to changes in aircraft design and any ethical, environmental, social and economic considerations of these changes
 *  researching how properties of gases were utilised in the gas warfare in the First World War and the subsequent development of the Geneva Protocol and the later adoption of the Chemical Weapons Convention international arms control treaty
 
-##### AC9S7H04
+##### AC9S7H04 {#ac9s7h04}
 
 explore the role of science communication in informing individual viewpoints and community policies and regulations
 
@@ -154,11 +154,11 @@ explore the role of science communication in informing individual viewpoints and
 *  reflecting on the role of contemporary First Nations Australians astronomers and astrophysicists, such as Wiradjuri astrophysicist and science communicator Kirsten Banks, in promoting First Nations astronomy knowledges and understandings
 *  investigating how science communication of the impact of waste materials on the environment has led to the adoption of community policies for separating household waste and encouraged other recycling initiatives
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9S7I01
+##### AC9S7I01 {#ac9s7i01}
 
 develop investigable questions, reasoned predictions and hypotheses to explore scientific models, identify patterns and test relationships
 
@@ -170,9 +170,9 @@ develop investigable questions, reasoned predictions and hypotheses to explore s
 *  discussing the relationship between a reasoned prediction and a hypothesis, identifying essential elements of a hypothesis and using a provided scaffold to develop hypotheses
 *  formulating hypotheses such as: ‘If the surface area of the parachute is decreased, the parachute will descend more quickly because there will be less air resistance’
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9S7I02
+##### AC9S7I02 {#ac9s7i02}
 
 plan and conduct reproducible investigations to answer questions and test hypotheses, including identifying variables and assumptions and, as appropriate, recognising and managing risks, considering ethical issues and recognising key considerations regarding heritage sites and artefacts on Country/Place
 
@@ -187,7 +187,7 @@ plan and conduct reproducible investigations to answer questions and test hypoth
 *  collaborating with First Nations Australians communities and organisations to conduct investigations about ecosystems, ensuring mutually beneficial outcomes
 *  acknowledging and recognising First Nations Australians’ artefacts and heritage sites, such as human stonework and scatter sites in comparison with rocks changed by natural processes, and understanding not to harm or disturb sites
 
-##### AC9S7I03
+##### AC9S7I03 {#ac9s7i03}
 
 select and use equipment to generate and record data with precision, using digital tools as appropriate
 
@@ -198,9 +198,9 @@ select and use equipment to generate and record data with precision, using digit
 *  using appropriate standard units and performing simple unit conversions when recording data
 *  using digital tools such as sensors to measure abiotic factors and apps that use image or call recognition to make field identifications
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9S7I04
+##### AC9S7I04 {#ac9s7i04}
 
 select and construct appropriate representations, including tables, graphs, models and mathematical relationships, to organise and process data and information
 
@@ -212,7 +212,7 @@ select and construct appropriate representations, including tables, graphs, mode
 *  distinguishing between discrete and continuous data and selecting appropriate data representations
 *  acknowledging, analysing and interpreting data and information from First Nations Australians’ astronomical observations
 
-##### AC9S7I05
+##### AC9S7I05 {#ac9s7i05}
 
 analyse data and information to describe patterns, trends and relationships and identify anomalies
 
@@ -223,9 +223,9 @@ analyse data and information to describe patterns, trends and relationships and 
 *  identifying anomalies in data and investigating their effect on observed patterns or relationships
 *  collaborating with First Nations Australians communities to create a calendar as a representation of seasonal patterns and relationships using digital tools
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9S7I06
+##### AC9S7I06 {#ac9s7i06}
 
 analyse methods, conclusions and claims for assumptions, possible sources of error, conflicting evidence and unanswered questions
 
@@ -237,7 +237,7 @@ analyse methods, conclusions and claims for assumptions, possible sources of err
 *  identifying possible sources of error in the method used and describing how the method could be improved to remove these sources of error
 *  identifying the evidence being cited to support a claim and evaluating conflicting evidence
 
-##### AC9S7I07
+##### AC9S7I07 {#ac9s7i07}
 
 construct evidence-based arguments to support conclusions or evaluate claims and consider any ethical issues and cultural protocols associated with using or citing secondary data or information
 
@@ -248,9 +248,9 @@ construct evidence-based arguments to support conclusions or evaluate claims and
 *  investigating the cultural, historical and archaeological evidence used in the scientific debate about the role of early First Nations Australians in the extinction of Australian megafauna
 *  researching the development of commercial products that are founded on the traditional knowledges and practices of First Nations Australians and discussing related ethical considerations associated with biopiracy and intellectual property rights
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9S7I08
+##### AC9S7I08 {#ac9s7i08}
 
 write and create texts to communicate ideas, findings and arguments for specific purposes and audiences, including selection of appropriate language and text features, using digital tools as appropriate
 
@@ -262,7 +262,7 @@ write and create texts to communicate ideas, findings and arguments for specific
 *  creating an informative text for a younger audience to show how the tilt of Earth’s axis, rotation of Earth on that axis, and the revolution of Earth around the sun cause the seasons
 *  creating an animation that explains particle theory to a peer audience
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 7 students explain how biological diversity is ordered and organised. They represent flows of matter and energy in ecosystems and predict the effects of environmental changes. They model cycles in the Earth-sun-moon system and explain the effects of these cycles on Earth phenomena. They represent and explain the effects of forces acting on objects. They use particle theory to explain the physical properties of substances and develop processes that separate mixtures. Students identify the factors that can influence development of and lead to changes in scientific knowledge. They explain how scientific responses are developed and can impact society. They explain the role of science communication in shaping viewpoints, policies and regulations.
 

--- a/curriculum/science/year-8.md
+++ b/curriculum/science/year-8.md
@@ -1,6 +1,6 @@
-# Science - Year 8
+# Science - Year 8 {#science-year-8}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 8 students are introduced to cells as microscopic structures that explain macroscopic features of living systems. They connect form and function at an organ level and explore the organisation of a body system in terms of flows of matter between interdependent organs. They continue to develop a view of Earth as a dynamic system, in which change occurs across a range of timescales. They classify different types of energy and describe the role of energy in causing change in systems, including the role of energy and forces in the geosphere. They learn to classify matter at the atomic level and distinguish between chemical and physical change. They understand that chemical reactions also involve energy. Students use experimentation to isolate relationships between components in systems and explain these relationships through increasingly complex representations. They consider the magnitude of properties and events and use appropriate units to describe proportional relationships.
 
@@ -12,13 +12,13 @@ Inquiry questions can help excite students’ curiosity and challenge their thin
 *   How can we best measure what we cannot directly see?
 *   How is a leaf like a lung?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Biological sciences
+#### Biological sciences {#biological-sciences}
 
-##### AC9S8U01
+##### AC9S8U01 {#ac9s8u01}
 
 recognise cells as the basic units of living things, compare plant and animal cells, and describe the functions of specialised cell structures and organelles
 
@@ -30,7 +30,7 @@ recognise cells as the basic units of living things, compare plant and animal ce
 *  designing a physical or digital model of a cell and explaining how the representation models the cell
 *  considering how the invention of the microscope has contributed to understanding of cell structure
 
-##### AC9S8U02
+##### AC9S8U02 {#ac9s8u02}
 
 analyse the relationship between structure and function of cells, tissues and organs in a plant and an animal organ system and explain how these systems enable survival of the individual
 
@@ -42,9 +42,9 @@ analyse the relationship between structure and function of cells, tissues and or
 *  researching how a disorder in cells or tissues can affect how an organ functions, such as how hardening of the arteries can lead to poor circulation or heart disease
 *  investigating how an artificial organ mimics or augments the function or functions of a real organ
 
-#### Earth and space sciences
+#### Earth and space sciences {#earth-and-space-sciences}
 
-##### AC9S8U03
+##### AC9S8U03 {#ac9s8u03}
 
 investigate tectonic activity including the formation of geological features at divergent, convergent and transform plate boundaries and describe the scientific evidence for the theory of plate tectonics
 
@@ -58,7 +58,7 @@ investigate tectonic activity including the formation of geological features at 
 *  exploring how geologist and oceanographic cartographer Marie Tharp’s topographic maps of the Atlantic Ocean floor provided support for the acceptance of the theory of plate tectonics
 *  researching First Nations Australians’ cultural accounts that provide evidence of earthquakes and volcanoes
 
-##### AC9S8U04
+##### AC9S8U04 {#ac9s8u04}
 
 describe the key processes of the rock cycle, including the timescales over which they occur, and examine how the properties of sedimentary, igneous and metamorphic rocks reflect their formation and influence their use
 
@@ -72,9 +72,9 @@ describe the key processes of the rock cycle, including the timescales over whic
 *  investigating how First Nations Australians have used quarrying to access rocks for use as or production of everyday objects such as grindstones, hammerstones, anvils and cutting tools
 *  exploring how the mining of ores and minerals impacts on local environments and examining environmental rehabilitation initiatives
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9S8U05
+##### AC9S8U05 {#ac9s8u05}
 
 classify different types of energy as kinetic or potential and investigate energy transfer and transformations in simple systems
 
@@ -87,9 +87,9 @@ classify different types of energy as kinetic or potential and investigate energ
 *  observing a Rube Goldberg machine and identifying the energy transfers and transformations involved
 *  investigating traditional fire-starting methods used by First Nations Australians and their understandings of the transformation of energy
 
-#### Chemical sciences
+#### Chemical sciences {#chemical-sciences}
 
-##### AC9S8U06
+##### AC9S8U06 {#ac9s8u06}
 
 classify matter as elements, compounds or mixtures and compare different representations of these, including 2-dimensional and 3-dimensional models, symbols for elements and formulas for molecules and compounds
 
@@ -101,7 +101,7 @@ classify matter as elements, compounds or mixtures and compare different represe
 *  examining the information conveyed by different types of representations of elements and compounds and identifying where and why these different representations are used
 *  creating a timeline or models to show how the concept of an element has changed over time from Democritus to John Dalton
 
-##### AC9S8U07
+##### AC9S8U07 {#ac9s8u07}
 
 compare physical and chemical changes and identify indicators of energy change in chemical reactions
 
@@ -112,11 +112,11 @@ compare physical and chemical changes and identify indicators of energy change i
 *  examining how the physical and chemical properties of a substance will affect its production or use
 *  discussing where indicators of chemical change are used for identifying the presence of particular substances, such as in soil, water and medical testing kits
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Nature and development of science
+#### Nature and development of science {#nature-and-development-of-science}
 
-##### AC9S8H01
+##### AC9S8H01 {#ac9s8h01}
 
 explain how new evidence or different perspectives can lead to changes in scientific knowledge
 
@@ -129,7 +129,7 @@ explain how new evidence or different perspectives can lead to changes in scient
 *  discussing the story of Sir Isaac Newton’s discovery of gravity or the questions that Albert Einstein asked which led him to developing a new theory
 *  researching why Dmitri Mendeleev developed a different representation of the periodic table
 
-##### AC9S8H02
+##### AC9S8H02 {#ac9s8h02}
 
 investigate how cultural perspectives and world views influence the development of scientific knowledge
 
@@ -140,9 +140,9 @@ investigate how cultural perspectives and world views influence the development 
 *  analysing how world views relating to fairness in sport have led to the development of rapid chemical tests to identify performance-enhancing drugs
 *  investigating how First Nations Australians develop material culture through holistic world views that employ multidisciplinary knowledges and skills
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9S8H03
+##### AC9S8H03 {#ac9s8h03}
 
 examine how proposed scientific responses to contemporary issues may impact on society and explore ethical, environmental, social and economic considerations
 
@@ -153,7 +153,7 @@ examine how proposed scientific responses to contemporary issues may impact on s
 *  examining how the development of hybrid and solar, electric and hydrogen-powered vehicles are applications of contemporary science responses to the depletion of fossil fuels and exploring environmental considerations
 *  exploring how the development of biodegradable materials has led to more sustainable packaging and reduction in landfill
 
-##### AC9S8H04
+##### AC9S8H04 {#ac9s8h04}
 
 explore the role of science communication in informing individual viewpoints and community policies and regulations
 
@@ -163,11 +163,11 @@ explore the role of science communication in informing individual viewpoints and
 *  investigating how promotion of biodegradable materials and the importance of using them has informed individual viewpoints
 *  researching how science organisations and high-profile science communicators such as Professor Lisa Harvey-Smith or Dr Karl Kruszelnicki influence people’s attitudes to science
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9S8I01
+##### AC9S8I01 {#ac9s8i01}
 
 develop investigable questions, reasoned predictions and hypotheses to explore scientific models, identify patterns and test relationships
 
@@ -178,9 +178,9 @@ develop investigable questions, reasoned predictions and hypotheses to explore s
 *  predicting what will happen when conditions change in a given scenario or phenomenon, such as: ‘When materials of less resistance are used to transfer electricity there will be less heat energy produced’
 *  formulating hypotheses such as: ‘An earthquake of greater magnitude will cause more damage because there is more energy transferred’
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9S8I02
+##### AC9S8I02 {#ac9s8i02}
 
 plan and conduct reproducible investigations to answer questions and test hypotheses, including identifying variables and assumptions and, as appropriate, recognising and managing risks, considering ethical issues and recognising key considerations regarding heritage sites and artefacts on Country/Place
 
@@ -191,7 +191,7 @@ plan and conduct reproducible investigations to answer questions and test hypoth
 *  considering ethical issues relating to the access to and use of biological material and secondary data
 *  acknowledging and recognising First Nations Australians’ artefacts and heritage sites of significance such as ceremonial grounds and traditional quarries, and ensuring they cause no harm to heritage sites and artefacts
 
-##### AC9S8I03
+##### AC9S8I03 {#ac9s8i03}
 
 select and use equipment to generate and record data with precision, using digital tools as appropriate
 
@@ -202,9 +202,9 @@ select and use equipment to generate and record data with precision, using digit
 *  using conventions related to dependent and independent variables with relevant units when constructing tables and spreadsheets
 *  using appropriate positive and negative signs for standard units, number of decimal points and exponential notation where relevant when recording data
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9S8I04
+##### AC9S8I04 {#ac9s8i04}
 
 select and construct appropriate representations, including tables, graphs, models and mathematical relationships, to organise and process data and information
 
@@ -217,7 +217,7 @@ select and construct appropriate representations, including tables, graphs, mode
 *  collating data from a number of sources such as different groups in the class who performed the same investigation to create a summary
 *  examining the strengths and limitations of representations such as physical models, diagrams and virtual simulations and selecting the most appropriate representation to use
 
-##### AC9S8I05
+##### AC9S8I05 {#ac9s8i05}
 
 analyse data and information to describe patterns, trends and relationships and identify anomalies
 
@@ -228,9 +228,9 @@ analyse data and information to describe patterns, trends and relationships and 
 *  analysing changes in battery energy output following recharging over many cycles and relating to available chemical potential energy
 *  comparing temperature differences obtained by reacting different proportions of the same chemicals to determine if there is a relationship
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9S8I06
+##### AC9S8I06 {#ac9s8i06}
 
 analyse methods, conclusions and claims for assumptions, possible sources of error, conflicting evidence and unanswered questions
 
@@ -241,7 +241,7 @@ analyse methods, conclusions and claims for assumptions, possible sources of err
 *  analysing conclusions or claims to determine if there are further questions which should be explored to verify the conclusion or claim
 *  analysing conclusions to identify facts or premises that are taken for granted to be true, and discussing the reasonableness of those assumptions with others
 
-##### AC9S8I07
+##### AC9S8I07 {#ac9s8i07}
 
 construct evidence-based arguments to support conclusions or evaluate claims and consider any ethical issues and cultural protocols associated with using or citing secondary data or information
 
@@ -252,9 +252,9 @@ construct evidence-based arguments to support conclusions or evaluate claims and
 *  analysing what evidence would be necessary to support the conclusion that all buildings in an earthquake area should be made of bamboo
 *  evaluating a claim that one brand of battery lasts longer than another brand of battery
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9S8I08
+##### AC9S8I08 {#ac9s8i08}
 
 write and create texts to communicate ideas, findings and arguments for specific purposes and audiences, including selection of appropriate language and text features, using digital tools as appropriate
 
@@ -267,7 +267,7 @@ write and create texts to communicate ideas, findings and arguments for specific
 *  creating a digital infographic to compare and contrast different forms of energy, highlighting examples of energy transfer and transformations within each
 *  acknowledging and exploring First Nations Australians’ ways of communicating their understanding of the internal systems of organisms
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8 students explain the role of specialised cell structures and organelles in cellular function and analyse the relationship between structure and function at organ and body system levels. They apply an understanding of the theory of plate tectonics to explain patterns of change in the geosphere. They explain how the properties of rocks relate to their formation and influence their use. They compare different forms of energy and represent transfer and transformation of energy in simple systems. They classify and represent different types of matter and distinguish between physical and chemical change. Students analyse how different factors influence development of and lead to changes in scientific knowledge. They analyse the key considerations that inform scientific responses and how these responses impact society. They analyse the importance of science communication in shaping viewpoints, policies and regulations.
 

--- a/curriculum/science/year-9.md
+++ b/curriculum/science/year-9.md
@@ -1,6 +1,6 @@
-# Science - Year 9
+# Science - Year 9 {#science-year-9}
 
-## Level Description
+## Level Description {#level-description}
 
 In Year 9 students consider the operation of systems at a range of scales and how those systems respond to external changes in order to maintain stability. They explore ways in which the human body system responds to changes in the external environment through physiological feedback mechanisms and the reproductive processes that enable a species to respond to a changing environment over time. They are introduced to the notion of the atom as a system of protons, electrons and neutrons, and how this system can change through nuclear decay. They learn that matter can be rearranged through chemical change and that these changes play an important role in many systems. They are introduced to the concepts of conservation of matter and energy and begin to develop a more sophisticated view of energy transfer. They explore these concepts as they relate to the global carbon cycle. Students begin to consider how well a sample or model represents the phenomena under study and use a range of evidence to support their conclusions.
 
@@ -12,13 +12,13 @@ Inquiry questions can help excite students’ curiosity and challenge their thin
 *   How does the carbon cycle affect life on Earth?
 *   How do different technologies help humans to communicate?
 
-## Strands
+## Strands {#strands}
 
-### Science understanding
+### Science understanding {#science-understanding}
 
-#### Biological sciences
+#### Biological sciences {#biological-sciences}
 
-##### AC9S9U01
+##### AC9S9U01 {#ac9s9u01}
 
 compare the role of body systems in regulating and coordinating the body’s response to a stimulus, and describe the operation of a negative feedback mechanism
 
@@ -30,7 +30,7 @@ compare the role of body systems in regulating and coordinating the body’s res
 *  examining the effects of a disorder in a feedback system, such as diabetes-induced blindness or hypothermia
 *  considering how understanding of feedback mechanisms has enabled the development of pharmaceuticals and other products to address issues or enhance performance, such as insulin or electrolytes in sports drinks
 
-##### AC9S9U02
+##### AC9S9U02 {#ac9s9u02}
 
 describe the form and function of reproductive cells and organs in animals and plants, and analyse how the processes of sexual and asexual reproduction enable survival of the species
 
@@ -42,9 +42,9 @@ describe the form and function of reproductive cells and organs in animals and p
 *  examining how the reproductive strategies of multicellular animals are related to their environment and the complexity of the organism
 *  examining how the number of offspring produced by animals is related to the amount of parental care
 
-#### Earth and space sciences
+#### Earth and space sciences {#earth-and-space-sciences}
 
-##### AC9S9U03
+##### AC9S9U03 {#ac9s9u03}
 
 represent the carbon cycle and examine how key processes including combustion, photosynthesis and respiration rely on interactions between Earth’s spheres (the geosphere, biosphere, hydrosphere and atmosphere)
 
@@ -59,9 +59,9 @@ represent the carbon cycle and examine how key processes including combustion, p
 *  identifying how carbon dioxide is captured and stored naturally or through the use of technologies
 *  calculating an individual’s carbon footprint, examining the impact of human activities and suggesting strategies to reduce carbon dioxide emissions
 
-#### Physical sciences
+#### Physical sciences {#physical-sciences}
 
-##### AC9S9U04
+##### AC9S9U04 {#ac9s9u04}
 
 use wave and particle models to describe energy transfer through different mediums and examine the usefulness of each model for explaining phenomena
 
@@ -74,7 +74,7 @@ use wave and particle models to describe energy transfer through different mediu
 *  investigating the impact of material selection on the transfer of sound energy in First Nations Australians’ traditional musical, hunting and communication instruments
 *  examining the forms of electromagnetic radiation that are used in different modern communication technologies and identifying any limitations
 
-##### AC9S9U05
+##### AC9S9U05 {#ac9s9u05}
 
 apply the law of conservation of energy to analyse system efficiency in terms of energy inputs, outputs, transfers and transformations
 
@@ -87,9 +87,9 @@ apply the law of conservation of energy to analyse system efficiency in terms of
 *  examining the meaning of energy star ratings given to appliances such as refrigerators and washing machines and criteria used to determine these ratings
 *  examining how improving efficiency in energy transfer and transformations in sporting activities such as pole vaulting or archery improves athletic performance
 
-#### Chemical sciences
+#### Chemical sciences {#chemical-sciences}
 
-##### AC9S9U06
+##### AC9S9U06 {#ac9s9u06}
 
 explain how the model of the atom changed following the discovery of electrons, protons and neutrons and describe how natural radioactive decay results in stable atoms
 
@@ -103,7 +103,7 @@ explain how the model of the atom changed following the discovery of electrons, 
 *  identifying where applications of radioactivity are used in medicine and industry such as diagnosing and treating cancer and checking for faults in materials used in aircraft and spacecraft
 *  discussing how mass and energy are connected at all scales and energy conversion processes within atomic nuclei
 
-##### AC9S9U07
+##### AC9S9U07 {#ac9s9u07}
 
 model the rearrangement of atoms in chemical reactions using a range of representations, including word and simple balanced chemical equations, and use these to demonstrate the law of conservation of mass
 
@@ -115,11 +115,11 @@ model the rearrangement of atoms in chemical reactions using a range of represen
 *  investigating why most elements are not found in their elemental state and processes which are used to obtain the element
 *  predicting how ideas of green chemistry such as minimising the amount of unusable waste products, energy use and using more environmentally friendly chemical processes will affect the environment
 
-### Science as a human endeavour
+### Science as a human endeavour {#science-as-a-human-endeavour}
 
-#### Nature and development of science
+#### Nature and development of science {#nature-and-development-of-science}
 
-##### AC9S9H01
+##### AC9S9H01 {#ac9s9h01}
 
 explain how scientific knowledge is validated and refined, including the role of publication and peer review
 
@@ -131,7 +131,7 @@ explain how scientific knowledge is validated and refined, including the role 
 *  researching how JJ Thomson’s discovery of the electron, Robert Millikan’s oil drop experiment, and Ernest Rutherford’s gold foil experiment provide consistency of evidence for the particle model of electricity
 *  examining how Marie and Pierre Curie’s discovery of new elements was validated
 
-##### AC9S9H02
+##### AC9S9H02 {#ac9s9h02}
 
 investigate how advances in technologies enable advances in science, and how science has contributed to developments in technologies and engineering
 
@@ -144,9 +144,9 @@ investigate how advances in technologies enable advances in science, and how sci
 *  exploring how understanding of the nature of matter and energy has changed over time, and how modern technology has enabled exploration of energy conversion processes at all scales, from black holes to atoms to sub-atomic particles
 *  examining how advances in understanding of radioactivity and radioisotopes have led to new applications and technologies
 
-#### Use and influence of science
+#### Use and influence of science {#use-and-influence-of-science}
 
-##### AC9S9H03
+##### AC9S9H03 {#ac9s9h03}
 
 analyse the key factors that contribute to science knowledge and practices being adopted more broadly by society
 
@@ -159,7 +159,7 @@ analyse the key factors that contribute to science knowledge and practices being
 *  analysing factors that have led to the adoption of solar panels and battery storage by individuals, industries and communities
 *  investigating how an understanding of materials and concern for the environment have led to the adoption of widespread recycling practices
 
-##### AC9S9H04
+##### AC9S9H04 {#ac9s9h04}
 
 examine how the values and needs of society influence the focus of scientific research
 
@@ -172,11 +172,11 @@ examine how the values and needs of society influence the focus of scientific re
 *  considering how the development of new materials and procedures has contributed to safe sound levels for humans in the workplace and leisure activities
 *  examining why many manufacturers are adopting green chemistry processes
 
-### Science inquiry
+### Science inquiry {#science-inquiry}
 
-#### Questioning and predicting
+#### Questioning and predicting {#questioning-and-predicting}
 
-##### AC9S9I01
+##### AC9S9I01 {#ac9s9i01}
 
 develop investigable questions, reasoned predictions and hypotheses to test relationships and develop explanatory models
 
@@ -187,9 +187,9 @@ develop investigable questions, reasoned predictions and hypotheses to test rela
 *  discussing why a scientific hypothesis has to be able to be supported or refuted through evidence
 *  proposing a hypothesis to test an identified relationship, such as: ‘If objects of different temperatures are placed in contact, heat energy will transfer from an object of higher temperature to an object of lower temperature until both objects reach the same temperature’
 
-#### Planning and conducting
+#### Planning and conducting {#planning-and-conducting}
 
-##### AC9S9I02
+##### AC9S9I02 {#ac9s9i02}
 
 plan and conduct valid, reproducible investigations to answer questions and test hypotheses, including identifying and controlling for possible sources of error and, as appropriate, developing and following risk assessments, considering ethical issues, and addressing key considerations regarding heritage sites and artefacts on Country/Place
 
@@ -201,7 +201,7 @@ plan and conduct valid, reproducible investigations to answer questions and test
 *  discussing the ethical and social issues involved in the care and use of animals for scientific purposes before starting an investigation involving animals
 *  recognising First Nations Australians’ heritage laws and public responsibilities to report new sites or artefacts, and developing awareness of the consequences for disturbing heritage sites on, above or below the land surface, or in waters
 
-##### AC9S9I03
+##### AC9S9I03 {#ac9s9i03}
 
 select and use equipment to generate and record data with precision to obtain useful sample sizes and replicable data, using digital tools as appropriate
 
@@ -213,9 +213,9 @@ select and use equipment to generate and record data with precision to obtain us
 *  discussing the amount of data needed to produce a useful sample size and why sample size is important
 *  considering an appropriate sample size for the investigation, and how the use of digital tools might enable more-efficient data collection for larger sample sizes
 
-#### Processing, modelling and analysing
+#### Processing, modelling and analysing {#processing-modelling-and-analysing}
 
-##### AC9S9I04
+##### AC9S9I04 {#ac9s9i04}
 
 select and construct appropriate representations, including tables, graphs, descriptive statistics, models and mathematical relationships, to organise and process data and information
 
@@ -226,7 +226,7 @@ select and construct appropriate representations, including tables, graphs, desc
 *  applying ratios to accurately represent usable and waste energy in transfer and transformation diagrams such as Sankey diagrams
 *  comparing the information provided by molecular models and word and balanced symbolic chemical equations when examining the law of conservation of mass
 
-##### AC9S9I05
+##### AC9S9I05 {#ac9s9i05}
 
 analyse and connect a variety of data and information to identify and explain patterns, trends, relationships and anomalies
 
@@ -237,9 +237,9 @@ analyse and connect a variety of data and information to identify and explain pa
 *  analysing data on heat transfer through multiple layers of an insulating material and identifying patterns and proportional relationships, such as: ‘When the thickness of the material is doubled the amount of heat transferred is halved’
 *  examining tables, graphs and digital simulations of radioactive decay half-life to predict changes in mass over time
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9S9I06
+##### AC9S9I06 {#ac9s9i06}
 
 assess the validity and reproducibility of methods and evaluate the validity of conclusions and claims, including by identifying assumptions, conflicting evidence and areas of uncertainty
 
@@ -251,7 +251,7 @@ assess the validity and reproducibility of methods and evaluate the validity of 
 *  considering if areas of uncertainty could lead to a viable alternative conclusion
 *  considering how general practitioners manage conflicting evidence to diagnose illness
 
-##### AC9S9I07
+##### AC9S9I07 {#ac9s9i07}
 
 construct arguments based on analysis of a variety of evidence to support conclusions or evaluate claims, and consider any ethical issues and cultural protocols associated with accessing, using or citing secondary data or information
 
@@ -264,9 +264,9 @@ construct arguments based on analysis of a variety of evidence to support conclu
 *  acknowledging and identifying the relationship between First Peoples’ knowledges and contemporary science and the co-contributions in arriving at shared understandings when working ‘both ways’
 *  acknowledging and constructing an argument for the contributions to medicine of First Nations Australians’ knowledges of physiological pathways and contemporary medicinal delivery systems
 
-#### Communicating
+#### Communicating {#communicating}
 
-##### AC9S9I08
+##### AC9S9I08 {#ac9s9i08}
 
 write and create texts to communicate ideas, findings and arguments effectively for identified purposes and audiences, including selection of appropriate content, language and text features, using digital tools as appropriate
 
@@ -278,7 +278,7 @@ write and create texts to communicate ideas, findings and arguments effectively 
 *  planning a social media campaign to encourage young people to reduce their carbon footprint
 *  collaborating to prepare a written report for local government on estimated carbon storage across different local ecosystems and proposals to increase carbon storage across the area
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 9 students explain how body systems provide a coordinated response to stimuli. They describe how the processes of sexual and asexual reproduction enable survival of the species. They explain how interactions within and between Earth’s spheres affect the carbon cycle. They analyse energy conservation in simple systems and apply wave and particle models to describe energy transfer. They explain observable chemical processes in terms of changes in atomic structure, atomic rearrangement and mass. Students explain the role of publication and peer review in the development of scientific knowledge and explain the relationship between science, technologies and engineering. They analyse the different ways in which science and society are interconnected.
 

--- a/curriculum/tech-design-and-technologies/foundation-year.md
+++ b/curriculum/tech-design-and-technologies/foundation-year.md
@@ -1,6 +1,6 @@
-# Technologies - Design and Technologies - Foundation Year
+# Design and Technologies - Foundation Year {#design-and-technologies-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 Learning in Design and Technologies builds on the Early Years Learning Framework, and each student’s prior learning and experiences.
 
@@ -8,13 +8,13 @@ By the end of Foundation students should have had the opportunity to create at l
 
 Students should have opportunities to experience designing and producing a product, service or environment. They explore technologies – materials and equipment – through play experiences in a context and generate ideas to design a solution for a purpose. Students develop an awareness of how people design products, services and environments. They evaluate design ideas and choose the most suitable idea. Students use a range of methods to communicate design ideas, including drawings or models, for example changing perspectives from front view to plan view. They explore working with materials such as cardboard, fabric and other common household items and using equipment such as scissors, glues, trowels or kitchen utensils. Students learn techniques to safely make a designed solution.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Technologies and society
+#### Technologies and society {#technologies-and-society}
 
-##### AC9TDEFK01
+##### AC9TDEFK01 {#ac9tdefk01}
 
 explore how familiar products, services and environments are designed by people
 
@@ -25,11 +25,11 @@ explore how familiar products, services and environments are designed by people
 *  describing how community gardens, public swimming pools and parks are designed to help people stay healthy
 *  asking questions about the design of products from the local store, for example why certain packaging materials might have been selected, and how people design the text and images on the packaging to attract people’s attention
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Designing and making
+#### Designing and making {#designing-and-making}
 
-##### AC9TDEFP01
+##### AC9TDEFP01 {#ac9tdefp01}
 
 generate, communicate and evaluate design ideas, and use materials, equipment and steps to safely make a solution for a purpose
 
@@ -41,7 +41,7 @@ generate, communicate and evaluate design ideas, and use materials, equipment an
 *  practising a range of technical skills safely using equipment, for example joining techniques when making a product from materials, such as a greenhouse to keep a seedling warm or a trellis for holding up tomato plants
 *  assembling components of systems and checking they function as planned, for example making and testing a bowling, stacking or obstacle game with discarded food containers or packaging
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Foundation students identify familiar products, services and environments. They create a designed solution for a school-selected context. Students create, communicate and choose design ideas. They follow steps and use materials and equipment to safely make a designed solution.
 

--- a/curriculum/tech-design-and-technologies/years-1-and-2.md
+++ b/curriculum/tech-design-and-technologies/years-1-and-2.md
@@ -1,6 +1,6 @@
-# Technologies - Design and Technologies - Years 1 and 2
+# Design and Technologies - Years 1 and 2 {#design-and-technologies-years-1-and-2}
 
-## Level Description
+## Level Description {#level-description}
 
 By the end of Year 2 students should have had the opportunity to create 3 types of designed solutions, and addressed each of these 2 technologies contexts:
 
@@ -17,13 +17,13 @@ Students use a range of technologies to communicate and explain design ideas, in
 
 They plan steps, follow directions and manage their own role to complete their own or group design projects. Students are aware of the need to work safely and cooperatively when making designed solutions.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Technologies and society
+#### Technologies and society {#technologies-and-society}
 
-##### AC9TDE2K01
+##### AC9TDE2K01 {#ac9tde2k01}
 
 identify how familiar products, services and environments are designed and produced by people to meet personal or local community needs and sustainability
 
@@ -34,9 +34,9 @@ identify how familiar products, services and environments are designed and produ
 *  exploring how local products are designed, for example brainstorming the materials and processes needed to create a costume for a school or community event including using recycled clothing or components to minimise waste
 *  exploring how people come up with new ideas or modify existing designs, for example preventing water wastage when caring for plants
 
-#### Technologies context: Engineering principles and systems; Materials and technologies specialisations
+#### Technologies context: Engineering principles and systems; Materials and technologies specialisations {#technologies-context-engineering-principles-and-systems-materials-and-technologies-specialisations}
 
-##### AC9TDE2K02
+##### AC9TDE2K02 {#ac9tde2k02}
 
 explore how technologies including materials affect movement in products
 
@@ -47,9 +47,9 @@ explore how technologies including materials affect movement in products
 *  exploring a system such as a marionette or Indonesian wayang kulit shadow puppet to see that by combining materials with forces movement can be created
 *  testing materials to see how they affect movement and speed, for example the movement of a wheeled toy on different surfaces such as timber, carpet, rubber and plastic
 
-#### Technologies context: Food and fibre production; Food specialisations
+#### Technologies context: Food and fibre production; Food specialisations {#technologies-context-food-and-fibre-production-food-specialisations}
 
-##### AC9TDE2K03
+##### AC9TDE2K03 {#ac9tde2k03}
 
 explore how plants and animals are grown for food, clothing and shelter
 
@@ -60,7 +60,7 @@ explore how plants and animals are grown for food, clothing and shelter
 *  identifying products that can be designed and produced from plants and animals, for example food products, paper and wood products, fabrics and yarns
 *  considering a range of tools and equipment that can be used to grow plants for a purpose and their suitability, for example naming and describing tools such as a spade or rake used to cultivate or mulch a home vegetable garden, or equipment such as a seed spreader or global positioning system (GPS) tractor to sow wheat, or a tubestock planting tool and drones to manage forestry plantations
 
-##### AC9TDE2K04
+##### AC9TDE2K04 {#ac9tde2k04}
 
 explore how food can be selected and prepared for healthy eating
 
@@ -71,11 +71,11 @@ explore how food can be selected and prepared for healthy eating
 *  exploring the local supermarket to observe the variety of foods and the placement of foods on shelves, in aisles and displays; and considering how their design may influence the purchase of foods for healthy food eating
 *  exploring different ways of preparing the products from the school kitchen garden, farmers’ market or supermarket, for example preparing vegetables for a salad, steaming or roasting vegetables and noticing the changes in flavour and texture
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Generating and designing
+#### Generating and designing {#generating-and-designing}
 
-##### AC9TDE2P01
+##### AC9TDE2P01 {#ac9tde2p01}
 
 generate and communicate design ideas through describing, drawing or modelling, including using digital tools
 
@@ -85,9 +85,9 @@ generate and communicate design ideas through describing, drawing or modelli
 *  communicating an opinion about their design ideas, for example expressing own likes and dislikes about a design idea for felt finger puppets including how they have made changes to their design ideas
 *  describing the results from exploring design ideas, for example recording the results from people taste-testing a food product
 
-#### Producing and implementing
+#### Producing and implementing {#producing-and-implementing}
 
-##### AC9TDE2P02
+##### AC9TDE2P02 {#ac9tde2p02}
 
 use materials, components, tools, equipment and techniques to safely make designed solutions
 
@@ -96,9 +96,9 @@ use materials, components, tools, equipment and techniques to safely make design
 *  practising a range of technical skills using tools and equipment safely, for example joining techniques when making products, watering and mulching gardens, preparing a recipe using a knife safely
 *  assembling components and checking they function as planned, for example containers, contents and joining materials when making musical shakers
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9TDE2P03
+##### AC9TDE2P03 {#ac9tde2p03}
 
 evaluate the success of design ideas and solutions based on personal preferences and including sustainability
 
@@ -108,9 +108,9 @@ evaluate the success of design ideas and solutions based on personal preferences
 *  reflecting on the environmental impacts of the production of a solution and considering alternative approaches that would minimise future negative impacts, for example identifying the negative environmental impacts of different food packaging and how these could be minimised
 *  reflecting on the challenges of designing and producing a solution and recording these reflections, for example when growing a food product, designing a structure to take a load or making a nutritious snack
 
-#### Collaborating and managing
+#### Collaborating and managing {#collaborating-and-managing}
 
-##### AC9TDE2P04
+##### AC9TDE2P04 {#ac9tde2p04}
 
 sequence steps for making designed solutions cooperatively
 
@@ -119,7 +119,7 @@ sequence steps for making designed solutions cooperatively
 *  recording the procedure for making a product, for example the ordered steps for making a salad, instructions for making a container or bag
 *  identifying roles for each member of a group when working cooperatively, for example when making a number of items for a school fete
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 2 students describe the purpose of familiar products, services and environments. For each of the 2 prescribed technologies contexts they describe the features and uses of technologies and create designed solutions. Students select design ideas based on their personal preferences. They communicate design ideas using models and drawings and follow sequenced steps to safely produce designed solutions.
 

--- a/curriculum/tech-design-and-technologies/years-3-and-4.md
+++ b/curriculum/tech-design-and-technologies/years-3-and-4.md
@@ -1,6 +1,6 @@
-# Technologies - Design and Technologies - Years 3 and 4
+# Design and Technologies - Years 3 and 4 {#design-and-technologies-years-3-and-4}
 
-## Level Description
+## Level Description {#level-description}
 
 By the end of Year 4 students should have had the opportunity to create 3 types of designed solutions, and addressed each of these 2 technologies contexts:
 
@@ -17,13 +17,13 @@ Students clarify and present ideas, using a range of technologies and graphical 
 
 Students become aware of appropriate ways to manage their time and co-develop and use design criteria. They list the major steps needed to complete a design task. They show an understanding of the importance of planning when designing solutions, in particular when collaborating. Students identify safety issues and learn to follow safety rules when producing designed solutions.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Technologies and society
+#### Technologies and society {#technologies-and-society}
 
-##### AC9TDE4K01
+##### AC9TDE4K01 {#ac9tde4k01}
 
 examine design and technologies occupations and factors including sustainability that impact on the design of products, services and environments to meet community needs
 
@@ -35,9 +35,9 @@ examine design and technologies occupations and factors including sustainability
 *  examining products and environments to discover the factors that may have influenced the design and, choice of technologies used, for example discussing energy-efficient cooking with a wok, or sustainable wood products for home use including furniture made from plantation timbers, bamboo toothbrushes or coconut shell bowls
 *  conducting a survey to identify a community need that involves accessibility and social sustainability, for example design features that improve access to the school
 
-#### Technologies context: Engineering principles and systems; Materials and technologies specialisations
+#### Technologies context: Engineering principles and systems; Materials and technologies specialisations {#technologies-context-engineering-principles-and-systems-materials-and-technologies-specialisations}
 
-##### AC9TDE4K02
+##### AC9TDE4K02 {#ac9tde4k02}
 
 describe how forces and the properties of materials affect function in a product or system
 
@@ -48,9 +48,9 @@ describe how forces and the properties of materials affect function in a product
 *  <p>deconstructing a product or system to identify how motion and forces affect performance, for example in a puppet such as a Japanese <em>bunraku puppet</em> or a model windmill with moving sails</p>
 *  identifying engineered systems and experimenting with available local materials, tools and equipment to solve problems, for example designing a container or parachute that will keep an egg intact when dropped from a height; a pop-up card; a tower; or a vehicle
 
-#### Technologies context: Food and fibre production; Food specialisations
+#### Technologies context: Food and fibre production; Food specialisations {#technologies-context-food-and-fibre-production-food-specialisations}
 
-##### AC9TDE4K03
+##### AC9TDE4K03 {#ac9tde4k03}
 
 describe the ways of producing food and fibre
 
@@ -60,7 +60,7 @@ describe the ways of producing food and fibre
 *  comparing farming methods for food in Australia and a country in Asia, for example the use of different types of plants and animals and how diverse technologies are used to produce them
 *  researching how animal fibres (for example wool, alpaca) and plant fibres (for example timber, cotton, bamboo) are produced in Australia, for example how production of plantation timbers may be different from bamboo production
 
-##### AC9TDE4K04
+##### AC9TDE4K04 {#ac9tde4k04}
 
 describe the ways food can be selected and prepared for healthy eating
 
@@ -71,11 +71,11 @@ describe the ways food can be selected and prepared for healthy eating
 *  considering creative ways foods can be prepared for maximum taste and appeal, for example locating and discussing images online that show colourful or fun ways to present food that might encourage healthy eating
 *  describing foods using the senses, for example describing the colour, aroma, sound, texture and taste of the ingredients in a salad or stir-fry and how our senses influence what we select to eat
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Investigating and defining
+#### Investigating and defining {#investigating-and-defining}
 
-##### AC9TDE4P01
+##### AC9TDE4P01 {#ac9tde4p01}
 
 explore needs or opportunities for designing, and test materials, components, tools, equipment and processes needed to create designed solutions
 
@@ -86,9 +86,9 @@ explore needs or opportunities for designing, and test materials, components, to
 *  exploring and testing a range of materials under different conditions for suitability including sustainability considerations, for example the compostability of paper-based materials or the strength and durability of natural materials
 *  exploring the different uses of materials in a range of products, including those from a country in Asia, to inform design decisions, for example in shelters, boats, handmade tools, baskets, wooden items, musical instruments, clothing and fabric
 
-#### Generating and designing
+#### Generating and designing {#generating-and-designing}
 
-##### AC9TDE4P02
+##### AC9TDE4P02 {#ac9tde4p02}
 
 generate and communicate design ideas and decisions using appropriate attributions, technical terms and graphical representation techniques, including using digital tools
 
@@ -98,9 +98,9 @@ generate and communicate design ideas and decisions using appropriate attributio
 *  communicating design ideas using annotated diagrams, for example labelling a diagram for a pushcart with technical terms and explanations about components such as the chassis, axle, wheels and steering
 *  generating design ideas for solutions using Safety by Design principles, for example designing communication that is accessible for all parents and carers
 
-#### Producing and implementing
+#### Producing and implementing {#producing-and-implementing}
 
-##### AC9TDE4P03
+##### AC9TDE4P03 {#ac9tde4p03}
 
 select and use materials, components, tools, equipment and techniques to safely make designed solutions
 
@@ -111,9 +111,9 @@ select and use materials, components, tools, equipment and techniques to safely 
 *  selecting and using materials, components, tools, equipment and processes with consideration of the environmental impact at each stage of the production process, for example considering how packaging and offcuts could be recycled or used for other purposes before choosing materials for a project
 *  using appropriate technologies terms to describe and share with other students the procedures and techniques for making, for example how to safely make an engineered solution such as a robotic device
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9TDE4P04
+##### AC9TDE4P04 {#ac9tde4p04}
 
 use given or co-developed design criteria including sustainability to evaluate design ideas and solutions
 
@@ -123,9 +123,9 @@ use given or co-developed design criteria including sustainability to evaluate d
 *  comparing the amount of waste that would be produced from different design ideas and the potential for recycling waste, for example exploring the choice of materials to construct a toy and whether these materials are repairable or able to be recycled once the toy breaks or is no longer wanted
 *  reflecting on how well their designed solution meets design criteria, such as ensuring safety and wellbeing of users and meeting the needs of communities or different cultures, for example reviewing and discussing the choice of fabrics used to make re-usable bags and how they could be made more appealing to all cultural groups by considering modifications to style
 
-#### Collaborating and managing
+#### Collaborating and managing {#collaborating-and-managing}
 
-##### AC9TDE4P05
+##### AC9TDE4P05 {#ac9tde4p05}
 
 sequence steps to individually and collaboratively make designed solutions
 
@@ -134,7 +134,7 @@ sequence steps to individually and collaboratively make designed solutions
 *  discussing the importance of managing time and resource allocation throughout production, for example discussing the roles different people might take in a team and identifying the tasks they will complete and the resources they will each need
 *  identifying the steps in a mass production process, for example drawing a flowchart or making a video recording of a procedure for packing identical boxes of food for community members in need, where each student in a group has a separate task as part of the production process
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 4 students describe how people design products, services and environments to meet the needs of people, including sustainability. For each of the 2 prescribed technologies contexts they describe the features and uses of technologies and create designed solutions. Students select design ideas against design criteria. They communicate design ideas using models and drawings including annotations and symbols. Students plan and sequence steps and use technologies and techniques to safely produce designed solutions.
 

--- a/curriculum/tech-design-and-technologies/years-5-and-6.md
+++ b/curriculum/tech-design-and-technologies/years-5-and-6.md
@@ -1,6 +1,6 @@
-# Technologies - Design and Technologies - Years 5 and 6
+# Design and Technologies - Years 5 and 6 {#design-and-technologies-years-5-and-6}
 
-## Level Description
+## Level Description {#level-description}
 
 By the end of Year 6 students should have had the opportunity to create 3 types of designed solutions, and addressed each of these 3 technologies contexts:
 
@@ -16,13 +16,13 @@ Using a range of technologies including a variety of graphical representation te
 
 Students work individually and collaboratively to identify and sequence steps needed for a design task, including negotiating criteria for success. They develop and follow plans to complete design tasks safely, adjusting when necessary. Students identify and maintain safety standards and practices when making designed solutions.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Technologies and society
+#### Technologies and society {#technologies-and-society}
 
-##### AC9TDE6K01
+##### AC9TDE6K01 {#ac9tde6k01}
 
 explain how people in design and technologies occupations consider competing factors including sustainability in the design of products, services and environments
 
@@ -34,9 +34,9 @@ explain how people in design and technologies occupations consider competing fac
 *  considering how engineers resolve competing factors to produce innovative solutions, for example experimenting with novel ideas such as biomimicry to engineer a solution such as a soft robotic device
 *  considering how Safety by Design principles have been used in the design of products, services or environments, for example considering how prevention, protection and proactive change can be used to improve safety of designed solutions
 
-#### Technologies context: Engineering principles and systems
+#### Technologies context: Engineering principles and systems {#technologies-context-engineering-principles-and-systems}
 
-##### AC9TDE6K02
+##### AC9TDE6K02 {#ac9tde6k02}
 
 explain how electrical energy can be transformed into movement, sound or light in a product or system
 
@@ -47,9 +47,9 @@ explain how electrical energy can be transformed into movement, sound or light i
 *  producing models using materials, tools and equipment to show how to control movement, sound or light, for example constructing an automation or lifting system including a pulley to raise a bucket or toy
 *  deconstructing a product or system to discover how movement, sound or light can be controlled, for example taking apart a torch or buzzer, or exploring circuit design in a security system and investigating the properties of materials to solve problems including the amount of light reflected from different surfaces to control a sensor
 
-#### Technologies context: Food and fibre production; Food specialisations
+#### Technologies context: Food and fibre production; Food specialisations {#technologies-context-food-and-fibre-production-food-specialisations}
 
-##### AC9TDE6K03
+##### AC9TDE6K03 {#ac9tde6k03}
 
 explain how and why food and fibre are produced in managed environments
 
@@ -60,7 +60,7 @@ explain how and why food and fibre are produced in managed environments
 *  sequencing the process of converting on-farm food or fibre products into a product suitable for retail sale, for example creating a digital flowchart to record a paddock-to-plate supply chain, or the fibre-to-garment life cycle (fibre, yarn, fabric, garment)
 *  visiting a farm or participating in a virtual tour to ask questions about how and why food and fibre are produced in that environment
 
-##### AC9TDE6K04
+##### AC9TDE6K04 {#ac9tde6k04}
 
 explain how the characteristics of foods influence selection and preparation for healthy eating
 
@@ -72,9 +72,9 @@ explain how the characteristics of foods influence selection and preparation for
 *  <p>developing strategies to communicate healthy choices based on the <em>Australian Dietary Guidelines</em>, for example designing a website with food preparation tips for healthy eating for pre-teens</p>
 *  exploring the food service options of a local restaurant, café, fast food or takeaway establishment and identifying the food preparation skills needed to prepare food for healthy eating
 
-#### Technologies context: Materials and technologies specialisations
+#### Technologies context: Materials and technologies specialisations {#technologies-context-materials-and-technologies-specialisations}
 
-##### AC9TDE6K05
+##### AC9TDE6K05 {#ac9tde6k05}
 
 explain how characteristics and properties of materials, systems, components, tools and equipment affect their use when producing designed solutions
 
@@ -86,11 +86,11 @@ explain how characteristics and properties of materials, systems, components, to
 *  comparing the design and production of products, services or environments in Australia and a country in Asia, for example comparing the diversity, availability and properties of preferred materials and the design of public shelters and housing in Indonesia and Australia
 *  investigating the properties of fibres and how these are used to create products, for example designing an experiment to test which fabrics are warmest and explaining how those properties influence what they are used for
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Investigating and defining
+#### Investigating and defining {#investigating-and-defining}
 
-##### AC9TDE6P01
+##### AC9TDE6P01 {#ac9tde6p01}
 
 investigate needs or opportunities for designing, and the materials, components, tools, equipment and processes needed to create designed solutions
 
@@ -102,9 +102,9 @@ investigate needs or opportunities for designing, and the materials, components,
 *  testing a range of materials, components, tools and equipment to determine the appropriate technologies needed to make products, services or environments, for example the materials for a product such as a rubber-band-powered vehicle or item of protective clothing
 *  investigating how to minimise material use and manage waste by comparing the environmental and social impacts of materials, components, tools and equipment, for example comparing the cost and environmental impact of repurposing an old item of clothing to create a carry bag with buying a new one, or using vegetable scraps to make a healthy soup versus buying takeaway soup
 
-#### Generating and designing
+#### Generating and designing {#generating-and-designing}
 
-##### AC9TDE6P02
+##### AC9TDE6P02 {#ac9tde6p02}
 
 generate, iterate and communicate design ideas, decisions and processes using technical terms and graphical representation techniques, including using digital tools
 
@@ -116,9 +116,9 @@ generate, iterate and communicate design ideas, decisions and processes using te
 *  experimenting with materials, tools and equipment to refine design decisions and processes, for example considering the selection of materials and joining techniques to suit the purpose of a product, such as a pop-up book, a fabric bag or an electric circuit
 *  considering the social values and ethics of clients when designing an environment, for example interviewing users of a space or seeking permission to use designs or images created by others including respect of cultural and intellectual property
 
-#### Producing and implementing
+#### Producing and implementing {#producing-and-implementing}
 
-##### AC9TDE6P03
+##### AC9TDE6P03 {#ac9tde6p03}
 
 select and use suitable materials, components, tools, equipment and techniques to safely make designed solutions
 
@@ -128,9 +128,9 @@ select and use suitable materials, components, tools, equipment and techniques t
 *  choosing appropriate materials, tools, equipment and techniques for a specific purpose, for example when safely and hygienically preparing food, cultivating garden beds or constructing electronic products
 *  identifying work practices that show an understanding of nutrition, environmental considerations, hygiene and food safety when designing and making a food product, for example washing fruit and vegetables carefully to remove residues, safe disposal of cooking oils to avoid environmental damage, refrigerated storage of highly perishable foods, being aware of food allergies
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9TDE6P04
+##### AC9TDE6P04 {#ac9tde6p04}
 
 negotiate design criteria including sustainability to evaluate design ideas, processes and solutions
 
@@ -141,9 +141,9 @@ negotiate design criteria including sustainability to evaluate design ideas, pro
 *  evaluating their designed solutions including considering the benefits and costs of production processes and the environmental impact, for example for the production of an animal shelter
 *  reflecting on designed solutions to evaluate and assess suitability and sustainability and determine how well they meet design criteria, for example gathering relevant data to make judgements about a school or community fundraising event in relation to waste reduction, attendance and funds raised, and considering how these aspects could be handled in future events
 
-#### Collaborating and managing
+#### Collaborating and managing {#collaborating-and-managing}
 
-##### AC9TDE6P05
+##### AC9TDE6P05 {#ac9tde6p05}
 
 develop project plans that include consideration of resources to individually and collaboratively make designed solutions
 
@@ -152,7 +152,7 @@ develop project plans that include consideration of resources to individually an
 *  identifying the human resources, materials, tools and equipment that will be needed to make the designed solution as part of the project plan and specifying when these will be needed, for example access to a wildlife expert at the planning stage and scheduling access to shared tools when building a habitat for local animals
 *  planning production steps needed to produce a product, service or environment using digital tools, for example making a flowchart or using a digital planner to record the sequence of tasks and deadlines needed to complete a project
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 6 students explain how people design products, services and environments to meet the needs of communities, including sustainability. For each of the 3 prescribed technologies contexts they explain how the features of technologies impact on design decisions and they create designed solutions. Students select and justify design ideas and solutions against design criteria that include sustainability. They communicate design ideas to an audience using technical terms and graphical representation techniques. Students develop project plans, including production processes, and select technologies and techniques to safely produce designed solutions.
 

--- a/curriculum/tech-design-and-technologies/years-7-and-8.md
+++ b/curriculum/tech-design-and-technologies/years-7-and-8.md
@@ -1,6 +1,6 @@
-# Technologies - Design and Technologies - Years 7 and 8
+# Design and Technologies - Years 7 and 8 {#design-and-technologies-years-7-and-8}
 
-## Level Description
+## Level Description {#level-description}
 
 By the end of Year 8 students should have had the opportunity to create at least 3 types of designed solutions, and addressed each of the 4 technologies contexts:
 
@@ -17,13 +17,13 @@ Using a range of technologies including a variety of graphical representation te
 
 With greater autonomy, students identify the sequences and steps involved in design tasks. They develop plans to manage design tasks, including safe and responsible use of materials and tools, and apply their plans to successfully complete these tasks. Students establish safety procedures that minimise risk and manage a project with safety and efficiency when making designed solutions.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Technologies and society
+#### Technologies and society {#technologies-and-society}
 
-##### AC9TDE8K01
+##### AC9TDE8K01 {#ac9tde8k01}
 
 analyse how people in design and technologies occupations consider ethical and sustainability factors to design and produce products, services and environments
 
@@ -34,7 +34,7 @@ analyse how people in design and technologies occupations consider ethical and s
 *  researching the rights and responsibilities of those working in design and technologies occupations, for example taking into account First Nations Australian protocols and Indigenous cultural and intellectual property rights
 *  analysing the ethical and social requirements when designing solutions for cultural groups including their involvement and consultation, for example designing a solution with community members from other cultural backgrounds or those who usually communicate in a language other than English
 
-##### AC9TDE8K02
+##### AC9TDE8K02 {#ac9tde8k02}
 
 analyse the impact of innovation and the development of technologies on designed solutions for global preferred futures
 
@@ -45,9 +45,9 @@ analyse the impact of innovation and the development of technologies on designed
 *  investigating influences impacting on manufactured products and processes such as historical developments, societal change, new materials, accessibility guidelines, control systems or biomimicry, for example researching the development of Velcro, which was inspired by burrs, or researching contemporary designers who use new materials to design and produce innovative products
 *  considering factors that impact on innovation, for example developing novel ideas, responding quickly to change, creating a point of differentiation, adding value for society, reducing costs and improving efficiency
 
-#### Technologies context: Engineering principles and systems
+#### Technologies context: Engineering principles and systems {#technologies-context-engineering-principles-and-systems}
 
-##### AC9TDE8K03
+##### AC9TDE8K03 {#ac9tde8k03}
 
 analyse how force, motion and energy are used to manipulate and control engineered systems
 
@@ -60,9 +60,9 @@ analyse how force, motion and energy are used to manipulate and control engineer
 *  experimenting with control systems to understand motion, for example programming a microcontroller or an object-based programming application to control a system such as a remote-controlled car or robotic arm
 *  investigating components, tools and equipment in terms of force, motion or energy, for example testing the durability of batteries or determining the effective range of wireless devices
 
-#### Technologies context: Food and fibre production
+#### Technologies context: Food and fibre production {#technologies-context-food-and-fibre-production}
 
-##### AC9TDE8K04
+##### AC9TDE8K04 {#ac9tde8k04}
 
 analyse how food and fibre are produced in managed environments and how these can become sustainable
 
@@ -74,9 +74,9 @@ analyse how food and fibre are produced in managed environments and how these ca
 *  investigating different animal nutrition strategies such as grazing and supplementary feeding, and their effects on quality when producing food and fibre products, for example meat tenderness, wool-fibre diameter (micron), milk fat and protein content
 *  recognising the importance of food and fibre production to Australia’s food security and economy, including exports and imports to and from countries across Asia, for example exports of Tasmanian Candy Abalone (wild-caught dried abalone)
 
-#### Technologies context: Food specialisations
+#### Technologies context: Food specialisations {#technologies-context-food-specialisations}
 
-##### AC9TDE8K05
+##### AC9TDE8K05 {#ac9tde8k05}
 
 analyse how properties of foods determine preparation and presentation techniques when designing solutions for healthy eating
 
@@ -86,9 +86,9 @@ analyse how properties of foods determine preparation and presentation technique
 *  investigating the relationship between food preparation techniques and the impact on nutrient value including how a recipe can be modified to enhance health benefits, for example stir-frying, steaming vegetables, leaving skin on vegetables or removing skin from chicken
 *  analysing food preparation techniques used in different cultures including those from countries across Asia and the impact of these on nutrient retention, aesthetics, taste and palatability, for example stir-frying, steaming, poaching and using a wide variety of vegetables
 
-#### Technologies context: Materials and technologies specialisations
+#### Technologies context: Materials and technologies specialisations {#technologies-context-materials-and-technologies-specialisations}
 
-##### AC9TDE8K06
+##### AC9TDE8K06 {#ac9tde8k06}
 
 analyse how characteristics and properties of materials, systems, components, tools and equipment can be combined to create designed solutions
 
@@ -101,11 +101,11 @@ analyse how characteristics and properties of materials, systems, components, to
 *  testing and selecting the most appropriate hand tools, equipment, processes and materials to produce a product, for example a stool or smartphone stand that can be assembled from bending and interlocking cardboard pieces or from wood using a laser cutter or other digital tools
 *  investigating carbon fibres (reinforced polymers) and graphite fibres which are strong, stiff, lightweight material used in specialised high-performance products, for example on the design of sporting equipment
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Investigating and defining
+#### Investigating and defining {#investigating-and-defining}
 
-##### AC9TDE8P01
+##### AC9TDE8P01 {#ac9tde8p01}
 
 analyse needs or opportunities for designing, and investigate and select materials, components, tools, equipment and processes to create designed solutions
 
@@ -118,9 +118,9 @@ analyse needs or opportunities for designing, and investigate and select materia
 *  analysing the viability of using different techniques and materials in areas considered remote, isolated areas or less developed countries and selecting appropriate materials to acknowledge sustainability needs by using life cycle thinking
 *  creating a survey to determine students’ food choices and developing a range of healthy food items such as snacks, juices, breakfast or nourish bowls such as a Buddha bowl which could be sold at the school canteen
 
-#### Generating and designing
+#### Generating and designing {#generating-and-designing}
 
-##### AC9TDE8P02
+##### AC9TDE8P02 {#ac9tde8p02}
 
 generate, test, iterate and communicate design ideas, processes and solutions using technical terms and graphical representation techniques, including using digital tools
 
@@ -131,9 +131,9 @@ generate, test, iterate and communicate design ideas, processes and solutions us
 *  producing annotated concept sketches and drawings, using technical terms, scale, symbols, pictorial and aerial views to draw environments; production drawings, perspective drawings, orthogonal drawings; patterns and templates to explain product design ideas
 *  documenting and communicating the generation and development and selection of design ideas for an intended audience, for example developing a digital portfolio with images and text which clearly communicate each step of a design process
 
-#### Producing and implementing
+#### Producing and implementing {#producing-and-implementing}
 
-##### AC9TDE8P03
+##### AC9TDE8P03 {#ac9tde8p03}
 
 select, justify and use suitable materials, components, tools, equipment, skills and processes to safely make designed solutions
 
@@ -144,9 +144,9 @@ select, justify and use suitable materials, components, tools, equipment, skills
 *  identifying and managing risks in the development of various projects, for example working safely, responsibly, cooperatively and ethically on design projects; assessing and responding to uncertainty and risk in relation to long-term health and environmental impacts, for example ensuring appropriate personal protective equipment (PPE) is worn or that ventilation is appropriate where solvents, glues or 3D printers are used
 *  considering how to improve technical expertise required to use tools or equipment needed to design a solution, for example using an online tutorial to learn to use software for design or production
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9TDE8P04
+##### AC9TDE8P04 {#ac9tde8p04}
 
 develop design criteria collaboratively including sustainability to evaluate design ideas, processes and solutions
 
@@ -156,9 +156,9 @@ develop design criteria collaboratively including sustainability to evaluate des
 *  re-evaluating, iterating and modifying design processes to improve efficiency and increase production, for example when mass producing a product for an enterprise or improving sustainability
 *  evaluating designed solutions and processes and transferring new knowledge and skills to future design projects, for example considering project planning skills learnt in producing an engineered product and using them in future projects
 
-#### Collaborating and managing
+#### Collaborating and managing {#collaborating-and-managing}
 
-##### AC9TDE8P05
+##### AC9TDE8P05 {#ac9tde8p05}
 
 develop project plans to individually and collaboratively manage time, cost and production of designed solutions
 
@@ -167,7 +167,7 @@ develop project plans to individually and collaboratively manage time, cost and 
 *  identifying risks and how to minimise them, organising time, evaluating decisions and managing resources to ensure successful project completion, for example using digital tools to keep track of tasks, resources, expenses and deadlines
 *  investigating the time needed for each step of production, for example estimating time allocations on a planning template for the different stages of the design process needed to produce a clock, acoustic speaker or desk lamp using prior knowledge, research and testing
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8 students explain how people design, innovate and produce products, services and environments for preferred futures. For each of the 4 prescribed technologies contexts they explain how the features of technologies impact on design decisions, and create designed solutions based on analysis of needs or opportunities. Students create and adapt design ideas, processes and solutions, and justify their decisions against developed design criteria that include sustainability. They communicate design ideas and solutions to audiences using technical terms and graphical representation techniques, including using digital tools. They independently and collaboratively document and manage production processes to safely produce designed solutions.
 

--- a/curriculum/tech-design-and-technologies/years-9-and-10.md
+++ b/curriculum/tech-design-and-technologies/years-9-and-10.md
@@ -1,6 +1,6 @@
-# Technologies - Design and Technologies - Years 9 and 10
+# Design and Technologies - Years 9 and 10 {#design-and-technologies-years-9-and-10}
 
-## Level Description
+## Level Description {#level-description}
 
 By the end of Year 10 students should have had the opportunity to design and produce at least 4 designed solutions focused on one or more of the 4 technologies contexts:
 
@@ -19,13 +19,13 @@ Using a range of technologies including a variety of graphical representation te
 
 Students identify the steps involved in planning the production of designed solutions. They develop detailed project management plans, incorporating elements such as sequenced time, cost and action plans, to manage design tasks safely. Students apply management plans, making adjustments when necessary, to successfully complete design tasks. They identify and establish safety procedures that minimise risk and manage projects with safety and efficiency in mind, maintaining safety standards and management procedures to ensure success.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Technologies and society
+#### Technologies and society {#technologies-and-society}
 
-##### AC9TDE10K01
+##### AC9TDE10K01 {#ac9tde10k01}
 
 analyse how people in design and technologies occupations consider ethical, security and sustainability factors to innovate and improve products, services and environments
 
@@ -38,7 +38,7 @@ analyse how people in design and technologies occupations consider ethical, secu
 *  examining mass production systems taking into account ethics and sustainability considerations, for example the mass production of food, clothing and shoes and why manufacturers produce different versions of the same product and support complete product life cycle strategies
 *  explaining the consequences of ethical and sustainability decisions for products, services and environments, for example the accessibility of a managed public environment, the design of roads to include aerial bridges for wildlife and signage powered with solar technologies
 
-##### AC9TDE10K02
+##### AC9TDE10K02 {#ac9tde10k02}
 
 analyse the impact of innovation, enterprise and emerging technologies on designed solutions for global preferred futures
 
@@ -48,9 +48,9 @@ analyse the impact of innovation, enterprise and emerging technologies on design
 *  investigating scenarios of how the future may unfold and what opportunities and impacts there may be for society and particular groups in a preferred future, for example by using forecasting and backcasting techniques
 *  examining real-world problems and understanding basic needs when considering designed solutions, for example students collaborating to design solutions to challenges in the Asia region; or artists from a country in South-East Asia creating posters for the world to take action in a pandemic
 
-#### Technologies context: Engineering principles and systems
+#### Technologies context: Engineering principles and systems {#technologies-context-engineering-principles-and-systems}
 
-##### AC9TDE10K03
+##### AC9TDE10K03 {#ac9tde10k03}
 
 analyse and make judgements on how the characteristics and properties of materials are combined with force, motion and energy to control engineered systems
 
@@ -62,9 +62,9 @@ analyse and make judgements on how the characteristics and properties of materia
 *  investigating how the placement of wind turbines in a wind farm affects their performance, for example designing a layout to maximise the productivity of a wind farm within a given space
 *  investigating the main types of chargers for electric vehicles (EV) and their capabilities, for example making a recommendation for the best charger for an EV owner who uses their vehicle for commuting to work
 
-#### Technologies context: Food and fibre production
+#### Technologies context: Food and fibre production {#technologies-context-food-and-fibre-production}
 
-##### AC9TDE10K04
+##### AC9TDE10K04 {#ac9tde10k04}
 
 analyse and make judgements on the ethical, secure and sustainable production and marketing of food and fibre enterprises
 
@@ -76,9 +76,9 @@ analyse and make judgements on the ethical, secure and sustainable production an
 *  considering the meaning of food and water security and how they may influence design decisions for creating preferred futures, for example using water-efficient irrigation, protected cropping where crops are grown under cover to increase production over a longer period or choosing drought-resistant varieties of plants and animals
 *  examining the marketing chain of a range of agricultural products and outlining the effect of product processing and advertising on demand and price including the impact of cash crops on communities
 
-#### Technologies context: Food specialisations
+#### Technologies context: Food specialisations {#technologies-context-food-specialisations}
 
-##### AC9TDE10K05
+##### AC9TDE10K05 {#ac9tde10k05}
 
 analyse and make judgements on how the sensory and functional properties of food influence the design and preparation of sustainable food solutions for healthy eating
 
@@ -91,9 +91,9 @@ analyse and make judgements on how the sensory and functional properties of food
 *  investigating ways innovations may influence human health and sustainability, for example 3D printing of foods, Internet of Things (IoT) network in the food supply chain or use of augmented reality (AR) in food labelling
 *  considering factors that influence the preparation and presentation of foods using a range of techniques to ensure optimum nutrient content, flavour, texture and visual appeal, for example designing and producing a healthy snack for the canteen and using food photography and digital tools to promote the item in a healthy eating campaign
 
-#### Technologies context: Materials and technologies specialisations
+#### Technologies context: Materials and technologies specialisations {#technologies-context-materials-and-technologies-specialisations}
 
-##### AC9TDE10K06
+##### AC9TDE10K06 {#ac9tde10k06}
 
 analyse and make judgements on how characteristics and properties of materials, systems, components, tools and equipment can be combined to create designed solutions
 
@@ -106,11 +106,11 @@ analyse and make judgements on how characteristics and properties of materials, 
 *  investigating fibre-based medical textile products and structures used in a medical environment for treatment of an injury or the clinical treatment of a wound or an illness, for example collagen fibre used as a suture is as strong as silk and biodegradable
 *  investigating soft robotics including nanomaterials which enable them to function like human muscles
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Investigating and defining
+#### Investigating and defining {#investigating-and-defining}
 
-##### AC9TDE10P01
+##### AC9TDE10P01 {#ac9tde10p01}
 
 analyse needs or opportunities for designing; develop design briefs; and investigate, analyse and select materials, systems, components, tools and equipment to create designed solutions
 
@@ -122,9 +122,9 @@ analyse needs or opportunities for designing; develop design briefs; and investi
 *  considering the needs of community groups to identify rich design tasks, for example interviewing community members about accessibility requirements to develop the initial brief and then during specific phases of the design process to determine the best possible designed solution for the community
 *  examining tools, techniques, equipment and relationships of properties for complementary materials for product development, for example examining compressive and tensile strengths of materials
 
-#### Generating and designing
+#### Generating and designing {#generating-and-designing}
 
-##### AC9TDE10P02
+##### AC9TDE10P02 {#ac9tde10p02}
 
 apply innovation and enterprise skills to generate, test, iterate and communicate design ideas, processes and solutions, including using digital tools
 
@@ -136,9 +136,9 @@ apply innovation and enterprise skills to generate, test, iterate and communicat
 *  communicating using appropriate technical terms and recording the generation and development of design ideas and processes for an intended audience including justification of decisions, for example developing a digital portfolio with images and text which clearly communicate each step of a design process
 *  using design thinking and enterprise skills to create innovative approaches to processes and solutions, for example brainstorming novel ideas inspired by nature or transforming a solution into an enterprise for a target market
 
-#### Producing and implementing
+#### Producing and implementing {#producing-and-implementing}
 
-##### AC9TDE10P03
+##### AC9TDE10P03 {#ac9tde10p03}
 
 select, justify, test and use suitable technologies, skills and processes, and apply safety procedures to safely make designed solutions
 
@@ -149,9 +149,9 @@ select, justify, test and use suitable technologies, skills and processes, and a
 *  modifying production processes to respond to opportunities, risks or unforeseen challenges, for example when producing bulk quantities of recipes in terms of workload and coordination, the impact of lower-than-average rainfalls on crop growth or using materials with unexpected faults
 *  experimenting with the functional and sensory properties of food to determine the most successful approach, for example preparing vegetables 3 different ways to maximise colour, flavour and nutritive value
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9TDE10P04
+##### AC9TDE10P04 {#ac9tde10p04}
 
 develop design criteria independently including sustainability to evaluate design ideas, processes and solutions
 
@@ -161,9 +161,9 @@ develop design criteria independently including sustainability to evaluate desig
 *  reflecting on learning including processes or choices made at various stages of a design process and modifying plans when needed with consideration of design criteria
 *  responding creatively to evaluation feedback to iterate and modify design ideas and processes to improve sustainability measures, for example considering opportunities to use sustainable materials, such as plant-based timber oils or bioplastics
 
-#### Collaborating and managing
+#### Collaborating and managing {#collaborating-and-managing}
 
-##### AC9TDE10P05
+##### AC9TDE10P05 {#ac9tde10p05}
 
 develop project plans for intended purposes and audiences to individually and collaboratively manage projects, taking into consideration time, cost, risk, processes and production of designed solutions
 
@@ -172,7 +172,7 @@ develop project plans for intended purposes and audiences to individually and co
 *  collaborating to develop production plans for equitable distribution of work including discussing roles, tasks and deadlines and considering flexibility and contingencies
 *  investigating manufacturing processes to identify strategies to enhance production, for example identifying techniques to reduce use, cut costs, speed up processes or to form beneficial partnerships with others in production
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 10 students should have had the opportunity to design and produce at least 4 designed solutions focused on one or more of the 4 technologies contexts:
 

--- a/curriculum/tech-digital-technologies/foundation-year.md
+++ b/curriculum/tech-digital-technologies/foundation-year.md
@@ -1,6 +1,6 @@
-# Technologies - Digital Technologies - Foundation Year
+# Digital Technologies - Foundation Year {#digital-technologies-foundation-year}
 
-## Level Description
+## Level Description {#level-description}
 
 Learning in Digital Technologies builds on the Early Years Learning Framework and each student’s prior learning and experiences.
 
@@ -10,13 +10,13 @@ Through Digital Technologies and Mathematics (_Statistics_), students have oppor
 
 In Digital Technologies, students should have frequent opportunities for authentic learning by making key connections with other learning areas.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Digital systems
+#### Digital systems {#digital-systems}
 
-##### AC9TDIFK01
+##### AC9TDIFK01 {#ac9tdifk01}
 
 recognise and explore digital systems (hardware and software) for a purpose
 
@@ -27,9 +27,9 @@ recognise and explore digital systems (hardware and software) for a purpose
 *  taking photos, with permission, to share with others, for example close-up photos of First Nations Australians' material culture, such as woven mats or baskets revealing intricate detail
 *  making a model of a digital system, using it in a role-play scenario and describing its features, for example a cardboard box with a keyboard and screen with app icons
 
-#### Data representation
+#### Data representation {#data-representation}
 
-##### AC9TDIFK02
+##### AC9TDIFK02 {#ac9tdifk02}
 
 represent data as objects, pictures and symbols
 
@@ -38,11 +38,11 @@ represent data as objects, pictures and symbols
 *  using coloured blocks to represent an attribute of people, for example representing students and their sports houses with different coloured blocks
 *  using a symbol to represent an idea, but knowing that the symbol is not the data itself, for example the symbols and colour on both the Australian Aboriginal flag and the Torres Strait Islander flag
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Privacy and security
+#### Privacy and security {#privacy-and-security}
 
-##### AC9TDIFP01
+##### AC9TDIFP01 {#ac9tdifp01}
 
 identify some data that is personal and owned by them
 
@@ -50,7 +50,7 @@ identify some data that is personal and owned by them
 *  listing things that contain personal and public data, for example photos of themselves with their family (private) and photos of local community sites (public)
 *  identifying apps and websites they use where their personal data could be made visible, for example photos of themselves on parents' or carers’ social media, or their username being shown to others in online games
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Foundation students show familiarity with digital systems and use them for a purpose. They represent data using objects, pictures and symbols and identify examples of data that is owned by them.
 

--- a/curriculum/tech-digital-technologies/years-1-and-2.md
+++ b/curriculum/tech-digital-technologies/years-1-and-2.md
@@ -1,6 +1,6 @@
-# Technologies - Digital Technologies - Years 1 and 2
+# Digital Technologies - Years 1 and 2 {#digital-technologies-years-1-and-2}
 
-## Level Description
+## Level Description {#level-description}
 
 By the end of Year 2 students should have had the opportunity to apply computational thinking by describing algorithms that include sequences of instructions and decisions, and by using digital systems to produce simple solutions. Through practice and investigation, they become more familiar with and confident in representing data in different ways.
 
@@ -10,13 +10,13 @@ Students develop systems thinking by exploring a range of purposes for using dig
 
 In Digital Technologies, students should have frequent opportunities for authentic learning by making key connections with other learning areas.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Digital systems
+#### Digital systems {#digital-systems}
 
-##### AC9TDI2K01
+##### AC9TDI2K01 {#ac9tdi2k01}
 
 identify and explore digital systems and their components for a purpose
 
@@ -25,9 +25,9 @@ identify and explore digital systems and their components for a purpose
 *  naming and using digital systems that they interact with at home and school, for example using a touchpad to move the cursor on a laptop, or the keyboard to type a simple message on a tablet
 *  using different digital systems to explore what they do and how to use them, for example selecting the camera icon allows them to take photos of things that are a familiar shape
 
-#### Data representation
+#### Data representation {#data-representation}
 
-##### AC9TDI2K02
+##### AC9TDI2K02 {#ac9tdi2k02}
 
 represent data as pictures, symbols, numbers and words
 
@@ -36,11 +36,11 @@ represent data as pictures, symbols, numbers and words
 *  recognising the equivalence of different representations of numbers, including words, digits and tally marks
 *  recognising that pictures in First Nations Australians’ seasonal calendars are used to represent and communicate data, such as how the appearance of a flower can signify a connected event or a resource availability, for example how the Gulumoerrgin Peoples from the Darwin region of the Northern Territory understand that the fruiting of freshwater mangrove signifies it is time to harvest magpie geese
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Investigating and defining
+#### Investigating and defining {#investigating-and-defining}
 
-##### AC9TDI2P01
+##### AC9TDI2P01 {#ac9tdi2p01}
 
 investigate simple problems for known users that can be solved with digital systems
 
@@ -50,9 +50,9 @@ investigate simple problems for known users that can be solved with digital syst
 *  identifying how digital systems are used to solve problems at school, for example taking attendance or borrowing a library book
 *  exploring how a familiar problem could be solved using a robot, for example creating a model robot using cardboard boxes and explaining how it could be used to clean up the classroom floor at the end of the day
 
-#### Generating and designing
+#### Generating and designing {#generating-and-designing}
 
-##### AC9TDI2P02
+##### AC9TDI2P02 {#ac9tdi2p02}
 
 follow and describe algorithms involving a sequence of steps, branching (decisions) and iteration (repetition)
 
@@ -64,9 +64,9 @@ follow and describe algorithms involving a sequence of steps, branching (decisio
 *  identifying the decisions needed to solve a problem and the next steps to follow in each case, for example if it is raining, take a raincoat, otherwise take a hat
 *  following algorithms that repeat a single step a fixed number of times, for example practise spelling a word 5 times or throw and catch a ball with a partner 10 times
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9TDI2P03
+##### AC9TDI2P03 {#ac9tdi2p03}
 
 discuss how existing digital systems satisfy identified needs for known users
 
@@ -76,9 +76,9 @@ discuss how existing digital systems satisfy identified needs for known users
 *  sharing ideas about how digital systems are used at school for learning, for example sharing a student's work with the class on an interactive display screen to provide class feedback on their writing
 *  sharing and describing ways that common digital systems can be used to meet communication needs, for example tablets can be used as phones and tools for communication between families living in different locations
 
-#### Collaborating and managing
+#### Collaborating and managing {#collaborating-and-managing}
 
-##### AC9TDI2P04
+##### AC9TDI2P04 {#ac9tdi2p04}
 
 use the basic features of common digital tools to create, locate and communicate content
 
@@ -89,7 +89,7 @@ use the basic features of common digital tools to create, locate and communicate
 *  using a camera or drawing app to create a picture, for example making a card for a family member that includes a photo and short message
 *  creating individual pieces of work that contribute to a group task, for example each student contributes a recipe and photo of their favourite food to create a class recipe book
 
-##### AC9TDI2P05
+##### AC9TDI2P05 {#ac9tdi2p05}
 
 use the basic features of common digital tools to share content and collaborate demonstrating agreed behaviours, guided by trusted adults
 
@@ -98,16 +98,16 @@ use the basic features of common digital tools to share content and collaborate 
 *  applying agreed standards of behaviour when sharing content with classmates, for example using language that is considered by all students and the teacher to be appropriate when they are writing messages to each other
 *  considering the need for online safety when sharing information, for example recognising that personal information such as a photo can be used inappropriately
 
-#### Privacy and security
+#### Privacy and security {#privacy-and-security}
 
-##### AC9TDI2P06
+##### AC9TDI2P06 {#ac9tdi2p06}
 
 access their school account with a recorded username and password
 
 **Elaborations**
 *  using username and password recorded in a private place to access a digital system, for example logging into a school computer using details given on a card by the teacher
 
-##### AC9TDI2P07
+##### AC9TDI2P07 {#ac9tdi2p07}
 
 discuss that some websites and apps store their personal data online
 
@@ -115,7 +115,7 @@ discuss that some websites and apps store their personal data online
 *  sharing examples of the data collected by apps and websites they commonly use, for example usernames and email addresses used by school websites and games to log in
 *  discussing the importance of asking permission from a parent or carer before entering personal details online such as address, phone number and date of birth
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 2 students show how simple digital solutions meet a need for known users. Students represent and process data in different ways. They follow and describe basic algorithms involving a sequence of steps and branching. With assistance, students access and use digital systems for a purpose. They use the basic features of common digital tools to create, locate and share content, and to collaborate, following agreed behaviours. Students recognise that digital tools may store their personal data online.
 

--- a/curriculum/tech-digital-technologies/years-3-and-4.md
+++ b/curriculum/tech-digital-technologies/years-3-and-4.md
@@ -1,6 +1,6 @@
-# Technologies - Digital Technologies - Years 3 and 4
+# Digital Technologies - Years 3 and 4 {#digital-technologies-years-3-and-4}
 
-## Level Description
+## Level Description {#level-description}
 
 By the end of Year 4 students should have had the opportunity to broaden their computational thinking by creating simple digital solutions, individually and in groups, that involve defining problems, and designing and implementing solutions as visual programs. Students practise defining problems using design criteria given to them, and user stories developed by the class. Through practice, students improve the precision of their algorithms and implement them as visual programs. Students expand their understanding of data representation by exploring how and why the same data can be represented in different ways to meet different purposes.
 
@@ -10,13 +10,13 @@ Students apply design thinking techniques to generate multiple ideas for the des
 
 In Digital Technologies, students should have frequent opportunities for authentic learning by making key connections with other learning areas.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Digital systems
+#### Digital systems {#digital-systems}
 
-##### AC9TDI4K01
+##### AC9TDI4K01 {#ac9tdi4k01}
 
 explore and describe a range of digital systems and their peripherals for a variety of purposes
 
@@ -25,7 +25,7 @@ explore and describe a range of digital systems and their peripherals for a vari
 *  adding peripherals to a digital system to expand its functionality, for example connecting a headset to a digital system to participate in an online lesson more effectively
 *  exploring how they can use digital systems differently depending on the task, recognising that many digital systems can perform multiple tasks, for example a student can use a tablet to take photos, record audio and find information to create a presentation
 
-##### AC9TDI4K02
+##### AC9TDI4K02 {#ac9tdi4k02}
 
 explore transmitting different types of data between digital systems
 
@@ -33,9 +33,9 @@ explore transmitting different types of data between digital systems
 *  exploring examples of different types of data that can be transferred between digital systems, for example streaming music or making a video call to a friend using a smartphone
 *  exploring how data (video call) can be transmitted from a remote community to a city location, for example looking at how many First Nations Australian communities in areas classified as remote rely on 3G network coverage, limiting the use of video calls
 
-#### Data representation
+#### Data representation {#data-representation}
 
-##### AC9TDI4K03
+##### AC9TDI4K03 {#ac9tdi4k03}
 
 recognise different types of data and explore how the same data can be represented differently depending on the purpose
 
@@ -45,11 +45,11 @@ recognise different types of data and explore how the same data can be represent
 *  explaining that the same information can be represented differently, for example the term ‘stop’ can also be represented with an octagon-shaped red sign or a hand icon
 *  identifying rock paintings and other cultural expressions to understand that images are used to encode and represent ethnobotanical knowledge, for example the representation of plant use in the Kimberley cave paintings and ancient engravings including important data on medicinal and food plant classification and their usable parts
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Investigating and defining
+#### Investigating and defining {#investigating-and-defining}
 
-##### AC9TDI4P01
+##### AC9TDI4P01 {#ac9tdi4p01}
 
 define problems with given design criteria and by co-creating user stories
 
@@ -60,9 +60,9 @@ define problems with given design criteria and by co-creating user stories
 *  developing a problem statement for collecting and managing information, for example how First Nations Australians rangers could monitor animal populations, such as local marine turtles, using global positioning systems (GPS)
 *  co-creating user stories about exploring hard-to-reach locations, for example a school student wants to explore neighbouring countries classified as remote to compare how people live
 
-#### Generating and designing
+#### Generating and designing {#generating-and-designing}
 
-##### AC9TDI4P02
+##### AC9TDI4P02 {#ac9tdi4p02}
 
 follow and describe algorithms involving sequencing, comparison operators (branching) and iteration
 
@@ -73,7 +73,7 @@ follow and describe algorithms involving sequencing, comparison operators (branc
 *  describing the decisions needed to solve a problem, including numerical and text comparisons, for example if the UV index is above 3, put on sunscreen and a hat
 *  describing algorithms that repeat steps a fixed number of times, for example calculating multiplication using repeated addition, where the sum changes in each iteration
 
-##### AC9TDI4P03
+##### AC9TDI4P03 {#ac9tdi4p03}
 
 generate, communicate and compare designs
 
@@ -82,9 +82,9 @@ generate, communicate and compare designs
 *  discussing whether the needs identified from the user story are met by generated design ideas, for example comparing design ideas in pairs for encouraging people to recycle
 *  ideating multiple design ideas and comparing them against user stories, for example as a class, discussing the needs identified from the user story and brainstorming multiple design ideas (accepting all suggestions as possibilities)
 
-#### Producing and implementing
+#### Producing and implementing {#producing-and-implementing}
 
-##### AC9TDI4P04
+##### AC9TDI4P04 {#ac9tdi4p04}
 
 implement simple algorithms as visual programs involving control structures and input
 
@@ -96,9 +96,9 @@ implement simple algorithms as visual programs involving control structures and 
 *  running and testing a program to check it performs as expected, for example a character: 1. moves forward 2. turns left 3. moves forward
 *  implementing a program that demonstrates the strict routines and techniques followed by First Nations Australian ranger groups when caring for or handling specific native animals, for example using IF and THEN statements to create a training manual, such as: IF <insert animal name> is injured THEN the ranger will <insert action>
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9TDI4P05
+##### AC9TDI4P05 {#ac9tdi4p05}
 
 discuss how existing and student solutions satisfy the design criteria and user stories
 
@@ -108,9 +108,9 @@ discuss how existing and student solutions satisfy the design criteria and user 
 *  making judgements on their digital solutions against the design criteria and user stories, for example how high their friends score in the game they created to help them learn what is recyclable
 *  reflecting on how the systems in the school help it run, for example how the librarian keeps track of books borrowed
 
-#### Collaborating and managing
+#### Collaborating and managing {#collaborating-and-managing}
 
-##### AC9TDI4P06
+##### AC9TDI4P06 {#ac9tdi4p06}
 
 use the core features of common digital tools to create, locate and communicate content, following agreed conventions
 
@@ -120,7 +120,7 @@ use the core features of common digital tools to create, locate and communicate 
 *  grouping, naming and itemising objects using a logical hierarchy, for example creating a section of a virtual library or virtual supermarket using folders and files
 *  using autocomplete features in text authoring tools; for example, using suggestions in a word processor to complete words or sentences, or using predictive text in SMS or messaging apps
 
-##### AC9TDI4P07
+##### AC9TDI4P07 {#ac9tdi4p07}
 
 use the core features of common digital tools to share content, plan tasks, and collaborate, following agreed behaviours, supported by trusted adults
 
@@ -131,9 +131,9 @@ use the core features of common digital tools to share content, plan tasks, and 
 *  interacting cooperatively in a group in an online environment to plan and complete a task, for example writing and responding to others’ views on canteen products
 *  using digital tools to plan an event as a class, for example jointly creating a class survey to help plan an end-of-year party, where responses conform to the class's accepted behavioural expectations
 
-#### Privacy and security
+#### Privacy and security {#privacy-and-security}
 
-##### AC9TDI4P08
+##### AC9TDI4P08 {#ac9tdi4p08}
 
 access their school account using a memorised password and explain why it should be easy to remember, but hard for others to guess
 
@@ -142,7 +142,7 @@ access their school account using a memorised password and explain why it should
 *  explaining how keeping a password secret prevents others from accessing their data, for example how their work is saved in their account and can only be accessed using their secret password
 *  exploring techniques to create an easy to remember and hard to guess password, for example creating a password using 3 unrelated but easy to remember words
 
-##### AC9TDI4P09
+##### AC9TDI4P09 {#ac9tdi4p09}
 
 identify what personal data is stored and shared in their online accounts and discuss any associated risks
 
@@ -150,7 +150,7 @@ identify what personal data is stored and shared in their online accounts and di
 *  identifying the personal data stored in accounts they use at school and at home and who has access to it, for example documents in their school cloud storage are accessible by the teacher, or their nickname in their online gaming accounts is visible to all players
 *  discussing how personal data stored in online accounts forms a person’s digital identity and can reveal detailed information about people, for example looking at photographs of themselves, friends or fictional characters that reveal details about a person's location, habits or home
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 4 students create simple digital solutions and use provided design criteria to check if solutions meet user needs. Students process and represent data for different purposes. They follow and describe simple algorithms involving branching and iteration and implement them as visual programs. Students securely access and use digital systems and their peripherals for a range of purposes, including transmitting data. They use the core features of common digital tools to plan, create, locate and share content, and to collaborate, following agreed behaviours. Students identify their personal data stored online and recognise the risks.
 

--- a/curriculum/tech-digital-technologies/years-5-and-6.md
+++ b/curriculum/tech-digital-technologies/years-5-and-6.md
@@ -1,6 +1,6 @@
-# Technologies - Digital Technologies - Years 5 and 6
+# Digital Technologies - Years 5 and 6 {#digital-technologies-years-5-and-6}
 
-## Level Description
+## Level Description {#level-description}
 
 By the end of Year 6 students should have had the opportunity to apply computational thinking by creating digital solutions that involve defining problems, designing and modifying algorithms, and implementing them as visual programs. Students practise different strategies to develop their abstract thinking, such as thinking out aloud to simplify problems, which is needed when defining them. They represent algorithms involving branching and iteration and implement them as visual programs that include variables and respond to input. Students think in a more abstract way, exploring how on and off states and whole numbers can be used to represent data.
 
@@ -10,13 +10,13 @@ Students apply systems thinking when investigating the functions and purpose of 
 
 In Digital Technologies, students should have frequent opportunities for authentic learning by making key connections with other learning areas.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Digital systems
+#### Digital systems {#digital-systems}
 
-##### AC9TDI6K01
+##### AC9TDI6K01 {#ac9tdi6k01}
 
 investigate the main internal components of common digital systems and their function
 
@@ -25,7 +25,7 @@ investigate the main internal components of common digital systems and their fun
 *  exploring how the central processing unit (CPU), memory and input/output components work together to perform a simple calculation
 *  investigating the main components in a video conferencing system and their functions, for example a telehealth system used to access ultrasound and other imagery services by communities in areas classified as remote such as those of some First Nations Australians
 
-##### AC9TDI6K02
+##### AC9TDI6K02 {#ac9tdi6k02}
 
 examine how digital systems form networks to transmit data
 
@@ -34,9 +34,9 @@ examine how digital systems form networks to transmit data
 *  describing the way data is structured and transmitted through a network, for example broken up into packets (small pieces) and passed from the source, through multiple devices, to the destination
 *  investigating the use of satellite phones where mobile phone networks are not available, inaccessible or unreliable, for example many homeland communities of Arnhem Land have limited access to mainstream communication networks
 
-#### Data representation
+#### Data representation {#data-representation}
 
-##### AC9TDI6K03
+##### AC9TDI6K03 {#ac9tdi6k03}
 
 explain how digital systems represent all data using numbers
 
@@ -44,7 +44,7 @@ explain how digital systems represent all data using numbers
 *  representing data using whole numbers and recognising this is how digital systems represent data, for example converting letters in a message to numbers using their position in the alphabet
 *  explaining how the data type used to represent data changes the operations that can be performed on it, for example adding numbers performs addition whereas adding strings joins them
 
-##### AC9TDI6K04
+##### AC9TDI6K04 {#ac9tdi6k04}
 
 explore how data can be represented by off and on states (zeros and ones in binary)
 
@@ -53,11 +53,11 @@ explore how data can be represented by off and on states (zeros and ones in bina
 *  demonstrating that an on/off state in a circuit can represent the digits one and zero, and this is how digital systems represent data
 *  recognising how the answer to a yes/no question can be represented using on/off states, for example switching a light on or off in a circuit or a long or short dash (beep) in Morse code
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Investigating and defining
+#### Investigating and defining {#investigating-and-defining}
 
-##### AC9TDI6P01
+##### AC9TDI6P01 {#ac9tdi6p01}
 
 define problems with given or co-developed design criteria and by creating user stories
 
@@ -66,9 +66,9 @@ define problems with given or co-developed design criteria and by creating user 
 *  discussing possible design criteria based on a stimulus, for example the cost, sustainability and timeliness for a roadside bushfire or flood risk rating system
 *  investigating the impact that feral animals have on native flora and fauna and how this problem has led to economic development opportunities for groups such as the Arnhem Land Progress Aboriginal Corporation
 
-#### Generating and designing
+#### Generating and designing {#generating-and-designing}
 
-##### AC9TDI6P02
+##### AC9TDI6P02 {#ac9tdi6p02}
 
 design algorithms involving multiple alternatives (branching) and iteration
 
@@ -80,7 +80,7 @@ design algorithms involving multiple alternatives (branching) and iteration
 *  planning algorithms that repeat until a condition is met, for example keep mixing UNTIL the ingredients are combined or subtracting a number UNTIL the result reaches zero
 *  designing an algorithm including branching and iteration which responds to data, for example how First Nations Australian rangers use structured procedures to respond to live tracking data that indicates feral buffalo are approaching an environmentally or culturally significant site
 
-##### AC9TDI6P03
+##### AC9TDI6P03 {#ac9tdi6p03}
 
 design a user interface for a digital system
 
@@ -89,7 +89,7 @@ design a user interface for a digital system
 *  designing a user interface to address an identified need, for example including customisable font size and colour contrast to help users who are visually impaired
 *  modelling how user interfaces allow people from different cultures and language backgrounds to access information, for example using consistent symbols to represent common actions such as copy, paste and save
 
-##### AC9TDI6P04
+##### AC9TDI6P04 {#ac9tdi6p04}
 
 generate, modify, communicate and evaluate designs
 
@@ -97,9 +97,9 @@ generate, modify, communicate and evaluate designs
 *  ideating a range of possible design ideas, discussing them and judging them against the design criteria and user stories, for example using the design criteria to put design ideas in order of preference in a group discussion
 *  suggesting modifications to the preferred design idea if it does not satisfy all design criteria and user stories, for example modifying a game or game controller so that it can be used by a wider range of players
 
-#### Producing and implementing
+#### Producing and implementing {#producing-and-implementing}
 
-##### AC9TDI6P05
+##### AC9TDI6P05 {#ac9tdi6p05}
 
 implement algorithms as visual programs involving control structures, variables and input
 
@@ -111,9 +111,9 @@ implement algorithms as visual programs involving control structures, variables 
 *  stating the expected behaviour of a program, running the program to check it is correct and fixing any errors, for example 'when I press the left arrow key, the cat should move left, finding the cat moves right, and fixing it by changing the 10 to -10 to alter the direction'
 *  programming digital systems to perform automated tasks, such as closing gates, for example simulating the work of First Nations Australian rangers attempting to lure and capture feral animals
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9TDI6P06
+##### AC9TDI6P06 {#ac9tdi6p06}
 
 evaluate existing and student solutions against the design criteria and user stories and their broader community impact
 
@@ -123,9 +123,9 @@ evaluate existing and student solutions against the design criteria and user sto
 *  reflecting on the many systems that are used in the wider community to address a range of problems, for example timetables to manage transport and other services through to details such as storing licence information so that police can enforce road rules
 *  verifying the correctness of AI-generated content against information known to be factually accurate; for example, comparing the output from a generative text model providing a biography of a local leader with the data published on their official website or other authoritative source
 
-#### Collaborating and managing
+#### Collaborating and managing {#collaborating-and-managing}
 
-##### AC9TDI6P07
+##### AC9TDI6P07 {#ac9tdi6p07}
 
 select and use appropriate digital tools effectively to create, locate and communicate content, applying common conventions
 
@@ -136,7 +136,7 @@ select and use appropriate digital tools effectively to create, locate and commu
 *  creating content for a school celebration, for example designing a collaborative spreadsheet that can be used by a small group to plan and cost their graduation party, together with a folder of tagged resources which support the planning
 *  judging the tone and appropriateness for the intended audience of text generated using autocomplete; for example, deciding that the predictive text was too formal for a conversation with a friend and rewriting it in more casual language
 
-##### AC9TDI6P08
+##### AC9TDI6P08 {#ac9tdi6p08}
 
 select and use appropriate digital tools effectively to share content online, plan tasks and collaborate on projects, demonstrating agreed behaviours
 
@@ -147,9 +147,9 @@ select and use appropriate digital tools effectively to share content online, pl
 *  demonstrating agreed behaviours; following cultural protocols, including relevant permissions and attributions; acknowledging diversity, capability and strength; and addressing risks and responsibilities such as privacy, security, and accuracy of data; for example when sharing images of First Nations Australians' cultural artefacts
 *  using a range of communication tools to share ideas and information with stakeholders, for example presenting content for a school celebration such as a graduation celebration with the parents and citizens association or school executive in an online forum
 
-#### Privacy and security
+#### Privacy and security {#privacy-and-security}
 
-##### AC9TDI6P09
+##### AC9TDI6P09 {#ac9tdi6p09}
 
 access multiple personal accounts using unique passphrases and explain the risks of password re-use
 
@@ -157,7 +157,7 @@ access multiple personal accounts using unique passphrases and explain the risks
 *  using multiple accounts, each with different passphrases, to access each website or app used for school and home, for example having a different username and password combination for school, gaming and music accounts
 *  explaining why re-using a password is risky when one of them is found out, for example how a compromised password from one social media account might be able to be used to access their bank or school account if the password is the same and other details are also compromised
 
-##### AC9TDI6P10
+##### AC9TDI6P10 {#ac9tdi6p10}
 
 explain the creation and permanence of their digital footprint and consider privacy when collecting user data
 
@@ -166,7 +166,7 @@ explain the creation and permanence of their digital footprint and consider priv
 *  explaining why collecting the smallest amount of data needed for a purpose is important to protect someone's privacy, for example how choosing not to collect information about someone's birthdate when it is not necessary ensures that private data cannot be stolen in a cyber attack
 *  understanding the implications of how personal data can be used to train generative AI models; for example, sharing personal information increases the likelihood that private information is revealed through AI outputs now and in the future
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 6 students develop and modify digital solutions, and define problems and evaluate solutions using user stories and design criteria. They process data and show how digital systems represent data. Students design algorithms involving complex branching and iteration and implement them as visual programs including variables. They securely access and use multiple digital systems and describe their components and how they interact to process and transmit data. Students select and use appropriate digital tools effectively to plan, create, locate and share content, and to collaborate, applying agreed conventions and behaviours. They identify their digital footprint and recognise its permanence.
 

--- a/curriculum/tech-digital-technologies/years-7-and-8.md
+++ b/curriculum/tech-digital-technologies/years-7-and-8.md
@@ -1,6 +1,6 @@
-# Technologies - Digital Technologies - Years 7 and 8
+# Digital Technologies - Years 7 and 8 {#digital-technologies-years-7-and-8}
 
-## Level Description
+## Level Description {#level-description}
 
 By the end of Year 8 students should have had the opportunity to apply computational thinking by defining and decomposing real-world problems, creating user experiences, designing and modifying algorithms, and implementing them in a general-purpose programming language. This involves students practising problem decomposition, using approaches such as divide and conquer to more clearly understand a problem by describing its component parts. Students represent and communicate their algorithmic solutions using flowcharts and pseudocode. Students check their solutions meet the specifications by testing and debugging their algorithms before and during implementation. They develop a deeper understanding of abstraction by explaining how and why digital systems represent data as whole numbers, which are then represented in binary.
 
@@ -12,13 +12,13 @@ Students apply systems thinking by exploring the connections between hardware ca
 
 In Digital Technologies, students should have frequent opportunities for authentic learning by making key connections with other learning areas.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Digital systems
+#### Digital systems {#digital-systems}
 
-##### AC9TDI8K01
+##### AC9TDI8K01 {#ac9tdi8k01}
 
 explain how hardware specifications affect performance and select appropriate hardware for particular tasks and workloads
 
@@ -28,7 +28,7 @@ explain how hardware specifications affect performance and select appropriate ha
 *  considering how First Nations Australians communities in areas classified as remote often share access to smartphone and internet services, and how the hardware specifications of these devices affect performance, for example where immediate and extended families share and access data through a single smartphone or device
 *  explaining how the specifications of components in a system impact the speed with which AI models can be trained; for example, GPUs are more efficient at performing the mathematical calculations necessary for training generative AI than CPUs
 
-##### AC9TDI8K02
+##### AC9TDI8K02 {#ac9tdi8k02}
 
 investigate how data is transmitted and secured in wired and wireless networks including the internet
 
@@ -38,9 +38,9 @@ investigate how data is transmitted and secured in wired and wireless networks i
 *  exploring simple encryption and decryption algorithms, for example ROT13 and XOR
 *  explaining how problems occur in network communication and how they can be solved, for example routers can drop packets and how Transmission Control Protocol (TCP) uses acknowledgements to confirm packets have been received
 
-#### Data representation
+#### Data representation {#data-representation}
 
-##### AC9TDI8K03
+##### AC9TDI8K03 {#ac9tdi8k03}
 
 investigate how digital systems represent text, image and audio data using integers
 
@@ -50,7 +50,7 @@ investigate how digital systems represent text, image and audio data using integ
 *  explaining how digital systems represent bitmap images (for example PNG and JPEG) as the colour of each pixel in separate red, green and blue (RGB) channels ranging from 0 to 255, and represent Scalable Vector graphics (SVG) using the geometry of lines and shapes
 *  investigating how a digital system converts audio data to integers as it records, stores and outputs sound, for example using the Welcome to Country app to understand the local history and Traditional Owners of the lands which students learn on to inform the programming of an Acknowledgement of Country in a local First Nations Australian language
 
-##### AC9TDI8K04
+##### AC9TDI8K04 {#ac9tdi8k04}
 
 explain how and why digital systems represent integers in binary
 
@@ -59,11 +59,11 @@ explain how and why digital systems represent integers in binary
 *  explaining how digital systems represent data in binary, for example by converting a character to its Unicode value, then converting that value into binary
 *  explaining how circuits can perform binary operations represented as on/off states, for example showing how circuits with 2 switches can represent AND or OR gates
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Acquiring, managing and analysing data
+#### Acquiring, managing and analysing data {#acquiring-managing-and-analysing-data}
 
-##### AC9TDI8P01
+##### AC9TDI8P01 {#ac9tdi8p01}
 
 acquire, store and validate data from a range of sources using software, including spreadsheets and databases
 
@@ -74,7 +74,7 @@ acquire, store and validate data from a range of sources using software, includi
 *  acquiring, storing and validating data from a reputable source, such as the Australian Bureau of Statistics, to analyse the geographic distribution of First Nations Australians, with the aim to highlight past and emerging trends
 *  ensuring that the data used to train an AI model minimises any potential biases in its output and is representative of the target audience; for example, training a model on data collected from a single demographic group may not produce correct outputs for a more diverse population
 
-##### AC9TDI8P02
+##### AC9TDI8P02 {#ac9tdi8p02}
 
 analyse and visualise data using a range of software, including spreadsheets and databases, to draw conclusions and make predictions by identifying trends
 
@@ -84,7 +84,7 @@ analyse and visualise data using a range of software, including spreadsheets and
 *  using an AI model with a natural language interface to generate queries to perform analysis; for example, describing a database schema and asking the model to generate an SQL query to find results that match a set of criteria
 *  comparing the analysis performed by a trained predictive AI model with other analysis techniques; for example, comparing the output from a classification model against data tagged manually to verify its accuracy and effectiveness
 
-##### AC9TDI8P03
+##### AC9TDI8P03 {#ac9tdi8p03}
 
 model and query the attributes of objects and events using structured data
 
@@ -93,9 +93,9 @@ model and query the attributes of objects and events using structured data
 *  using a spreadsheet table to model objects and events, including choosing appropriate formats for each column, and filtering and sorting rows to answer questions
 *  interpreting and querying single-table databases using visual or simple SQL queries with SELECT, WHERE and ORDER BY clauses, for example answering queries in a database for a historical event
 
-#### Investigating and defining
+#### Investigating and defining {#investigating-and-defining}
 
-##### AC9TDI8P04
+##### AC9TDI8P04 {#ac9tdi8p04}
 
 define and decompose real-world problems with design criteria and by creating user stories
 
@@ -105,9 +105,9 @@ define and decompose real-world problems with design criteria and by creating us
 *  using a template such as "As a <type of user>, I want <some goal> so that <some reason>", for example "As a user with a visual impairment I want to be able to get the news on my smartphone so that I can keep up with my world"
 *  making predictions about future population distribution of First Nations Australians based on identified trends, for example analysing and visualising data using spreadsheets and databases on their population growth in metropolitan areas
 
-#### Generating and designing
+#### Generating and designing {#generating-and-designing}
 
-##### AC9TDI8P05
+##### AC9TDI8P05 {#ac9tdi8p05}
 
 design algorithms involving nested control structures and represent them using flowcharts and pseudocode
 
@@ -116,7 +116,7 @@ design algorithms involving nested control structures and represent them using f
 *  describing algorithms precisely in pseudocode (structured English) or with flowcharts for each part of the problem, for example using separate flowcharts to describe the purchase of an item and the giving of change during the purchase
 *  describing algorithms with nested control structures, including a nested if, for example IF it is raining THEN [IF parents are home THEN drive to school]; or an IF inside a loop, for example REPEAT [select the largest coin smaller than the remaining total, and subtract it] UNTIL the remainder is zero
 
-##### AC9TDI8P06
+##### AC9TDI8P06 {#ac9tdi8p06}
 
 trace algorithms to predict output for a given input and to identify errors
 
@@ -125,7 +125,7 @@ trace algorithms to predict output for a given input and to identify errors
 *  specifying test cases and comparing the expected and actual output to determine the correctness of an algorithm, for example a test case of the change-calculating algorithm could have input $1.45 and expected output 1 x $1, 2 x 20c and 1 x 5c coins
 *  following instructions for making woven baskets or nets by hand, as done by First Nations Australians, and making predictions of how the instructions would need to be modified to enable the item to be produced through automated manufacturing processes
 
-##### AC9TDI8P07
+##### AC9TDI8P07 {#ac9tdi8p07}
 
 design the user experience of a digital system
 
@@ -134,7 +134,7 @@ design the user experience of a digital system
 *  considering the factors of why a user might buy and use a product, in addition to its utility, for example how aligning the brand with the user’s values and identity contributes to its appeal
 *  exploring the evolution of a user interface, for example comparing the design and branding of different search engines over time
 
-##### AC9TDI8P08
+##### AC9TDI8P08 {#ac9tdi8p08}
 
 generate, modify, communicate and evaluate alternative designs
 
@@ -143,9 +143,9 @@ generate, modify, communicate and evaluate alternative designs
 *  using concept maps, wireframes or other diagrams to record and discuss the generated ideas, for example creating and discussing wireframes of a music streaming service, evaluating it against design criteria and user stories, such as the needs of diverse users
 *  comparing multiple outputs from a generative model to determine the most suitable; for example, using AI tools to generate multiple prototypes of a user interface and selecting the design or features that best address users’ needs
 
-#### Producing and implementing
+#### Producing and implementing {#producing-and-implementing}
 
-##### AC9TDI8P09
+##### AC9TDI8P09 {#ac9tdi8p09}
 
 implement, modify and debug programs involving control structures and functions in a general-purpose programming language
 
@@ -156,9 +156,9 @@ implement, modify and debug programs involving control structures and functions 
 *  writing a program that contains nested control structures to perform more complicated branching and decisions, for example using an IF statement inside a loop to count the warm days from an array containing temperature data only when the temperature for each day is more than 20 degrees Celsius
 *  defining and using a function that produces different output based on the argument(s) it receives, for example a function that receives the name of an actor from user input, and searches a file or database to return a list of movies that actor appears in
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9TDI8P10
+##### AC9TDI8P10 {#ac9tdi8p10}
 
 evaluate existing and student solutions against the design criteria, user stories and possible future impact
 
@@ -168,9 +168,9 @@ evaluate existing and student solutions against the design criteria, user storie
 *  judging existing solutions on the basis of their possible impact on the economy, environment or society, for example cloud computing services decrease data loss but require vast amounts of electricity to power the servers
 *  discussing the risks and consequences of AI-generated content on social media platforms; for example, the potential for the spread of misinformation due to high volumes of automatically generated and intentionally misleading content being posted
 
-#### Collaborating and managing
+#### Collaborating and managing {#collaborating-and-managing}
 
-##### AC9TDI8P11
+##### AC9TDI8P11 {#ac9tdi8p11}
 
 select and use a range of digital tools efficiently, including unfamiliar features, to create, locate and communicate content, consistently applying common conventions
 
@@ -182,7 +182,7 @@ select and use a range of digital tools efficiently, including unfamiliar featur
 *  using effective prompts with generative AI models to create output that is better suited to the problem being solved; for example, specifying the voice, tone and brevity for a persuasive news article with a restrictive word limit
 *  using a progressive series of prompts with generative models to refine output to improve its correctness; for example, performing translation from one language to another and instructing the model to correct errors in translation
 
-##### AC9TDI8P12
+##### AC9TDI8P12 {#ac9tdi8p12}
 
 select and use a range of digital tools efficiently and responsibly to share content online, and plan and manage individual and collaborative agile projects
 
@@ -193,9 +193,9 @@ select and use a range of digital tools efficiently and responsibly to share con
 *  determining and recording the tasks, responsibilities and timeframes for a collaborative project, for example using a spreadsheet to record tasks and their sequence, critical dates and who is responsible for each task so a project can be finished on time
 *  using AI tools to decompose high-level instructions into more detailed steps to assist with completing a task; for example, asking an AI model to break down the steps involved in building a website from scratch
 
-#### Privacy and security
+#### Privacy and security {#privacy-and-security}
 
-##### AC9TDI8P13
+##### AC9TDI8P13 {#ac9tdi8p13}
 
 explain how multi-factor authentication protects an account when the password is compromised and identify phishing and other cyber security threats
 
@@ -203,7 +203,7 @@ explain how multi-factor authentication protects an account when the password is
 *  explaining how multi-factor authentication prevents unauthorised access by prompting the account owner for a token or single-use password, for example demonstrating how a funds transfer from their bank account requires not only logging in, but provision of a one-time password received via SMS
 *  identifying the common techniques used in phishing scams to identify and exploit susceptible users, for example using an email address from an unofficial domain when pretending to be an online retailer, or including grammatical errors to help filter out users who are more likely to detect the scam
 
-##### AC9TDI8P14
+##### AC9TDI8P14 {#ac9tdi8p14}
 
 investigate and manage the digital footprint existing systems and student solutions collect and assess if the data is essential to their purpose
 
@@ -214,7 +214,7 @@ investigate and manage the digital footprint existing systems and student soluti
 *  assessing the appropriateness and relevance of data collected by surveys from other students and organisations they complete online, for example identifying that providing your address data is not necessary for a survey asking about your food preferences but providing the address for the Census would be appropriate
 *  explaining the risks associated with sharing personal data due to the ease with which generative AI models can create new content; for example, from short videos and audio recordings it is possible for convincing deepfake videos to be generated and distributed for malicious purposes
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 8 students develop and modify creative digital solutions, decompose real-world problems, and evaluate alternative solutions against user stories and design criteria. Students acquire, interpret and model data with spreadsheets and represent data with integers and binary. They design and trace algorithms and implement them in a general-purpose programming language. Students select appropriate hardware for particular tasks, explain how data is transmitted and secured in networks, and identify cyber security threats. They select and use a range of digital tools efficiently and responsibly to create, locate and share content; and to plan, collaborate on and manage projects. Students manage their digital footprint.
 

--- a/curriculum/tech-digital-technologies/years-9-and-10.md
+++ b/curriculum/tech-digital-technologies/years-9-and-10.md
@@ -1,6 +1,6 @@
-# Technologies - Digital Technologies - Years 9 and 10
+# Digital Technologies - Years 9 and 10 {#digital-technologies-years-9-and-10}
 
-## Level Description
+## Level Description {#level-description}
 
 By the end of Year 10 students should have had the opportunity to apply computational thinking by defining and decomposing real-world problems, creating user experiences, designing and modifying algorithms, and implementing them, including in an object-oriented programming language. Students use techniques, including interviewing stakeholders to develop user stories, to increase the precision of their problem definitions and solution specifications. They verify their solutions solve the problem by validating their algorithms, represented as flowcharts and pseudocode, and using test cases to confirm the correctness of their solutions. Students develop their object-oriented programming skills, and apply them to develop, modify and debug programs. They explain the importance of abstraction by representing online documents in terms of content, structure and presentation, as well as exploring simple data compression techniques and comparing their effectiveness.
 
@@ -12,13 +12,13 @@ Students consolidate their systems thinking by exploring how the hardware and so
 
 In Digital Technologies, students should have frequent opportunities for authentic learning by making key connections to other learning areas.
 
-## Strands
+## Strands {#strands}
 
-### Knowledge and understanding
+### Knowledge and understanding {#knowledge-and-understanding}
 
-#### Digital systems
+#### Digital systems {#digital-systems}
 
-##### AC9TDI10K01
+##### AC9TDI10K01 {#ac9tdi10k01}
 
 investigate how hardware and software manage, control and secure access to data in networked digital systems
 
@@ -29,9 +29,9 @@ investigate how hardware and software manage, control and secure access to data 
 *  explaining how domain names and IP addresses allow data to be transmitted to specific networked devices, for example DNS and routing tables
 *  describing elements of access control and explaining why they are necessary, for example authentication and permissions for restricting access to install software to administrators
 
-#### Data representation
+#### Data representation {#data-representation}
 
-##### AC9TDI10K02
+##### AC9TDI10K02 {#ac9tdi10k02}
 
 represent documents online as content (text), structure (markup) and presentation (styling) and explain why such representations are important
 
@@ -40,7 +40,7 @@ represent documents online as content (text), structure (markup) and presentatio
 *  writing web pages using HyperText Markup Language (HTML) for the content and structure and Cascading Style Sheets (CSS) for styling the page and explaining how HTML tags separate content from structure
 *  explaining how representing content, structure and presentation separately allows each of them to be designed, edited, manipulated and stored independently of the others and why this is important
 
-##### AC9TDI10K03
+##### AC9TDI10K03 {#ac9tdi10k03}
 
 investigate simple data compression techniques
 
@@ -49,11 +49,11 @@ investigate simple data compression techniques
 *  exploring the difference between lossy and lossless compression and the consequences of each, for example exploring codecs for audiovisual compression such as MP3, MP4 and WAV formats, considering energy requirements of file sizes
 *  examining an image and discussing whether the image quality would be compromised if all the blue pixels of the sky in one row were to be replaced by one token and the number of pixels it represents
 
-### Processes and production skills
+### Processes and production skills {#processes-and-production-skills}
 
-#### Acquiring, managing and analysing data
+#### Acquiring, managing and analysing data {#acquiring-managing-and-analysing-data}
 
-##### AC9TDI10P01
+##### AC9TDI10P01 {#ac9tdi10p01}
 
 develop techniques to acquire, store and validate data from a range of sources using software, including spreadsheets and databases
 
@@ -65,7 +65,7 @@ develop techniques to acquire, store and validate data from a range of sources u
 *  identifying strengths and weaknesses of collecting data using different methods, for example online surveys, face-to-face interviews, phone interviews, observation, comments in response to a social media posting, phone logs, browser history and online webcam systems
 *  considering how training data issues such as the zero problem dictate the output from predictive models; for example, a model with many examples of horses and no zebras in its training data is likely to classify all zebras as horses
 
-##### AC9TDI10P02
+##### AC9TDI10P02 {#ac9tdi10p02}
 
 analyse and visualise data interactively using a range of software, including spreadsheets and databases, to draw conclusions and make predictions by identifying trends and outliers
 
@@ -76,7 +76,7 @@ analyse and visualise data interactively using a range of software, including sp
 *  exploring machine learning, a form of artificial intelligence where an algorithm is trained using a data set, for example to classify images into categories
 *  adjusting parameters of an AI model to observe the impact of different factors on predicted outcomes; for example, changing the weighting of different input variables to see how much it changes the model's outputs
 
-##### AC9TDI10P03
+##### AC9TDI10P03 {#ac9tdi10p03}
 
 model and query entities and their relationships using structured data
 
@@ -85,9 +85,9 @@ model and query entities and their relationships using structured data
 *  using structured data to help in decision-making, for example creating a data schema for a relational database and building the database, incorporating query and reporting functionality to solve a problem of student choice
 *  interpreting and querying multi-table databases using SQL queries with SELECT, WHERE and simple JOIN/GROUP BY clauses and counting, for example checking that each user has only reviewed each movie once
 
-#### Investigating and defining
+#### Investigating and defining {#investigating-and-defining}
 
-##### AC9TDI10P04
+##### AC9TDI10P04 {#ac9tdi10p04}
 
 define and decompose real-world problems with design criteria and by interviewing stakeholders to create user stories
 
@@ -98,9 +98,9 @@ define and decompose real-world problems with design criteria and by interviewin
 *  recognising the importance of diverse perspectives when defining the problem and devising survey or interview questions to elicit stakeholder needs, for example “What types of exercise count?” and allowing open-ended responses to the exercise they do
 *  exploring how First Nations Australian cultural stories and languages are being preserved with digital systems, for example how communities could record, animate and maintain their connections with culture and language in a contemporary format that resonates with young people to help ensure that vital practices continue
 
-#### Generating and designing
+#### Generating and designing {#generating-and-designing}
 
-##### AC9TDI10P05
+##### AC9TDI10P05 {#ac9tdi10p05}
 
 design algorithms involving logical operators and represent them as flowcharts and pseudocode
 
@@ -110,7 +110,7 @@ design algorithms involving logical operators and represent them as flowcharts a
 *  describing algorithms precisely and succinctly using pseudocode, for example short, unambiguous statements such as IF length of word is greater than 4 AND first letter is a vowel
 *  using Boolean operations (that is, AND, OR and NOT) to express complex conditions in control structures, for example IF [the temperature is above 30 degrees AND people are inside the building] THEN open the windows
 
-##### AC9TDI10P06
+##### AC9TDI10P06 {#ac9tdi10p06}
 
 validate algorithms and programs by comparing their output against a range of test cases
 
@@ -119,7 +119,7 @@ validate algorithms and programs by comparing their output against a range of te
 *  determining boundary test cases and testing that they are handled correctly by a program, for example checking that an intersection is detected when 2 shapes are perfectly aligned
 *  generating invalid input and user errors and testing that they are handled appropriately by a program, for example checking that a program does not crash when text is entered instead of a number
 
-##### AC9TDI10P07
+##### AC9TDI10P07 {#ac9tdi10p07}
 
 design and prototype the user experience of a digital system
 
@@ -129,7 +129,7 @@ design and prototype the user experience of a digital system
 *  considering all aspects of a product as perceived by the users, for example evaluating users’ initial experience of setting up and using a system, or users’ emotional or cultural response to using a digital system
 *  designing documentation, branding and marketing for a digital solution, for example a product demonstration screencast or ‘getting started’ user guide
 
-##### AC9TDI10P08
+##### AC9TDI10P08 {#ac9tdi10p08}
 
 generate, modify, communicate and critically evaluate alternative designs
 
@@ -138,9 +138,9 @@ generate, modify, communicate and critically evaluate alternative designs
 *  using a range of ideation techniques to create multiple design ideas for a solution, for example using graphic organisers, role-play and mind mapping to develop and then record a range of ideas without evaluating them first
 *  combining the output from generative AI models and human capital from recognised experts to meet a specific need; for example, using a range of outputs from an image generator as inspiration for modelling a 3D character in a game
 
-#### Producing and implementing
+#### Producing and implementing {#producing-and-implementing}
 
-##### AC9TDI10P09
+##### AC9TDI10P09 {#ac9tdi10p09}
 
 implement, modify and debug modular programs, applying selected algorithms and data structures, including in an object-oriented programming language
 
@@ -153,9 +153,9 @@ implement, modify and debug modular programs, applying selected algorithms and d
 *  defining their own classes to model and define the actions that can be performed on data in their programs, for example defining a class for a book that stores information such as the author, title and publisher, and methods that are used to track the book's status in a library management system or store inventory
 *  selecting different types of data structures such as array, record and object to model structured data
 
-#### Evaluating
+#### Evaluating {#evaluating}
 
-##### AC9TDI10P10
+##### AC9TDI10P10 {#ac9tdi10p10}
 
 evaluate existing and student solutions against the design criteria, user stories, possible future impact and opportunities for enterprise
 
@@ -166,9 +166,9 @@ evaluate existing and student solutions against the design criteria, user storie
 *  examining the unintended consequences of an image generation solution implemented using AI; for example, using a model trained on a homogenous population to generate graphics that do not represent the diversity of customers in a website’s target audience
 *  considering the complexities associated with training predictive models to capture events that occur with low probability; for example, in training data for an autonomous vehicle, including a person lying on the road and the correct behaviour for that situation
 
-#### Collaborating and managing
+#### Collaborating and managing {#collaborating-and-managing}
 
-##### AC9TDI10P11
+##### AC9TDI10P11 {#ac9tdi10p11}
 
 select and use emerging digital tools and advanced features to create and communicate interactive content for a diverse audience
 
@@ -179,7 +179,7 @@ select and use emerging digital tools and advanced features to create and commun
 *  ensuring content is accessible by using built-in accessibility features, for example using ALT tags in images inside HTML to ensure screen readers can communicate content for people who are visually impaired
 *  combining the output from multiple generative AI sources to communicate a complex idea or narrative; for example, using images, sounds and text from a variety of tools to produce an interactive animation
 
-##### AC9TDI10P12
+##### AC9TDI10P12 {#ac9tdi10p12}
 
 use simple project management tools to plan and manage individual and collaborative agile projects, accounting for risks and responsibilities
 
@@ -191,9 +191,9 @@ use simple project management tools to plan and manage individual and collaborat
 *  accounting for appropriate project management responsibilities, for example when collaborating with First Nations Australians’ community groups to develop digital solutions to projects: following cultural protocols, including relevant permissions and attributions; acknowledging diversity, capability and strength; and addressing risks and responsibilities such as privacy, security and accuracy of data
 *  incorporating suggestions made by built-in virtual assistants in project planning and organisation tools to streamline and prioritise work; for example, using AI to summarise meeting outcomes, identify important tasks and forecast project risks
 
-#### Privacy and security
+#### Privacy and security {#privacy-and-security}
 
-##### AC9TDI10P13
+##### AC9TDI10P13 {#ac9tdi10p13}
 
 develop cyber security threat models, and explore a software, user or software supply chain vulnerability
 
@@ -202,7 +202,7 @@ develop cyber security threat models, and explore a software, user or software s
 *  exploring the impact of a cyber security threat by systematically following the steps involved in bypassing a known vulnerability in their own software, for example manually changing the value stored in a login cookie to that of another user to observe the impact of unauthorised access on the system
 *  explaining how techniques like prompt injection can change the intended behaviour of generative AI models; for example, carefully chosen inputs can circumvent any protections or limitations that may have been included in the design of the model
 
-##### AC9TDI10P14
+##### AC9TDI10P14 {#ac9tdi10p14}
 
 apply the Australian Privacy Principles to critique and manage the digital footprint that existing systems and student solutions collect
 
@@ -210,7 +210,7 @@ apply the Australian Privacy Principles to critique and manage the digital footp
 *  critiquing the extent to which online services allow them to control access to their data in line with the Australian Privacy Principles, for example assessing whether their social media accounts allow them to update their contact information if these details change, and who else can see that information on the platform
 *  using the Australian Privacy Principles as a reference to evaluate the steps they are taking to protect user information in their application, for example explaining how they are storing passwords using cryptographic hashing algorithms so that a data breach does not expose their users to security vulnerabilities due to password re-use
 
-## Achievement Standards
+## Achievement Standards {#achievement-standards}
 
 By the end of Year 10 students should have had the opportunity to apply computational thinking by defining and decomposing real-world problems, creating user experiences, designing and modifying algorithms, and implementing them, including in an object-oriented programming language. Students use techniques, including interviewing stakeholders to develop user stories, to increase the precision of their problem definitions and solution specifications. They verify their solutions solve the problem by validating their algorithms, represented as flowcharts and pseudocode, and using test cases to confirm the correctness of their solutions. Students develop their object-oriented programming skills, and apply them to develop, modify and debug programs. They explain the importance of abstraction by representing online documents in terms of content, structure and presentation, as well as exploring simple data compression techniques and comparing their effectiveness.
 


### PR DESCRIPTION
This pull request updates the formatting of headings and strand identifiers across the Foundation to Year 6 Dance curriculum documentation. The main goal is to add explicit anchor links (HTML IDs) to all major sections and strand codes, improving navigation and referenceability within the markdown files.

### Consistency and Navigation Improvements

* Added explicit anchor links (HTML IDs) to all top-level headings, section headings, and strand codes in `foundation-year.md`, `years-1-and-2.md`, `years-3-and-4.md`, and `years-5-and-6.md`, making it easier to link directly to specific curriculum sections. [[1]](diffhunk://#diff-b2a2ad0254fbdb85c6264188a8d033acdb37f7ec6e8197139b0047580d5f9253L1-R3) [[2]](diffhunk://#diff-b23eac7063ddf269671b9ad31d3e92f5a11b7dd39c65984b0ba4d91c6d9743f7L1-R3) [[3]](diffhunk://#diff-b693fb8884c858ef2e1c562060215c91d0d99dd9ba6397df8b70adf0f84f9d59L1-R3) [[4]](diffhunk://#diff-a05d619a1e6085c726a42aade4cd3f204a820d4198d5dbed2e07526b6d381f06L1-R3)
* Updated all strand section headings (e.g., "Exploring and responding", "Developing practices and skills", etc.) to include anchor links for consistency and improved accessibility. [[1]](diffhunk://#diff-b2a2ad0254fbdb85c6264188a8d033acdb37f7ec6e8197139b0047580d5f9253L18-R22) [[2]](diffhunk://#diff-b23eac7063ddf269671b9ad31d3e92f5a11b7dd39c65984b0ba4d91c6d9743f7L24-R28) [[3]](diffhunk://#diff-b693fb8884c858ef2e1c562060215c91d0d99dd9ba6397df8b70adf0f84f9d59L24-R28) [[4]](diffhunk://#diff-a05d619a1e6085c726a42aade4cd3f204a820d4198d5dbed2e07526b6d381f06L24-R28)

### Strand Identifier Enhancements

* Added anchor links to all strand codes (e.g., `AC9ADAFE01`, `AC9ADA2E01`, etc.) so they can be referenced directly in documentation or external resources. [[1]](diffhunk://#diff-b2a2ad0254fbdb85c6264188a8d033acdb37f7ec6e8197139b0047580d5f9253L18-R22) [[2]](diffhunk://#diff-b23eac7063ddf269671b9ad31d3e92f5a11b7dd39c65984b0ba4d91c6d9743f7L24-R28) [[3]](diffhunk://#diff-b693fb8884c858ef2e1c562060215c91d0d99dd9ba6397df8b70adf0f84f9d59L24-R28) [[4]](diffhunk://#diff-a05d619a1e6085c726a42aade4cd3f204a820d4198d5dbed2e07526b6d381f06L24-R28)

### Achievement Standards Section

* Added anchor links to the "Achievement Standards" section headers for all year levels, ensuring these key curriculum outcomes are directly accessible. [[1]](diffhunk://#diff-b2a2ad0254fbdb85c6264188a8d033acdb37f7ec6e8197139b0047580d5f9253L82-R82) [[2]](diffhunk://#diff-b23eac7063ddf269671b9ad31d3e92f5a11b7dd39c65984b0ba4d91c6d9743f7L88-R88) [[3]](diffhunk://#diff-b693fb8884c858ef2e1c562060215c91d0d99dd9ba6397df8b70adf0f84f9d59L86-R86)

These changes do not alter curriculum content but significantly improve usability for educators and maintainers.