### PR TITLE
Refactor elaborations to use markdown formatting to replace html

### DIFF
--- a/curriculum/hass-civics-and-citizenship/year-10.md
+++ b/curriculum/hass-civics-and-citizenship/year-10.md
@@ -48,7 +48,7 @@ the role of the parliament and the High Court of Australia in protecting rights 
 **Elaborations**
 *  explaining the role of the High Court in interpreting and applying the law, using contemporary Australian examples
 *  exploring the concepts of express and implied rights through High Court cases such as the Stolen Generations Case (Kruger v the Commonwealth [1997]) and the Vicki Lee Roach Case (Roach v Electoral Commissioner [2007])
-*  <p>investigating understanding of terra nullius and how the <em>Native Title Act 1993</em> property rights were developed through High Court interpretation of common law and enshrined in statutory law</p>
+*  investigating understanding of terra nullius and how the *Native Title Act 1993* property rights were developed through High Court interpretation of common law and enshrined in statutory law
 *  comparing the effectiveness of a constitutional bill of rights, such as in the USA, with a statutory bill of rights, such as in New Zealand
 
 ##### AC9HC10K04 {#ac9hc10k04}

--- a/curriculum/hass-civics-and-citizenship/year-9.md
+++ b/curriculum/hass-civics-and-citizenship/year-9.md
@@ -24,7 +24,7 @@ the role of the Australian Constitution in providing the basis for Australia’s
 *  understanding the aims of the founding fathers prior to Federation in writing the Australian Constitution, including the need for compromise
 *  describing the process by which referendums to change the Australian Constitution are initiated and decided, including the role of the Australian Electoral Commission, and discussing the advantages and disadvantages of having a constitution that can only be amended by referendum
 *  investigating the extent to which the Constitution upholds and enables democratic institutions and processes, including a constitutional monarchy, a federal parliamentary system with elected legislatures, protection of states’ rights and individual rights, and representation of the interests of all Australians
-*  <p>assessing the effectiveness of the process of constitutional change and the degree to which it supports popular sovereignty through examining selected referendum proposals; for example, the successful vote on the <em>Constitution Alteration (Aboriginals) 1967</em> or the unsuccessful vote on the <em>Constitution Alteration (Establishment of Republic) 1999</em></p>
+*  assessing the effectiveness of the process of constitutional change and the degree to which it supports popular sovereignty through examining selected referendum proposals; for example, the successful vote on the *Constitution Alteration (Aboriginals) 1967* or the unsuccessful vote on the *Constitution Alteration (Establishment of Republic) 1999*
 
 ##### AC9HC9K02 {#ac9hc9k02}
 

--- a/curriculum/hass-history/year-10.md
+++ b/curriculum/hass-history/year-10.md
@@ -134,8 +134,8 @@ the significant events and methods in the movement for the civil rights of First
 
 **Elaborations**
 *  investigating the effects of the US civil rights movement of the 1960’s and its influence on Australia in changing perspectives, beliefs and opinions; for example, outlining the Freedom Rides in the USA, how they inspired civil rights campaigners in Australia and how they became a turning point in the campaign of First Nations Australians for rights and freedoms
-*  <p>creating a chronological account of the significant events in the movement for the civil rights of First Nations Australians, including the right to vote federally in 1962, Freedom Rides, the 1967 Referendum, the Tent Embassy, the Mabo decision, prime minister Keating's Redfern Speech, the <em>Bringing Them Home report</em>, the first Sorry Day, the Apology to the Stolen Generations and the Uluru Statement from the Heart</p>
-*  <p>explaining how significant events contributed to change; for example, legal changes, especially land rights, as a result of the Pilbara Strike, Palm Island Strike, Wave Hill Walk-Off, the Mabo decision, the Wik decision and the Tent Embassy; political changes as a result of the right to vote federally in 1962 and the 1967 Referendum; social changes as a result of the Freedom Rides; changes to advance Reconciliation as a result of the Redfern Speech, the <em>Bringing Them Home report</em>, the Royal Commission into Deaths in Custody and the Apology to the Stolen Generations</p>
+*  creating a chronological account of the significant events in the movement for the civil rights of First Nations Australians, including the right to vote federally in 1962, Freedom Rides, the 1967 Referendum, the Tent Embassy, the Mabo decision, prime minister Keating's Redfern Speech, the *Bringing Them Home report*, the first Sorry Day, the Apology to the Stolen Generations and the Uluru Statement from the Heart
+*  explaining how significant events contributed to change; for example, legal changes, especially land rights, as a result of the Pilbara Strike, Palm Island Strike, Wave Hill Walk-Off, the Mabo decision, the Wik decision and the Tent Embassy; political changes as a result of the right to vote federally in 1962 and the 1967 Referendum; social changes as a result of the Freedom Rides; changes to advance Reconciliation as a result of the Redfern Speech, the *Bringing Them Home report*, the Royal Commission into Deaths in Custody and the Apology to the Stolen Generations
 *  discussing how Reconciliation is not a single significant event or change, but an ongoing process of truth-telling and healing between First Nations Australians and other Australians
 *  investigating the Mabo case and the significance of this event’s contribution to understanding of terra nullius and the land rights movement for First Nations Australians
 
@@ -144,7 +144,7 @@ the significant events and methods in the movement for the civil rights of First
 the significant events, individuals and groups in the women’s movement in Australia, and how they have changed the role and status of women
 
 **Elaborations**
-*  <p>investigating events connected to the changing roles and rights of women in the workforce since 1945 such as the repeal of the “marriage bar”, the <em>Sex Discrimination Act 1984</em>, the changing nature of participation in employment and the gender pay gap</p>
+*  investigating events connected to the changing roles and rights of women in the workforce since 1945 such as the repeal of the “marriage bar”, the *Sex Discrimination Act 1984*, the changing nature of participation in employment and the gender pay gap
 *  examining the contributions of significant female leaders in Australian public life; for example, political leaders and activists, social reformers, sporting identities, artists and entertainers
 
 ##### AC9HH10K13 {#ac9hh10k13}
@@ -154,7 +154,7 @@ the continuing efforts to create change in the civil rights and freedoms in Aust
 **Elaborations**
 *  identifying areas such as education, health care, housing and employment that are the focus for continued civil rights action for First Nations Australians, and discussing why there continues to be a need for such action
 *  examining the changes in women’s rights in 20th- and 21st-century Australia, ranging from suffrage to election to state and commonwealth parliaments, employment law, reproductive rights, access to public places like hotels, and protections against domestic and family violence
-*  <p>investigating the changes in government policy in relation to migrants and how these policies have reflected and impacted on Australia’s changing place in the world; for example, the <em>Racial Discrimination Act 1975</em></p>
+*  investigating the changes in government policy in relation to migrants and how these policies have reflected and impacted on Australia’s changing place in the world; for example, the *Racial Discrimination Act 1975*
 *  examining the ideas in and Australia’s responsibilities as a signatory to the United Nations Declaration of the Rights of Indigenous Peoples (UNDRIP) (2007) and discussing how it influences calls for recognising the rights of First Nations Australians and First Peoples in other countries
 
 #### The globalising world {#the-globalising-world}

--- a/curriculum/hass-history/year-7.md
+++ b/curriculum/hass-history/year-7.md
@@ -172,7 +172,7 @@ causes and effects of contacts and conflicts within ancient societies and/or wit
 *  explaining the nature of contact and conflict with other societies, such as trade with Cyprus, Crete and Greece, and the Battle of Kadesh in the New Kingdom that concluded with Ramses II’s peace treaty with the Hittites
 *  analysing the long-term causes of the rise of the Mauryan Empire and the spread of Mauryan philosophies and beliefs
 *  examining the extent of Indian contact with other societies such as the Persians under Cyrus, the Macedonians under Alexander; the extensive trade with the Romans and Chinese; the material remains of the Mauryan Empire such as the Pillars of Ashoka and the Barabar Caves; and the spread of Hinduism and Buddhism
-*  <p>explaining the rise of imperial China; for example, through chariot warfare and the adoption of mass infantry armies, the building of the first phase of the Great Wall of China, military strategies as codified in Sun Tzu’s <em>The Art of War</em></p>
+*  explaining the rise of imperial China; for example, through chariot warfare and the adoption of mass infantry armies, the building of the first phase of the Great Wall of China, military strategies as codified in Sun Tzu’s *The Art of War*
 *  describing indirect contact and interactions between the Roman Empire and the Han Dynasty
 
 ##### AC9HH7K13 {#ac9hh7k13}

--- a/curriculum/hass-history/year-8.md
+++ b/curriculum/hass-history/year-8.md
@@ -62,10 +62,10 @@ the roles and relationships of different groups in Medieval, Renaissance or pre-
 *  explaining how medieval society changed and affected the environment; for example, harnessing water and wind power for milling, urban settlements and agriculture, management practices and legal structures of medieval forests such as the English royal forests
 *  describing key changes of life in the late Medieval period such as the spread of literacy and the development of new ways to disseminate ideas through schools and universities, scientific academies, debating societies, literary salons, coffee houses, and the reach of printed books, journals and pamphlets
 *  explaining reactions to the Black Death, such as the emergence of flagellants (those who would whip themselves to be free of sin) and the persecution of Jewish people
-*  <p>identifying the similarities and differences of daily life between the <em>popolo minuto</em> and <em>popolo grasso</em></p>
+*  identifying the similarities and differences of daily life between the *popolo minuto* and *popolo grasso*
 *  describing the way of life of people in Renaissance Italy; for example, the role of men in tending the fields or merchant shops, the role of women in the society and the influence of government in particular city-states such as Naples (a monarchy) and Florence (a republic)
 *  identifying the spread of Renaissance culture to England; for example, the rise of literature through Shakespeare
-*  <p>describing the contribution of key theories such as Nicolaus Copernicus’ <em>De revolutionibus orbium coelestium</em>, Galileo’s <em>Dialogue Concerning the Two Chief World Systems</em> and Isaac Newton’s <em>Philosophiae Naturalis Principia Mathematica</em> to the changes brought about by the Scientific Revolution</p>
+*  describing the contribution of key theories such as Nicolaus Copernicus’ *De revolutionibus orbium coelestium*, Galileo’s *Dialogue Concerning the Two Chief World Systems* and Isaac Newton’s *Philosophiae Naturalis Principia Mathematica* to the changes brought about by the Scientific Revolution
 *  examining the changes in economic activity created by the discoveries of new commodities, making the costs of basic foodstuffs lower and the quality higher, and the advancements of technologies such as in tools, armaments and shipbuilding
 
 ##### AC9HH8K03 {#ac9hh8k03}
@@ -79,9 +79,9 @@ a significant event, development, turning point or challenge that contributed to
 *  describing the impact of the Magna Carta on different social groups including the nobility, religious orders, merchants, workers/craftsmen, peasants and women
 *  investigating the effects of the Black Death in a city such as Carthage, Damascus or Rome; for example, labour shortages, peasant uprisings, the weakening of feudal structures, increased social mobility, and challenges to religious ideas and power
 *  identifying the effect of the Black Death on human populations using studies of church records from the period, considering the reliability of these statistics and explaining the impact of the population change in areas such as farming, commerce, culture and religion
-*  describing the significance of double-entry bookkeeping, as seen in the <em>Messari</em> accounts of the Republic of Genoa in 1340 CE, in accelerating the production of wealth and patronage
+*  describing the significance of double-entry bookkeeping, as seen in the *Messari* accounts of the Republic of Genoa in 1340 CE, in accelerating the production of wealth and patronage
 *  investigating learning in the Renaissance period (for example, humanism and the influence of ancient Greece and Rome) and analysing the symbolic representation of this learning in architecture, artworks and inventions from individuals such as Brunelleschi, Copernicus, Donatello, da Vinci, Michelangelo and Titian
-*  <p>explaining why the <em>Catasto</em> of 1427 was introduced in Florence following the end of war with the Duchy of Milan</p>
+*  explaining why the *Catasto* of 1427 was introduced in Florence following the end of war with the Duchy of Milan
 *  identifying a range of primary sources, such as artwork, music, literature, architecture, correspondence and diaries, that demonstrate the spread of the Renaissance across Europe
 *  describing the impact of the printing press on the rise of literacy
 *  investigating the Enlightenment ideas about human freedom and the exercise of authority, which promoted radical change to the political order; for example constitutional government and the separation of Church and state
@@ -94,8 +94,8 @@ the experiences and perspectives of rulers and of subject peoples, and the inter
 
 **Elaborations**
 *  explaining the reasons for different punishments for different groups of people, such as trial by combat as a privilege granted to the nobility and ducking stools as a punishment for women, and the use of punishment as a deterrent
-*  <p>describing the impact of the Black Death on daily life using primary sources such as Matteo Villani’s diary, Boccaccio’s <em>Decameron</em>, Fordun’s <em>Chronicle of the Scottish Nation</em> and Ibn Khaldun’s recollection of the impact of the plague</p>
-*  <p>analysing how rulers responded to demands from the lower classes to improve their working conditions and lives following the plague, using sources such as King Edward III’s law <em>Statute of Labourers</em></p>
+*  describing the impact of the Black Death on daily life using primary sources such as Matteo Villani’s diary, Boccaccio’s *Decameron*, Fordun’s *Chronicle of the Scottish Nation* and Ibn Khaldun’s recollection of the impact of the plague
+*  analysing how rulers responded to demands from the lower classes to improve their working conditions and lives following the plague, using sources such as King Edward III’s law *Statute of Labourers*
 *  analysing primary sources to understand the interactions between the rulers of Florence, Venice, Naples and/or the Papal States
 *  explaining the differing levels of political involvement in city-states such as the guilds in Florence and Libro d’Oro in Venice
 *  examining the change in the role and power of monarchies in the political systems of Western Europe, for example, decline of "absolutism", development of parliaments, and new ideas relating to nationalism
@@ -106,7 +106,7 @@ the experiences and perspectives of rulers and of subject peoples, and the inter
 the role and achievements of a significant individual and/or group in Medieval, Renaissance or pre-modern Europe
 
 **Elaborations**
-*  <p>explaining the influence and dominance of the Catholic Church on society using visual sources such as the illustration of <em>Hell in the Hortus Deliciarum</em> manuscript by Herrad of Landsberg</p>
+*  explaining the influence and dominance of the Catholic Church on society using visual sources such as the illustration of *Hell in the Hortus Deliciarum* manuscript by Herrad of Landsberg
 *  investigating the role of the Catholic Church in Medieval Europe in the provision of social services such as education, health care and social welfare, and in feudal village organisation
 *  explaining the influence of the Medici family in Florence as bankers and merchants, and their patronage of the arts
 *  explaining the influences and contributions of individuals such as Lucrezia Borgia, Galileo, Leonardo da Vinci, Niccolo Machiavelli, Martin Luther and Louis XIV
@@ -159,7 +159,7 @@ a significant event, development, turning point or challenge that contributed to
 *  explaining the triggers of declining Viking power such as the Battle of Standford Bridge, the treaty of Saint-Clair-sur-Epte, new colonies, changing climate and/or the spread of Christianity
 *  explaining the arrival of Spanish conquistadores in Mexico and Peru from 1510 CE (Balboa) to 1531 (Pizarro), and their reasons; for example, seeking wealth, claiming land for their king, converting the local populations to Christianity, sense of adventure
 *  analysing the significance of Alexander VI’s papal decrees of 1493 in legalising Spanish territorial expansion and claims in the Americas
-*  <p>outlining the effects of Spanish conquest on the Americas, such as the spread of disease, introduction of crops such as maize, beans, tobacco, chocolate and potatoes to Europe, the <em>Encomienda system</em>, mining and deforestation, and the impact of the loss of natural resources</p>
+*  outlining the effects of Spanish conquest on the Americas, such as the spread of disease, introduction of crops such as maize, beans, tobacco, chocolate and potatoes to Europe, the *Encomienda system*, mining and deforestation, and the impact of the loss of natural resources
 *  explaining the longer-term effects of conquest and colonisation on the Indigenous populations of the Americas, such as the unequal distribution of land and wealth, slavery, political inequality, and supremacy of Spanish culture and language over conquered territories
 
 ##### AC9HH8K09 {#ac9hh8k09}

--- a/curriculum/hass-history/year-9.md
+++ b/curriculum/hass-history/year-9.md
@@ -58,10 +58,10 @@ significant events, ideas, people, groups and movements in the development of Au
 **Elaborations**
 *  discussing the rise of nationalist sentiment in Australia in the mid- to late 19th century
 *  explaining the factors that contributed to Federation and the development of democracy in Australia, such as defence concerns, economic concerns and the 1890s depression, the “White Australia" ideal, nationalist ideals and egalitarianism
-*  <p>describing the key steps to Federation, such as the Australasian Federation Conference (1890), the first Federal Constitutional Convention (1891), the second Federal Constitutional Convention (1897–1898), the first referendum on the Federal Constitution (1898), the second referendum on the Federal Constitution (1899), the <em>Commonwealth of Australia Constitution Act</em> (1900) and Federation Day (1 January 1901)</p>
+*  describing the key steps to Federation, such as the Australasian Federation Conference (1890), the first Federal Constitutional Convention (1891), the second Federal Constitutional Convention (1897–1898), the first referendum on the Federal Constitution (1898), the second referendum on the Federal Constitution (1899), the *Commonwealth of Australia Constitution Act* (1900) and Federation Day (1 January 1901)
 *  examining the influences on the development of the Australian Constitution, such as the British Westminster system, the Washington system and federalism
-*  <p>analysing the significance of the advance of women’s voting rights to the development of Australian democracy, including the suffragist movements, the Christian Women's Temperance Union and the <em>Commonwealth Franchise Act</em> 1902</p>
-*  <p>investigating key people and groups involved in the Federation movement and the development of an Australian identity, such as Sir Henry Parkes, Sir Samuel Griffith, William Guthrie Spence, John Feltham Archibald, Catherine Helen Spence, Alfred Deakin, Tom Roberts, Frederick McCubbin, Arthur Streeton, Joseph Furphy, Barbara Baynton, Banjo Paterson, Henry Lawson, “Federation leagues”, the Australian Natives Association and <em>The Bulletin</em></p>
+*  analysing the significance of the advance of women’s voting rights to the development of Australian democracy, including the suffragist movements, the Christian Women's Temperance Union and the *Commonwealth Franchise Act* 1902
+*  investigating key people and groups involved in the Federation movement and the development of an Australian identity, such as Sir Henry Parkes, Sir Samuel Griffith, William Guthrie Spence, John Feltham Archibald, Catherine Helen Spence, Alfred Deakin, Tom Roberts, Frederick McCubbin, Arthur Streeton, Joseph Furphy, Barbara Baynton, Banjo Paterson, Henry Lawson, “Federation leagues”, the Australian Natives Association and *The Bulletin*
 
 ##### AC9HH9K05 {#ac9hh9k05}
 
@@ -89,7 +89,7 @@ different experiences and perspectives of colonisers, settlers and First Nations
 the development of Australian society in relation to other nations in the world by 1914, including the effects of ideas and movements of people
 
 **Elaborations**
-*  <p>investigating how the major social legislation of the new Federal Government affected living and working conditions in Australia; for example, the Harvester Judgment, the <em>Immigration Restriction Act 1901</em>, invalid and old-age pensions, the maternity allowance scheme and the <em>Defence Act 1903</em></p>
+*  investigating how the major social legislation of the new Federal Government affected living and working conditions in Australia; for example, the Harvester Judgment, the *Immigration Restriction Act 1901*, invalid and old-age pensions, the maternity allowance scheme and the *Defence Act 1903*
 *  explaining the continuities and changes in the role of women, such as advocating for women’s rights, suffrage, political representation and pacificism; (for example, Elizabeth Macquarie, Caroline Chisholm, Catherine Helen Spence, Louisa Lawson, Muriel Matters, Vida Goldstein)
 
 #### First World War (1914–1918) {#first-world-war-19141918}
@@ -197,7 +197,7 @@ the ideas that emerged and influenced change in society, such as nationalism, ca
 the role of a significant individual or group such as agricultural and factory workers, inventors and entrepreneurs, landowners, politicians and religious groups in promoting and enacting some of the ideas that emerged during the Industrial Revolution
 
 **Elaborations**
-*  <p>explaining responses to particular ideas; for example, how religious groups responded to ideas in Charles Darwin’s 1859 book <em>On the Origin of Species</em> or how workers responded to the idea of capitalism or socialism</p>
+*  explaining responses to particular ideas; for example, how religious groups responded to ideas in Charles Darwin’s 1859 book *On the Origin of Species* or how workers responded to the idea of capitalism or socialism
 *  investigating the role played by an individual or group in promoting a key idea; for example, the role of Adam Smith and entrepreneurs in promoting capitalism, Florence Nightingale in promoting reform to health care and the rights of women, Pope Leo XIII in promoting the rights of workers in capitalist economies, Chartist William Cuffay in Tasmania or British Chartists on the goldfields in Victoria and New South Wales
 
 #### Asia and the World (1750–1914) {#asia-and-the-world-17501914}

--- a/curriculum/hass/year-6.md
+++ b/curriculum/hass/year-6.md
@@ -33,7 +33,7 @@ changes in Australia's political system and to Australian citizenship after Fede
 
 **Elaborations**
 *  describing the significance of the 1962 right to vote federally and the importance of the 1967 referendum for First Nations Australians
-*  <p>investigating the developments in advancing democracy and citizenship for women, such as the suffragette movement, the right to vote, the bar on married women working, equal pay and the <em>Sex Discrimination Act 1984</em></p>
+*  investigating the developments in advancing democracy and citizenship for women, such as the suffragette movement, the right to vote, the bar on married women working, equal pay and the *Sex Discrimination Act 1984*
 *  investigating the developments in advancing democracy and citizenship for all citizens, including migrant groups; for example, the establishment of the minimum wage, anti-discrimination legislation and official national multicultural policy
 *  investigating the experiences of children who were placed in orphanages, homes and other institutions; for example, their food and shelter, protection, education and contacts with family
 

--- a/curriculum/maths/year-1.md
+++ b/curriculum/maths/year-1.md
@@ -87,7 +87,7 @@ recognise, continue and create pattern sequences, with numbers, symbols, shapes 
 *  recognising the patterns in sequences formed by skip counting; for example, that skip counting in fives starting from zero always results in either a \(5\) or zero as the final digit
 *  counting by twos, fives, or tens to determine how much money is in a collection of coins or notes of the same denomination; for example, \(5\) cent, \(10\) cent and \(\$2\) coins, or \(\$5\) and \(\$10\) notes
 *  role-playing being an industrial robot on an assembly line that packs various items into boxes or packets in groups of five or ten, keeping count of the total number of items produced
-*  <p>using different variations of the popular Korean counting game <em>Sam-yuk-gu</em> for generating skip counting pattern sequences</p>
+*  using different variations of the popular Korean counting game *Sam-yuk-gu* for generating skip counting pattern sequences
 
 ##### AC9M1A02 {#ac9m1a02}
 

--- a/curriculum/science/year-9.md
+++ b/curriculum/science/year-9.md
@@ -124,7 +124,7 @@ model the rearrangement of atoms in chemical reactions using a range of represen
 explain how scientific knowledge is validated and refined, including the role of publication and peer review
 
 **Elaborations**
-*  <p>investigating the process of publishing a paper in a scientific journal such as <em>Science</em>, which receives about 12,000 submissions per year, and considering how editors evaluate submitted papers</p>
+*  investigating the process of publishing a paper in a scientific journal such as *Science*, which receives about 12,000 submissions per year, and considering how editors evaluate submitted papers
 *  investigating how the publication of data and findings related to the reintroduction of First Nations Australians’ traditional fire regimes has informed more effective fire-reduction strategies and policies
 *  exploring why the work of Professor Barry Marshall and Dr Robin Warren related to the cause of peptic ulcers was first rejected for publication then later validated
 *  examining the scientific consensus supporting global warming

--- a/curriculum/tech-design-and-technologies/foundation-year.md
+++ b/curriculum/tech-design-and-technologies/foundation-year.md
@@ -19,7 +19,7 @@ Students should have opportunities to experience designing and producing a produ
 explore how familiar products, services and environments are designed by people
 
 **Elaborations**
-*  <p>identifying how First Nations Australians have long designed and produced domestic items including clothing, tools and shelter, for example the Lamalama Peoples of the eastern Cape York Peninsula weave the reddish coloured fibres from <em>Acacia latifolia</em> alternately with white coloured fibres from <em>Brachychiton diversifolium</em> to produce a striped woven bag</p>
+*  identifying how First Nations Australians have long designed and produced domestic items including clothing, tools and shelter, for example the Lamalama Peoples of the eastern Cape York Peninsula weave the reddish coloured fibres from *Acacia latifolia* alternately with white coloured fibres from *Brachychiton diversifolium* to produce a striped woven bag
 *  exploring how local delivery services meet different needs of people, for example describing how gift packages can be sent to and from people who live in different locations and how online shopping items arrive at a person’s home
 *  exploring how an environment such as a local playground may have shade structures to protect users and be designed to allow access for all
 *  describing how community gardens, public swimming pools and parks are designed to help people stay healthy

--- a/curriculum/tech-design-and-technologies/years-1-and-2.md
+++ b/curriculum/tech-design-and-technologies/years-1-and-2.md
@@ -65,9 +65,9 @@ explore how plants and animals are grown for food, clothing and shelter
 explore how food can be selected and prepared for healthy eating
 
 **Elaborations**
-*  <p>identifying a wide range of foods, categorising them into food groups according to the <em>Australian Guide to Healthy Eating</em> and discussing ways to eat a variety of food groups, including cooking methods, tools and equipment needed to prepare them for healthy eating</p>
+*  identifying a wide range of foods, categorising them into food groups according to the *Australian Guide to Healthy Eating* and discussing ways to eat a variety of food groups, including cooking methods, tools and equipment needed to prepare them for healthy eating
 *  exploring how people including peoples from the countries of Asia design and produce food for healthy eating based on the available plants and animals in their region, the influence of cultural practices, and locally available tools and equipment
-*  <p>exploring the <em>Australian Guide to Healthy Eating</em> and the <em>Aboriginal and Torres Strait Islander Guide to Healthy Eating</em> and identifying foods in each of the 5 food groups which contribute to health and wellbeing, for example choosing foods from each of the 5 food groups which they are familiar with and designing a menu for a day</p>
+*  exploring the *Australian Guide to Healthy Eating* and the *Aboriginal and Torres Strait Islander Guide to Healthy Eating* and identifying foods in each of the 5 food groups which contribute to health and wellbeing, for example choosing foods from each of the 5 food groups which they are familiar with and designing a menu for a day
 *  exploring the local supermarket to observe the variety of foods and the placement of foods on shelves, in aisles and displays; and considering how their design may influence the purchase of foods for healthy food eating
 *  exploring different ways of preparing the products from the school kitchen garden, farmers’ market or supermarket, for example preparing vegetables for a salad, steaming or roasting vegetables and noticing the changes in flavour and texture
 

--- a/curriculum/tech-design-and-technologies/years-3-and-4.md
+++ b/curriculum/tech-design-and-technologies/years-3-and-4.md
@@ -45,7 +45,7 @@ describe how forces and the properties of materials affect function in a product
 *  researching how First Nations Australians consider buoyant forces as they select materials for watercraft, for example making bark or dugout canoes
 *  looking at models to identify how materials are used and movement is created, for example in the design of a toy with wheels or moving parts
 *  exploring through play how movement can be started by combining materials and using forces, for example releasing a wound rubber band to propel a model boat, how different materials may impact a marble roll speed, or how various surfaces from carpet to grass to concrete might affect a robot’s movement
-*  <p>deconstructing a product or system to identify how motion and forces affect performance, for example in a puppet such as a Japanese <em>bunraku puppet</em> or a model windmill with moving sails</p>
+*  deconstructing a product or system to identify how motion and forces affect performance, for example in a puppet such as a Japanese *bunraku puppet* or a model windmill with moving sails
 *  identifying engineered systems and experimenting with available local materials, tools and equipment to solve problems, for example designing a container or parachute that will keep an egg intact when dropped from a height; a pop-up card; a tower; or a vehicle
 
 #### Technologies context: Food and fibre production; Food specialisations {#technologies-context-food-and-fibre-production-food-specialisations}

--- a/curriculum/tech-design-and-technologies/years-5-and-6.md
+++ b/curriculum/tech-design-and-technologies/years-5-and-6.md
@@ -66,10 +66,10 @@ explain how the characteristics of foods influence selection and preparation for
 
 **Elaborations**
 *  investigating how First Nations Australians have long selected and prepared foods for healthy eating, for example based on their nutritional value, availability, spoilage, preparation and processing requirements
-*  <p>using the <em>Australian Dietary Guidelines</em> to determine the recommended number of serves for an individual, for example describing and planning a healthy meal or lunchbox for a particular individual with recommended serving sizes to inform choices and then explaining the characteristics of the selected foods</p>
+*  using the *Australian Dietary Guidelines* to determine the recommended number of serves for an individual, for example describing and planning a healthy meal or lunchbox for a particular individual with recommended serving sizes to inform choices and then explaining the characteristics of the selected foods
 *  experimenting with tools, equipment, ingredients and techniques to design and make food products or meals for selected groups for healthy eating taking into consideration environmental impacts and nutritional benefits, for example experimenting with preserving techniques including pickling, fermentation, air drying or sun drying and presenting information on the benefits for an audience
 *  exploring a variety of tastes and how they may influence the selection or preparation of food, for example the sour, salty, sweet, spicy and umami flavours of many foods from countries across Asia
-*  <p>developing strategies to communicate healthy choices based on the <em>Australian Dietary Guidelines</em>, for example designing a website with food preparation tips for healthy eating for pre-teens</p>
+*  developing strategies to communicate healthy choices based on the *Australian Dietary Guidelines*, for example designing a website with food preparation tips for healthy eating for pre-teens
 *  exploring the food service options of a local restaurant, café, fast food or takeaway establishment and identifying the food preparation skills needed to prepare food for healthy eating
 
 #### Technologies context: Materials and technologies specialisations {#technologies-context-materials-and-technologies-specialisations}

--- a/curriculum/tech-digital-technologies/years-3-and-4.md
+++ b/curriculum/tech-digital-technologies/years-3-and-4.md
@@ -41,7 +41,7 @@ recognise different types of data and explore how the same data can be represent
 
 **Elaborations**
 *  describing different types of data and how they can be used, for example numbers, letters, symbols and pictures
-*  <p>explaining how the same data can be represented in different ways and why some representations are better than others in certain contexts, for example four vs 4 vs IV vs I I I I vs <em>quatre</em> and that numerals are better for calculation than words</p>
+*  explaining how the same data can be represented in different ways and why some representations are better than others in certain contexts, for example four vs 4 vs IV vs I I I I vs *quatre* and that numerals are better for calculation than words
 *  explaining that the same information can be represented differently, for example the term ‘stop’ can also be represented with an octagon-shaped red sign or a hand icon
 *  identifying rock paintings and other cultural expressions to understand that images are used to encode and represent ethnobotanical knowledge, for example the representation of plant use in the Kimberley cave paintings and ancient engravings including important data on medicinal and food plant classification and their usable parts
 


### PR DESCRIPTION
This pull request standardises the formatting of references to significant laws, reports, and works across multiple curriculum files by replacing HTML `<em>` tags with Markdown-style italics (`*...*`). This improves readability and consistency in how titles and named entities are presented in elaborations and examples.

Formatting consistency improvements:

* Replaced HTML emphasis tags with Markdown italics for references to laws, reports, and works in `year-7.md`, `year-8.md`, `year-9.md`, and `year-10.md` curriculum files, ensuring consistent formatting for items such as the *Native Title Act 1993*, *Sex Discrimination Act 1984*, *Bringing Them Home report*, and others. [[1]](diffhunk://#diff-0da3ded797f08d9db2aea80d3b6a0976b526afe27018d561202a31172ae05a7aL51-R51) [[2]](diffhunk://#diff-5baf5fa7f9b617ff5747a84b8c32fddd4100d8f807476af4b870efaa243d6caaL27-R27) [[3]](diffhunk://#diff-9a1f4178dd069d531983a4dddb797ff98656cae7444ec0f5847091ee998d2f83L137-R138) [[4]](diffhunk://#diff-9a1f4178dd069d531983a4dddb797ff98656cae7444ec0f5847091ee998d2f83L147-R147) [[5]](diffhunk://#diff-9a1f4178dd069d531983a4dddb797ff98656cae7444ec0f5847091ee998d2f83L157-R157) [[6]](diffhunk://#diff-30bad93ee0ea9d369678b8c9d7146717269416bece9841f035b5d019f4becb1cL175-R175) [[7]](diffhunk://#diff-6e5648cfc613b8976e8dc5dec64f5cee659c10b5123fead0104159afdbef3697L65-R68) [[8]](diffhunk://#diff-6e5648cfc613b8976e8dc5dec64f5cee659c10b5123fead0104159afdbef3697L82-R84) [[9]](diffhunk://#diff-6e5648cfc613b8976e8dc5dec64f5cee659c10b5123fead0104159afdbef3697L97-R98) [[10]](diffhunk://#diff-6e5648cfc613b8976e8dc5dec64f5cee659c10b5123fead0104159afdbef3697L109-R109) [[11]](diffhunk://#diff-6e5648cfc613b8976e8dc5dec64f5cee659c10b5123fead0104159afdbef3697L162-R162) [[12]](diffhunk://#diff-ef8df5630a9acd1113c19912adfb2caab9e724774e4fe4f944b94c704169f483L61-R64) [[13]](diffhunk://#diff-ef8df5630a9acd1113c19912adfb2caab9e724774e4fe4f944b94c704169f483L92-R92)

* Updated references to historical documents, scientific works, and primary sources to use Markdown italics, such as *Decameron*, *Chronicle of the Scottish Nation*, *Statute of Labourers*, *Hell in the Hortus Deliciarum*, *Messari*, *Catasto*, and *Encomienda system*. [[1]](diffhunk://#diff-6e5648cfc613b8976e8dc5dec64f5cee659c10b5123fead0104159afdbef3697L97-R98) [[2]](diffhunk://#diff-6e5648cfc613b8976e8dc5dec64f5cee659c10b5123fead0104159afdbef3697L109-R109) [[3]](diffhunk://#diff-6e5648cfc613b8976e8dc5dec64f5cee659c10b5123fead0104159afdbef3697L82-R84) [[4]](diffhunk://#diff-6e5648cfc613b8976e8dc5dec64f5cee659c10b5123fead0104159afdbef3697L162-R162)

* Ensured that legislative acts and constitutional references, including *Commonwealth of Australia Constitution Act*, *Commonwealth Franchise Act 1902*, *Immigration Restriction Act 1901*, and *Defence Act 1903*, are consistently formatted across relevant curriculum areas. [[1]](diffhunk://#diff-ef8df5630a9acd1113c19912adfb2caab9e724774e4fe4f944b94c704169f483L61-R64) [[2]](diffhunk://#diff-ef8df5630a9acd1113c19912adfb2caab9e724774e4fe4f944b94c704169f483L92-R92)

* Applied the same formatting approach to references in historical elaborations, such as *De revolutionibus orbium coelestium*, *Dialogue Concerning the Two Chief World Systems*, and *Philosophiae Naturalis Principia Mathematica*.

* Improved clarity in references to significant reports and speeches, for example, *Bringing Them Home report*, *Redfern Speech*, and *The Bulletin*. [[1]](diffhunk://#diff-9a1f4178dd069d531983a4dddb797ff98656cae7444ec0f5847091ee998d2f83L137-R138) [[2]](diffhunk://#diff-ef8df5630a9acd1113c19912adfb2caab9e724774e4fe4f944b94c704169f483L61-R64)