### PR TITLE
Update links in achievement standards for consistency

### DIFF
--- a/curriculum/arts-dance/foundation-year.md
+++ b/curriculum/arts-dance/foundation-year.md
@@ -81,6 +81,6 @@ share their arts works with audiences
 
 ## Achievement Standards {#achievement-standards}
 
-[By the end of the Foundation year, students describe experiences, observations, ideas and/or feelings about arts works they encounter at school, home and/or in the community.](?standard=ac9adafe01&standard=ac9adafp01)
+[By the end of the Foundation year, students describe experiences, observations, ideas and/or feelings about arts works they encounter at school, home and/or in the community.](?code=ac9adafe01&code=ac9adafp01#strands)
 
-[Students use play, imagination, arts knowledge, processes and/or skills to create and share arts works in different forms.](?standard=ac9adafe01&standard=ac9adafd01&standard=ac9adafc01&standard=ac9adap01)
+[Students use play, imagination, arts knowledge, processes and/or skills to create and share arts works in different forms.](?code=ac9adafe01&code=ac9adafd01&code=ac9adafc01&code=ac9adap01#strands)


### PR DESCRIPTION
This pull request updates the achievement standards links in the Foundation Year Dance curriculum to use the correct URL query parameters and anchors.

* Achievement standards links now use the `code` parameter instead of `standard`, and include the `#strands` anchor for improved navigation. (`curriculum/arts-dance/foundation-year.md`)